### PR TITLE
Add ReasoningEvent and DisplayEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ for event in parser.parse(graph.stream(input_data, stream_mode="updates")):
 | Event | Description |
 |-------|-------------|
 | `ContentEvent` | Text content from AI messages. Includes `agent_name` when from a deep agent subagent. |
+| `ReasoningEvent` | Reasoning / thinking text — from langchain-core `reasoning` content blocks or `think_tool` reflections |
 | `ToolCallStartEvent` | Tool call initiated by AI |
 | `ToolCallEndEvent` | Tool call completed with result |
-| `ToolExtractedEvent` | Special content extracted from tool (e.g., reflections, todos) |
+| `ToolExtractedEvent` | Special content extracted from tool (e.g., todos, custom extractors) |
+| `DisplayEvent` | Rich inline content (dataframe, image, plotly, html, json) from `display_inline`-style tools |
 | `InterruptEvent` | Human-in-the-loop interrupt requiring decision |
 | `StateUpdateEvent` | Non-message state updates (opt-in) |
 | `UsageEvent` | Token usage metadata (input/output/total tokens) |
@@ -235,6 +237,60 @@ for event in parser.parse(stream):
         case CustomEvent(data=data):
             print(f"Progress: {data}")
 ```
+
+### Reasoning & Thinking
+
+Reasoning content arrives as a distinct `ReasoningEvent` so UIs can render it differently from the final answer (greyed out, collapsed, etc.). Two sources, same event type:
+
+```python
+for event in parser.parse(stream):
+    match event:
+        case ReasoningEvent(content=text, source="content_block"):
+            # From langchain-core reasoning blocks (Anthropic thinking,
+            # OpenAI reasoning summaries). Streamed token-by-token.
+            print(f"\033[90m{text}\033[0m", end="")  # grey
+        case ReasoningEvent(content=text, source="think_tool"):
+            # From the built-in think_tool ThinkToolExtractor.
+            print(f"💭 {text}")
+        case ContentEvent(content=text):
+            print(text, end="")
+```
+
+### Rich Inline Display
+
+For agents that need to show DataFrames, charts, images, or HTML in the transcript, use a `display_inline`-style tool. The parser recognizes the convention and emits a typed `DisplayEvent` — no stringified dict hacks.
+
+**Tool side** — return a JSON string with `display_type`, `data`, `title`, `status`:
+
+```python
+def show_dataframe(df_name: str) -> str:
+    import json
+    df = load(df_name)
+    return json.dumps({
+        "type": "display_inline",
+        "display_type": "dataframe",
+        "title": df_name,
+        "data": df.to_html(),       # or fig.to_json() for plotly,
+        "status": "success",         # base64 PNG for matplotlib, etc.
+    })
+```
+
+Configure your LangGraph tool registration with `name="display_inline"` (or register a custom `DisplayInlineExtractor` for a different name).
+
+**Consumer side** — match on `DisplayEvent`:
+
+```python
+for event in parser.parse(stream):
+    match event:
+        case DisplayEvent(display_type="dataframe", data=html, title=title):
+            ui.show_html(f"<h3>{title}</h3>{html}")
+        case DisplayEvent(display_type="plotly", data=plotly_json):
+            ui.show_plotly(json.loads(plotly_json))
+        case DisplayEvent(display_type=kind, data=data):
+            ui.show_generic(kind, data)
+```
+
+The `display_type` field is consumer-defined — any string the tool and UI agree on. Common values: `"dataframe"`, `"image"`, `"plotly"`, `"html"`, `"json"`.
 
 ### Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ for event in parser.parse(graph.stream(input_data, stream_mode="updates")):
 | `StateUpdateEvent` | Non-message state updates (opt-in) |
 | `UsageEvent` | Token usage metadata (input/output/total tokens) |
 | `CustomEvent` | Custom data emitted via `get_stream_writer()` |
+| `ValuesEvent` | Full state snapshot from `stream_mode="values"` (v2) |
+| `DebugEvent` | Debug, checkpoint, or task trace from v2 streaming |
 | `CompleteEvent` | Stream finished successfully |
 | `ErrorEvent` | Error during streaming |
 
@@ -415,16 +417,17 @@ The package includes extractors for common LangGraph tools:
 
 - **ThinkToolExtractor**: Extracts reflections from `think_tool`
 - **TodoExtractor**: Extracts todo lists from `write_todos`
+- **DisplayInlineExtractor**: Extracts inline display artifacts from `display_inline`
 
 ## Examples
 
 ### FastAPI WebSocket Streaming
 
-See [examples/fastapi_websocket.py](examples/fastapi_websocket.py) for a complete example of streaming LangGraph events to a web client via WebSockets.
+See [examples/fastapi_websocket.py](examples/fastapi_websocket.py) for a complete example using `FastAPIAdapter` to stream LangGraph events to a web client.
 
 ```bash
 # Install dependencies
