### PR TITLE
Add context_parts to prepare_agent_input

### DIFF
--- a/src/langgraph_stream_parser/resume.py
+++ b/src/langgraph_stream_parser/resume.py
@@ -62,6 +62,7 @@ def prepare_agent_input(
     message: str | None = None,
     decisions: list[dict[str, Any]] | None = None,
     raw_input: Any = None,
+    context_parts: list[str] | None = None,
 ) -> Any:
     """Prepare input for a LangGraph agent.
 
@@ -75,6 +76,9 @@ def prepare_agent_input(
             to a Command object.
         raw_input: Raw input passed directly (for custom formats).
             Bypasses all processing.
+        context_parts: Optional list of context lines to prepend to the
+            message (e.g., timestamp, working directory). Only used with
+            ``message``. Each part becomes a line before the message content.
 
     Returns:
         Prepared input for the agent.
@@ -85,6 +89,12 @@ def prepare_agent_input(
     Example:
         # Regular message
         input_data = prepare_agent_input(message="Hello!")
+
+        # Message with context
+        input_data = prepare_agent_input(
+            message="What time is it?",
+            context_parts=["[Current time: 2025-01-01 12:00:00 UTC]"],
+        )
 
         # Resume from interrupt
         input_data = prepare_agent_input(decisions=[{"type": "approve"}])
@@ -110,7 +120,10 @@ def prepare_agent_input(
 
     # Handle regular message
     if message is not None:
-        return {"messages": [{"role": "user", "content": message}]}
+        content = message
+        if context_parts:
+            content = "\n".join(context_parts) + "\n\n" + content
+        return {"messages": [{"role": "user", "content": content}]}
 
     # Handle resume from interrupt
     if decisions is not None:

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -67,3 +67,27 @@ class TestPrepareAgentInput:
             prepare_agent_input(message="Hi", raw_input={"x": 1})
 
         assert "Can only provide one of" in str(exc_info.value)
+
+    def test_with_context_parts(self):
+        result = prepare_agent_input(
+            message="Hello!",
+            context_parts=["[Current time: 2025-01-01 12:00:00 UTC]"],
+        )
+
+        content = result["messages"][0]["content"]
+        assert content == "[Current time: 2025-01-01 12:00:00 UTC]\n\nHello!"
+
+    def test_with_multiple_context_parts(self):
+        result = prepare_agent_input(
+            message="Hello!",
+            context_parts=["[Time: now]", "[CWD: /tmp]"],
+        )
+
+        content = result["messages"][0]["content"]
+        assert content == "[Time: now]\n[CWD: /tmp]\n\nHello!"
+
+    def test_context_parts_without_message_ignored(self):
+        """context_parts is only used with message, ignored otherwise."""
+        custom = {"custom": "data"}
+        result = prepare_agent_input(raw_input=custom, context_parts=["ignored"])
+        assert result == custom


### PR DESCRIPTION
## Summary
- Add `context_parts` parameter to `prepare_agent_input()` for prepending context lines (e.g., timestamp, working directory) to user messages
- 3 new tests covering single context, multiple context parts, and context_parts without message

## Test plan
- [x] All 297 tests pass on dev