-pip install fastapi uvicorn websockets
+pip install 'langgraph-stream-parser[fastapi]' uvicorn
 
 # Run the example
 uvicorn examples.fastapi_websocket:app --reload

--- a/src/langgraph_stream_parser/__init__.py
+++ b/src/langgraph_stream_parser/__init__.py
@@ -32,9 +32,11 @@ Legacy Dict-Based API:
 from .parser import StreamParser
 from .events import (
     ContentEvent,
+    ReasoningEvent,
     ToolCallStartEvent,
     ToolCallEndEvent,
     ToolExtractedEvent,
+    DisplayEvent,
     InterruptEvent,
     StateUpdateEvent,
     UsageEvent,
@@ -63,9 +65,11 @@ __all__ = [
     "StreamParser",
     # Event types
     "ContentEvent",
+    "ReasoningEvent",
     "ToolCallStartEvent",
     "ToolCallEndEvent",
     "ToolExtractedEvent",
+    "DisplayEvent",
     "InterruptEvent",
     "StateUpdateEvent",
     "UsageEvent",

--- a/src/langgraph_stream_parser/adapters/base.py
+++ b/src/langgraph_stream_parser/adapters/base.py
@@ -13,9 +13,11 @@ from typing import Any, Callable
 from ..events import (
     StreamEvent,
     ContentEvent,
+    ReasoningEvent,
     ToolCallStartEvent,
     ToolCallEndEvent,
     ToolExtractedEvent,
+    DisplayEvent,
     InterruptEvent,
     StateUpdateEvent,
     UsageEvent,
@@ -309,6 +311,14 @@ class BaseAdapter(ABC):
 
             case ToolExtractedEvent():
                 self._display_items.append(("extraction", event))
+
+            case ReasoningEvent():
+                self._flush_current_message()
+                self._display_items.append(("reasoning", event))
+
+            case DisplayEvent():
+                self._flush_current_message()
+                self._display_items.append(("display", event))
 
             case InterruptEvent():
                 self._flush_current_message()

--- a/src/langgraph_stream_parser/compat.py
+++ b/src/langgraph_stream_parser/compat.py
@@ -11,8 +11,10 @@ from .events import (
     CompleteEvent,
     ContentEvent,
     CustomEvent,
+    DisplayEvent,
     ErrorEvent,
     InterruptEvent,
+    ReasoningEvent,
     StreamEvent,
     ToolCallEndEvent,
     ToolCallStartEvent,
@@ -102,6 +104,36 @@ def _event_to_dict(event: StreamEvent) -> dict[str, Any] | None:
         case CustomEvent(data=data):
             return {
                 "custom": data,
+                "status": "streaming",
+            }
+
+        case ReasoningEvent(content=content):
+            # Preserves legacy behavior where think_tool reflections
+            # arrived as {"chunk": text}. Downstream code matching on
+            # "chunk" still works; new code can use "reasoning".
+            return {
+                "chunk": content,
+                "reasoning": content,
+                "status": "streaming",
+            }
+
+        case DisplayEvent(
+            display_type=display_type,
+            data=data,
+            title=title,
+            status=status,
+            error=error,
+            tool_name=tool_name,
+        ):
+            return {
+                "display": {
+                    "display_type": display_type,
+                    "data": data,
+                    "title": title,
+                    "status": status,
+                    "error": error,
+                    "tool": tool_name,
+                },
                 "status": "streaming",
             }
 

--- a/src/langgraph_stream_parser/events.py
+++ b/src/langgraph_stream_parser/events.py
@@ -438,6 +438,109 @@ class DebugEvent:
 
 
 @dataclass
+class ReasoningEvent:
+    """Reasoning / thinking content from an AI message.
+
+    Emitted for the langchain-core standardized ``reasoning`` content
+    block (Anthropic thinking, OpenAI reasoning summaries) and for
+    ``think_tool`` reflections. Consumers can render reasoning
+    differently from final answer text (e.g., greyed out, collapsible).
+
+    Attributes:
+        content: The reasoning text.
+        source: Where the reasoning came from — "content_block" for
+            langchain-core reasoning blocks, "think_tool" for
+            ThinkToolExtractor output.
+        node: The graph node that produced the reasoning.
+        agent_name: The deep agent name, if from a subagent.
+        namespace: The subgraph namespace path, if from a subgraph.
+        timestamp: When the event was created.
+    """
+    content: str
+    source: Literal["content_block", "think_tool"] = "content_block"
+    node: str | None = None
+    agent_name: str | None = None
+    namespace: tuple[str, ...] | None = None
+    timestamp: datetime = field(default_factory=datetime.now)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict for web APIs."""
+        d: dict[str, Any] = {
+            "type": "reasoning",
+            "content": self.content,
+            "source": self.source,
+            "node": self.node,
+        }
+        if self.agent_name is not None:
+            d["agent_name"] = self.agent_name
+        if self.namespace is not None:
+            d["namespace"] = list(self.namespace)
+        return d
+
+
+@dataclass
+class DisplayEvent:
+    """Rich inline content from a ``display_inline``-style tool.
+
+    Emitted when a tool returns structured display metadata — typically
+    a serialized dataframe, matplotlib/plotly figure, image, or HTML
+    blob that the frontend should render inline rather than treat as
+    plain text.
+
+    Tool authors typically produce this by returning a JSON string with
+    ``{"display_type": str, "data": str, "title": str, "status": str}``
+    from a tool. The parser's ``DisplayInlineExtractor`` handles the
+    parse and yields this event.
+
+    Attributes:
+        display_type: The display kind — e.g., "dataframe", "image",
+            "plotly", "html", "json". Consumer-defined.
+        data: The serialized payload (HTML string, base64 image, plotly
+            JSON, etc.). Format depends on ``display_type``.
+        title: Optional display title.
+        status: "success" or "error".
+        error: Optional error message when ``status == "error"``.
+        tool_name: The tool that produced the display.
+        tool_call_id: The originating tool call ID.
+        node: The graph node that produced the event.
+        namespace: The subgraph namespace path, if from a subgraph.
+        timestamp: When the event was created.
+    """
+    display_type: str
+    data: Any
+    title: str | None = None
+    status: str = "success"
+    error: str | None = None
+    tool_name: str | None = None
+    tool_call_id: str | None = None
+    node: str | None = None
+    namespace: tuple[str, ...] | None = None
+    timestamp: datetime = field(default_factory=datetime.now)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to JSON-serializable dict for web APIs."""
+        d: dict[str, Any] = {
+            "type": "display",
+            "display_type": self.display_type,
+            "data": self.data,
+            "status": self.status,
+        }
+        if self.title is not None:
+            d["title"] = self.title
+        if self.error is not None:
+            d["error"] = self.error
+        if self.tool_name is not None:
+            d["tool_name"] = self.tool_name
+        if self.tool_call_id is not None:
+            d["tool_call_id"] = self.tool_call_id
+        if self.node is not None:
+            d["node"] = self.node
+        if self.namespace is not None:
+            d["namespace"] = list(self.namespace)
+        return d
+
+
+@dataclass
 class CompleteEvent:
     """Stream completed successfully.
 
@@ -502,9 +605,11 @@ def event_to_dict(event: "StreamEvent") -> dict[str, Any]:
 # Union type for all events - useful for type hints
 StreamEvent = Union[
     ContentEvent,
+    ReasoningEvent,
     ToolCallStartEvent,
     ToolCallEndEvent,
     ToolExtractedEvent,
+    DisplayEvent,
     InterruptEvent,
     StateUpdateEvent,
     UsageEvent,

--- a/src/langgraph_stream_parser/extractors/messages.py
+++ b/src/langgraph_stream_parser/extractors/messages.py
@@ -10,18 +10,19 @@ from typing import Any
 
 
 def extract_message_content(message: Any) -> str:
-    """Extract and convert message content to string.
+    """Extract and convert message text content to string.
 
     Handles different content formats:
         - String content (returned as-is)
-        - List of content blocks (text blocks joined)
+        - List of content blocks — reasoning/thinking blocks are
+          skipped so they can be surfaced as ReasoningEvent separately.
         - Other types (converted to string)
 
     Args:
         message: A LangChain message object with 'content' attribute.
 
     Returns:
-        Content as a string.
+        Text content as a string (reasoning blocks excluded).
     """
     if not hasattr(message, 'content'):
         return ""
@@ -31,16 +32,58 @@ def extract_message_content(message: Any) -> str:
     if isinstance(content, str):
         return content
     elif isinstance(content, list):
-        # Handle list of content blocks (e.g., [{"text": "...", "type": "text"}])
+        # Handle list of content blocks. Skip reasoning blocks — those
+        # are surfaced as ReasoningEvent separately.
         parts = []
         for block in content:
             if isinstance(block, dict):
+                btype = block.get("type")
+                if btype == "reasoning" or btype == "thinking":
+                    continue
                 parts.append(block.get("text", str(block)))
             else:
                 parts.append(str(block))
         return " ".join(parts)
     else:
         return str(content)
+
+
+def extract_reasoning_content(message: Any) -> str:
+    """Extract reasoning / thinking text from a message.
+
+    Returns concatenated text from reasoning blocks in the
+    langchain-core standardized format. Recognizes both ``type:
+    "reasoning"`` (standardized) and ``type: "thinking"`` (Anthropic).
+
+    Args:
+        message: A LangChain message object with 'content' attribute.
+
+    Returns:
+        Concatenated reasoning text, or empty string if none found.
+    """
+    if not hasattr(message, 'content'):
+        return ""
+
+    content = message.content
+    if not isinstance(content, list):
+        return ""
+
+    parts = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        btype = block.get("type")
+        if btype not in ("reasoning", "thinking"):
+            continue
+        text = (
+            block.get("reasoning")
+            or block.get("thinking")
+            or block.get("text")
+            or ""
+        )
+        if text:
+            parts.append(str(text))
+    return "".join(parts)
 
 
 def clean_tool_dict_from_content(content: str) -> str:

--- a/src/langgraph_stream_parser/handlers/messages.py
+++ b/src/langgraph_stream_parser/handlers/messages.py
@@ -7,9 +7,10 @@ AIMessageChunk and metadata contains langgraph_node, langgraph_step, etc.
 """
 from typing import Any, Iterator
 
-from ..events import ContentEvent, StreamEvent
+from ..events import ContentEvent, ReasoningEvent, StreamEvent
 from ..extractors.messages import (
     extract_message_content,
+    extract_reasoning_content,
     clean_tool_dict_from_content,
     get_message_type_name,
 )
@@ -49,18 +50,18 @@ class MessagesHandler:
     def _process_ai_chunk(
         self, chunk: Any, metadata: dict
     ) -> Iterator[StreamEvent]:
-        """Process an AIMessageChunk for text content only.
+        """Process an AIMessageChunk for reasoning and text content.
 
-        Skips chunks that are tool-call-only (have tool_call_chunks or
-        tool_calls but no meaningful text). Also cleans any tool call
-        dict representations that leak into content strings.
+        Skips chunks that are tool-call-only. Emits ReasoningEvent for
+        reasoning/thinking content blocks (langchain-core standardized
+        format), then ContentEvent for any remaining text.
 
         Args:
             chunk: An AIMessageChunk object.
             metadata: Metadata dict with langgraph_node etc.
 
         Yields:
-            ContentEvent if the chunk has non-empty text content.
+            ReasoningEvent for reasoning blocks, ContentEvent for text.
         """
         # Skip chunks that carry tool call data — tool lifecycle is
         # handled by the updates handler in dual mode.
@@ -69,8 +70,24 @@ class MessagesHandler:
         if tool_call_chunks or tool_calls:
             return
 
-        content = extract_message_content(chunk)
+        node_name = None
+        agent_name = None
+        if isinstance(metadata, dict):
+            node_name = metadata.get("langgraph_node")
+            agent_name = metadata.get("lc_agent_name")
 
+        # Reasoning / thinking blocks — emitted before text so UI
+        # consumers can render the "thinking" indicator first.
+        reasoning = extract_reasoning_content(chunk)
+        if reasoning:
+            yield ReasoningEvent(
+                content=reasoning,
+                source="content_block",
+                node=node_name,
+                agent_name=agent_name,
+            )
+
+        content = extract_message_content(chunk)
         if not content:
             return
 
@@ -78,12 +95,6 @@ class MessagesHandler:
         content = clean_tool_dict_from_content(content)
         if not content:
             return
-
-        node_name = None
-        agent_name = None
-        if isinstance(metadata, dict):
-            node_name = metadata.get("langgraph_node")
-            agent_name = metadata.get("lc_agent_name")
 
         yield ContentEvent(
             content=content,

--- a/src/langgraph_stream_parser/handlers/updates.py
+++ b/src/langgraph_stream_parser/handlers/updates.py
@@ -8,7 +8,9 @@ from typing import Any, Iterator
 
 from ..events import (
     ContentEvent,
+    DisplayEvent,
     InterruptEvent,
+    ReasoningEvent,
     StateUpdateEvent,
     StreamEvent,
     ToolCallEndEvent,
@@ -236,6 +238,54 @@ class UpdatesHandler:
                 node=node_name,
             )
 
+    def _event_from_extraction(
+        self,
+        *,
+        tool_name: str | None,
+        tool_call_id: str | None,
+        extracted_type: str,
+        data: Any,
+    ) -> Iterator[StreamEvent]:
+        """Route extractor output to the appropriate typed event.
+
+        Known extracted_types map to first-class events (ReasoningEvent,
+        DisplayEvent). Everything else falls through to the generic
+        ToolExtractedEvent so user-registered extractors still work.
+        """
+        if extracted_type == "reflection":
+            # ThinkToolExtractor output. ``data`` is the reflection text.
+            yield ReasoningEvent(
+                content=str(data) if data is not None else "",
+                source="think_tool",
+            )
+        elif extracted_type == "display_inline":
+            # DisplayInlineExtractor output. ``data`` is a dict with
+            # display_type / data / title / status / error.
+            if isinstance(data, dict):
+                yield DisplayEvent(
+                    display_type=data.get("display_type", "unknown"),
+                    data=data.get("data"),
+                    title=data.get("title"),
+                    status=data.get("status", "success"),
+                    error=data.get("error"),
+                    tool_name=tool_name,
+                    tool_call_id=tool_call_id,
+                )
+            else:
+                # Malformed extraction — fall back to generic event.
+                yield ToolExtractedEvent(
+                    tool_name=tool_name,
+                    extracted_type=extracted_type,
+                    data=data,
+                )
+        else:
+            # Unknown extracted_type — emit generic event for user extractors.
+            yield ToolExtractedEvent(
+                tool_name=tool_name,
+                extracted_type=extracted_type,
+                data=data,
+            )
+
     def _process_tool_message(self, message: Any) -> Iterator[StreamEvent]:
         """Process a ToolMessage.
 
@@ -265,8 +315,9 @@ class UpdatesHandler:
             try:
                 extracted = extractor.extract(artifact if artifact is not None else content)
                 if extracted is not None:
-                    yield ToolExtractedEvent(
+                    yield from self._event_from_extraction(
                         tool_name=tool_name,
+                        tool_call_id=tool_call_id,
                         extracted_type=extractor.extracted_type,
                         data=extracted,
                     )

--- a/src/langgraph_stream_parser/parser.py
+++ b/src/langgraph_stream_parser/parser.py
@@ -522,13 +522,6 @@ class StreamParser:
         """
         updates_handler = self._create_updates_handler()
         messages_handler = self._create_messages_handler()
-        has_messages = False
-
-        # Two-pass approach: first scan to check if messages type is present
-        # would require buffering. Instead, we use a simpler approach:
-        # process all chunks, and if we see both updates and messages types,
-        # the user should use dual mode or accept potential content duplication.
-        # In practice, v2 streams with multiple modes will have distinct types.
 
         for chunk in stream:
             if not _is_v2_stream_part(chunk):

--- a/tests/fixtures/mocks.py
+++ b/tests/fixtures/mocks.py
@@ -389,6 +389,39 @@ SUBGRAPH_MULTI_CHILD_MSG_WITH_AGENT = (
     (AIMessageChunk(content="Sub agent token"), MESSAGES_METADATA_WITH_AGENT),
 )
 
+# --- Reasoning content block fixtures ---
+# langchain-core standardized reasoning block (Anthropic thinking,
+# OpenAI reasoning summaries). Blocks are a list on AIMessageChunk.content.
+
+MESSAGES_CHUNK_REASONING_ONLY = (
+    AIMessageChunk(
+        content=[
+            {"type": "reasoning", "reasoning": "Let me think about this carefully..."}
+        ],
+    ),
+    MESSAGES_METADATA,
+)
+
+MESSAGES_CHUNK_REASONING_AND_TEXT = (
+    AIMessageChunk(
+        content=[
+            {"type": "reasoning", "reasoning": "First, I will analyze the input. "},
+            {"type": "text", "text": "The answer is 42."},
+        ],
+    ),
+    MESSAGES_METADATA,
+)
+
+# Anthropic-style "thinking" block (alternate type name)
+MESSAGES_CHUNK_THINKING_BLOCK = (
+    AIMessageChunk(
+        content=[
+            {"type": "thinking", "thinking": "I should search for recent data."}
+        ],
+    ),
+    MESSAGES_METADATA,
+)
+
 # --- v2 StreamPart fixtures ---
 # v2 chunks are dicts with {"type": str, "ns": tuple, "data": ...}
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,9 +5,11 @@ from typing import Iterator
 from langgraph_stream_parser import (
     StreamParser,
     ContentEvent,
+    ReasoningEvent,
     ToolCallStartEvent,
     ToolCallEndEvent,
     ToolExtractedEvent,
+    DisplayEvent,
     InterruptEvent,
     StateUpdateEvent,
     UsageEvent,
@@ -144,11 +146,10 @@ class TestStreamParserParse:
 
         events = list(parser.parse(stream))
 
-        extracted_events = [e for e in events if isinstance(e, ToolExtractedEvent)]
-        assert len(extracted_events) == 1
-        assert extracted_events[0].tool_name == "think_tool"
-        assert extracted_events[0].extracted_type == "reflection"
-        assert extracted_events[0].data == "I should search for more recent data."
+        reasoning_events = [e for e in events if isinstance(e, ReasoningEvent)]
+        assert len(reasoning_events) == 1
+        assert reasoning_events[0].source == "think_tool"
+        assert reasoning_events[0].content == "I should search for more recent data."
 
     def test_think_tool_string_content(self):
         parser = StreamParser()
@@ -156,9 +157,10 @@ class TestStreamParserParse:
 
         events = list(parser.parse(stream))
 
-        extracted_events = [e for e in events if isinstance(e, ToolExtractedEvent)]
-        assert len(extracted_events) == 1
-        assert "reflection" in extracted_events[0].data.lower() or "problem" in extracted_events[0].data.lower()
+        reasoning_events = [e for e in events if isinstance(e, ReasoningEvent)]
+        assert len(reasoning_events) == 1
+        assert reasoning_events[0].source == "think_tool"
+        assert "reflection" in reasoning_events[0].content.lower() or "problem" in reasoning_events[0].content.lower()
 
     def test_write_todos_extraction(self):
         parser = StreamParser()
@@ -377,12 +379,11 @@ class TestStreamParserDisplayInline:
         parser = StreamParser()
         events = list(parser.parse(make_stream([DISPLAY_INLINE_ARTIFACT_MESSAGE])))
 
-        extracted = [e for e in events if isinstance(e, ToolExtractedEvent)]
-        assert len(extracted) == 1
-        assert extracted[0].tool_name == "display_inline"
-        assert extracted[0].extracted_type == "display_inline"
-        assert extracted[0].data["display_type"] == "dataframe"
-        assert extracted[0].data["title"] == "Sales Data"
+        displays = [e for e in events if isinstance(e, DisplayEvent)]
+        assert len(displays) == 1
+        assert displays[0].tool_name == "display_inline"
+        assert displays[0].display_type == "dataframe"
+        assert displays[0].title == "Sales Data"
 
     def test_artifact_extraction_tool_end_has_stub(self):
         """ToolCallEndEvent.result should be the stub content, not the artifact."""
@@ -399,10 +400,10 @@ class TestStreamParserDisplayInline:
         parser = StreamParser()
         events = list(parser.parse(make_stream([DISPLAY_INLINE_CONTENT_MESSAGE])))
 
-        extracted = [e for e in events if isinstance(e, ToolExtractedEvent)]
-        assert len(extracted) == 1
-        assert extracted[0].data["display_type"] == "image"
-        assert extracted[0].data["title"] == "Chart"
+        displays = [e for e in events if isinstance(e, DisplayEvent)]
+        assert len(displays) == 1
+        assert displays[0].display_type == "image"
+        assert displays[0].title == "Chart"
 
 
 class TestStreamParserReset:

--- a/tests/test_reasoning_display.py
+++ b/tests/test_reasoning_display.py
@@ -1,0 +1,205 @@
+"""Tests for ReasoningEvent and DisplayEvent."""
+from typing import Iterator
+
+from langgraph_stream_parser import (
+    StreamParser,
+    ContentEvent,
+    ReasoningEvent,
+    DisplayEvent,
+    ToolExtractedEvent,
+    CompleteEvent,
+    event_to_dict,
+)
+
+from .fixtures.mocks import (
+    THINK_TOOL_MESSAGE,
+    THINK_TOOL_STRING_CONTENT,
+    DISPLAY_INLINE_ARTIFACT_MESSAGE,
+    DISPLAY_INLINE_CONTENT_MESSAGE,
+    WRITE_TODOS_MESSAGE,
+    MESSAGES_CHUNK_REASONING_ONLY,
+    MESSAGES_CHUNK_REASONING_AND_TEXT,
+    MESSAGES_CHUNK_THINKING_BLOCK,
+)
+
+
+def make_stream(chunks: list) -> Iterator:
+    return iter(chunks)
+
+
+# ── ReasoningEvent from messages-mode content blocks ─────────────────
+
+
+class TestReasoningFromContentBlocks:
+    def test_reasoning_only_chunk(self):
+        parser = StreamParser(stream_mode="messages")
+        events = list(parser.parse(make_stream([MESSAGES_CHUNK_REASONING_ONLY])))
+
+        reasoning = [e for e in events if isinstance(e, ReasoningEvent)]
+        content = [e for e in events if isinstance(e, ContentEvent)]
+
+        assert len(reasoning) == 1
+        assert reasoning[0].source == "content_block"
+        assert reasoning[0].content == "Let me think about this carefully..."
+        assert reasoning[0].node == "agent"
+        # No final ContentEvent — only the reasoning block was present
+        assert len(content) == 0
+
+    def test_reasoning_and_text_emits_both(self):
+        parser = StreamParser(stream_mode="messages")
+        events = list(parser.parse(make_stream([MESSAGES_CHUNK_REASONING_AND_TEXT])))
+
+        reasoning = [e for e in events if isinstance(e, ReasoningEvent)]
+        content = [e for e in events if isinstance(e, ContentEvent)]
+
+        assert len(reasoning) == 1
+        assert reasoning[0].content == "First, I will analyze the input. "
+        assert len(content) == 1
+        assert content[0].content == "The answer is 42."
+
+    def test_reasoning_before_content(self):
+        """ReasoningEvent must be emitted before ContentEvent in one chunk."""
+        parser = StreamParser(stream_mode="messages")
+        events = list(parser.parse(make_stream([MESSAGES_CHUNK_REASONING_AND_TEXT])))
+
+        # Drop CompleteEvent at the end
+        stream_events = [e for e in events if not isinstance(e, CompleteEvent)]
+        assert isinstance(stream_events[0], ReasoningEvent)
+        assert isinstance(stream_events[1], ContentEvent)
+
+    def test_anthropic_thinking_block_recognized(self):
+        """'thinking' type (Anthropic) is treated as reasoning."""
+        parser = StreamParser(stream_mode="messages")
+        events = list(parser.parse(make_stream([MESSAGES_CHUNK_THINKING_BLOCK])))
+
+        reasoning = [e for e in events if isinstance(e, ReasoningEvent)]
+        assert len(reasoning) == 1
+        assert reasoning[0].content == "I should search for recent data."
+
+    def test_to_dict_shape(self):
+        event = ReasoningEvent(
+            content="thinking...",
+            source="content_block",
+            node="agent",
+        )
+        d = event.to_dict()
+        assert d["type"] == "reasoning"
+        assert d["content"] == "thinking..."
+        assert d["source"] == "content_block"
+        assert d["node"] == "agent"
+
+
+# ── ReasoningEvent from ThinkToolExtractor ──────────────────────────
+
+
+class TestReasoningFromThinkTool:
+    def test_think_tool_emits_reasoning(self):
+        parser = StreamParser()
+        events = list(parser.parse(make_stream([THINK_TOOL_MESSAGE])))
+
+        reasoning = [e for e in events if isinstance(e, ReasoningEvent)]
+        assert len(reasoning) == 1
+        assert reasoning[0].source == "think_tool"
+        assert reasoning[0].content == "I should search for more recent data."
+
+    def test_think_tool_string_content_emits_reasoning(self):
+        parser = StreamParser()
+        events = list(parser.parse(make_stream([THINK_TOOL_STRING_CONTENT])))
+
+        reasoning = [e for e in events if isinstance(e, ReasoningEvent)]
+        assert len(reasoning) == 1
+        assert reasoning[0].source == "think_tool"
+
+    def test_think_tool_does_not_emit_tool_extracted(self):
+        """Backward-compat guard: no generic ToolExtractedEvent for reflections."""
+        parser = StreamParser()
+        events = list(parser.parse(make_stream([THINK_TOOL_MESSAGE])))
+
+        generic = [
+            e for e in events
+            if isinstance(e, ToolExtractedEvent) and e.extracted_type == "reflection"
+        ]
+        assert len(generic) == 0
+
+
+# ── DisplayEvent from DisplayInlineExtractor ────────────────────────
+
+
+class TestDisplayEvent:
+    def test_artifact_emits_display(self):
+        parser = StreamParser()
+        events = list(parser.parse(make_stream([DISPLAY_INLINE_ARTIFACT_MESSAGE])))
+
+        displays = [e for e in events if isinstance(e, DisplayEvent)]
+        assert len(displays) == 1
+        d = displays[0]
+        assert d.display_type == "dataframe"
+        assert d.title == "Sales Data"
+        assert d.status == "success"
+        assert d.tool_name == "display_inline"
+        assert d.tool_call_id == "call_display"
+
+    def test_content_fallback_emits_display(self):
+        parser = StreamParser()
+        events = list(parser.parse(make_stream([DISPLAY_INLINE_CONTENT_MESSAGE])))
+
+        displays = [e for e in events if isinstance(e, DisplayEvent)]
+        assert len(displays) == 1
+        assert displays[0].display_type == "image"
+        assert displays[0].title == "Chart"
+
+    def test_display_does_not_emit_tool_extracted(self):
+        """Backward-compat guard: no generic ToolExtractedEvent for display_inline."""
+        parser = StreamParser()
+        events = list(parser.parse(make_stream([DISPLAY_INLINE_ARTIFACT_MESSAGE])))
+
+        generic = [
+            e for e in events
+            if isinstance(e, ToolExtractedEvent)
+            and e.extracted_type == "display_inline"
+        ]
+        assert len(generic) == 0
+
+    def test_to_dict_shape(self):
+        event = DisplayEvent(
+            display_type="dataframe",
+            data="<table>...</table>",
+            title="Sales",
+            tool_name="display_inline",
+        )
+        d = event.to_dict()
+        assert d["type"] == "display"
+        assert d["display_type"] == "dataframe"
+        assert d["data"] == "<table>...</table>"
+        assert d["title"] == "Sales"
+        assert d["status"] == "success"
+        assert d["tool_name"] == "display_inline"
+
+    def test_to_dict_omits_none_fields(self):
+        event = DisplayEvent(display_type="json", data={"k": 1})
+        d = event.to_dict()
+        assert "title" not in d
+        assert "error" not in d
+        assert "tool_name" not in d
+
+    def test_event_to_dict_routes_correctly(self):
+        """event_to_dict() dispatches DisplayEvent to its to_dict."""
+        event = DisplayEvent(display_type="plotly", data='{"layout": {}}')
+        d = event_to_dict(event)
+        assert d["type"] == "display"
+        assert d["display_type"] == "plotly"
+
+
+# ── Backward compat: other extractors still use ToolExtractedEvent ──
+
+
+class TestOtherExtractorsUnchanged:
+    def test_todos_still_tool_extracted(self):
+        """write_todos continues to emit ToolExtractedEvent."""
+        parser = StreamParser()
+        events = list(parser.parse(make_stream([WRITE_TODOS_MESSAGE])))
+
+        extracted = [e for e in events if isinstance(e, ToolExtractedEvent)]
+        assert len(extracted) == 1
+        assert extracted[0].extracted_type == "todos"
+        assert isinstance(extracted[0].data, list)


### PR DESCRIPTION
## Summary
- New `ReasoningEvent` dataclass emitted for langchain-core reasoning content blocks (Anthropic thinking, OpenAI reasoning summaries) and for `think_tool` reflections; discriminated by `source` field
- New `DisplayEvent` dataclass for rich inline content (dataframes, images, plotly, html, json) via `display_inline`-style tools; replaces `ToolExtractedEvent(extracted_type="display_inline")`
- `extract_reasoning_content()` helper for parsing reasoning blocks from `AIMessageChunk.content`
- `UpdatesHandler._event_from_extraction()` routes extractor output to typed events; unknown extracted_types still flow through `ToolExtractedEvent` so custom extractors keep working
- v2 parser audit: all 7 StreamPart variants confirmed covered; removed dead `has_messages` variable in `_parse_v2`
- README: new Reasoning & Thinking and Rich Inline Display sections
- 15 new tests (426 total, all passing)

## Breaking changes
- `think_tool` output was previously `ToolExtractedEvent(extracted_type="reflection")`; now emits `ReasoningEvent(source="think_tool")`
- `display_inline` output was previously `ToolExtractedEvent(extracted_type="display_inline")`; now emits `DisplayEvent`
- Legacy compat layer preserves both via existing dict shapes (`{"chunk": ...}` for reflections, new `{"display": {...}}` for displays)

## Test plan
- [x] All 426 tests pass
- [x] README updated with typed matching examples