### PR TITLE
Shared runtime: host conventions, SessionAdapter, demo agent (v0.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/header.svg" alt="langgraph-stream-parser" width="100%">
+</p>
+
 # langgraph-stream-parser
 
 Universal parser for LangGraph streaming outputs. Normalizes complex, variable output shapes from `graph.stream()` and `graph.astream()` into consistent, typed event objects.

--- a/assets/header.svg
+++ b/assets/header.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="340" viewBox="0 0 1280 340" role="img" aria-label="langgraph-stream-parser — typed events and adapters for LangGraph streaming output">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0B1221"/>
+      <stop offset="1" stop-color="#121226"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#7C5CFF"/>
+      <stop offset="1" stop-color="#34D6C8"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.82" cy="0.15" r="0.6">
+      <stop offset="0" stop-color="#7C5CFF" stop-opacity="0.22"/>
+      <stop offset="1" stop-color="#7C5CFF" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1280" height="340" rx="20" fill="url(#bg)"/>
+  <rect width="1280" height="340" rx="20" fill="url(#glow)"/>
+  <rect x="1" y="1" width="1278" height="338" rx="19" fill="none" stroke="#26284A" stroke-width="1.5"/>
+
+  <!-- ===== left: identity ===== -->
+  <g transform="translate(72,64)">
+    <rect width="92" height="34" rx="17" fill="#1A1535" stroke="url(#accent)" stroke-width="1.5"/>
+    <circle cx="22" cy="17" r="5" fill="url(#accent)"/>
+    <text x="38" y="23" font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="15" fill="#C9BEFF">v0.2</text>
+  </g>
+
+  <text x="70" y="176" font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="50" font-weight="700" fill="#F2F6FC" letter-spacing="-1">langgraph<tspan fill="url(#accent)">-stream-parser</tspan></text>
+
+  <text x="72" y="220" font-family="'Segoe UI',Helvetica,Arial,sans-serif" font-size="22" fill="#A6AECB">Typed events &#38; adapters for LangGraph streaming output.</text>
+  <text x="72" y="250" font-family="'Segoe UI',Helvetica,Arial,sans-serif" font-size="22" fill="#A6AECB">The shared runtime behind the deep-agent surfaces.</text>
+
+  <g font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="13" fill="#7C7FA6">
+    <text x="72" y="298">StreamParser</text>
+    <text x="196" y="298" fill="#45487A">&#8226;</text>
+    <text x="216" y="298">extractors</text>
+    <text x="312" y="298" fill="#45487A">&#8226;</text>
+    <text x="332" y="298">adapters</text>
+    <text x="420" y="298" fill="#45487A">&#8226;</text>
+    <text x="440" y="298">host &#183; demo</text>
+  </g>
+
+  <!-- ===== right: stream -> typed events ===== -->
+  <g transform="translate(840,86)">
+    <!-- source: graph.stream() -->
+    <rect width="150" height="40" rx="10" fill="#161433" stroke="#3A2F66" stroke-width="1.5"/>
+    <text x="18" y="25" font-family="'SF Mono','Consolas',monospace" font-size="13" fill="#9FB0CC">graph.stream()</text>
+
+    <!-- arrow -->
+    <line x1="150" y1="20" x2="196" y2="20" stroke="url(#accent)" stroke-width="2"/>
+    <path d="M196 20 l-9 -5 v10 z" fill="#34D6C8"/>
+
+    <!-- parser node -->
+    <rect x="196" y="2" width="118" height="36" rx="10" fill="#1A1535" stroke="url(#accent)" stroke-width="1.5"/>
+    <circle cx="216" cy="20" r="5" fill="url(#accent)"/>
+    <text x="230" y="25" font-family="'SF Mono','Consolas',monospace" font-size="12" fill="#C9BEFF">parse()</text>
+
+    <!-- typed event chips -->
+    <g font-family="'SF Mono','Consolas',monospace" font-size="12">
+      <g transform="translate(40,72)">
+        <rect width="130" height="26" rx="6" fill="#10243A" stroke="#2F9BFF" stroke-width="1"/>
+        <circle cx="15" cy="13" r="4" fill="#2F9BFF"/>
+        <text x="28" y="17" fill="#8FC4FF">ContentEvent</text>
+      </g>
+      <g transform="translate(190,72)">
+        <rect width="150" height="26" rx="6" fill="#0C2A22" stroke="#34D6C8" stroke-width="1"/>
+        <circle cx="15" cy="13" r="4" fill="#34D6C8"/>
+        <text x="28" y="17" fill="#7FE3D6">ToolCallStart</text>
+      </g>
+      <g transform="translate(40,108)">
+        <rect width="150" height="26" rx="6" fill="#0C2A22" stroke="#34D6C8" stroke-width="1"/>
+        <circle cx="15" cy="13" r="4" fill="#34D6C8"/>
+        <text x="28" y="17" fill="#7FE3D6">ToolCallEnd</text>
+      </g>
+      <g transform="translate(210,108)">
+        <rect width="130" height="26" rx="6" fill="#241A33" stroke="#7C5CFF" stroke-width="1"/>
+        <circle cx="15" cy="13" r="4" fill="#7C5CFF"/>
+        <text x="28" y="17" fill="#C9BEFF">Interrupt</text>
+      </g>
+      <g transform="translate(40,144)">
+        <rect width="180" height="26" rx="6" fill="#10243A" stroke="#2F9BFF" stroke-width="1"/>
+        <circle cx="15" cy="13" r="4" fill="#2F9BFF"/>
+        <text x="28" y="17" fill="#8FC4FF">Reasoning &#183; Display &#8230;</text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.1.9"
+version = "0.2.0"
 description = "Universal parser for LangGraph streaming outputs"
 readme = "README.md"
 license = {text = "MIT"}
@@ -37,6 +37,9 @@ jupyter = [
 ]
 fastapi = [
     "fastapi>=0.100",
+]
+demo = [
+    "deepagents>=0.3",
 ]
 dev = [
     "pytest>=7.0",

--- a/src/langgraph_stream_parser/__init__.py
+++ b/src/langgraph_stream_parser/__init__.py
@@ -51,6 +51,7 @@ from .events import (
 from .extractors.base import ToolExtractor
 from .extractors.builtins import ThinkToolExtractor, TodoExtractor, DisplayInlineExtractor
 from .resume import create_resume_input, prepare_agent_input
+from .host import load_agent_spec, HostConfig, Workspace
 from .compat import (
     stream_graph_updates,
     astream_graph_updates,
@@ -58,7 +59,7 @@ from .compat import (
     aresume_graph_from_interrupt,
 )
 
-__version__ = "0.1.9"
+__version__ = "0.2.0"
 
 __all__ = [
     # Main parser
@@ -87,6 +88,10 @@ __all__ = [
     # Resume utilities
     "create_resume_input",
     "prepare_agent_input",
+    # Host conventions
+    "load_agent_spec",
+    "HostConfig",
+    "Workspace",
     # Serialization
     "event_to_dict",
     # Legacy/compat functions

--- a/src/langgraph_stream_parser/adapters/__init__.py
+++ b/src/langgraph_stream_parser/adapters/__init__.py
@@ -4,6 +4,7 @@ from .base import BaseAdapter, ToolStatus, ToolState
 from .print import PrintAdapter
 from .cli import CLIAdapter
 from .fastapi import FastAPIAdapter
+from .session import SessionAdapter, Session
 
 __all__ = [
     "BaseAdapter",
@@ -12,4 +13,6 @@ __all__ = [
     "PrintAdapter",
     "CLIAdapter",
     "FastAPIAdapter",
+    "SessionAdapter",
+    "Session",
 ]

--- a/src/langgraph_stream_parser/adapters/session.py
+++ b/src/langgraph_stream_parser/adapters/session.py
@@ -1,0 +1,256 @@
+"""Session-scoped streaming adapter for web hosts.
+
+Where :class:`~langgraph_stream_parser.adapters.fastapi.FastAPIAdapter` is
+request-scoped (one turn per call), ``SessionAdapter`` keeps a long-lived
+session that:
+
+- survives client disconnects (a page refresh resumes the same session),
+- multiplexes a per-session event queue so a producer turn and out-of-band
+  events (file-change notifications, etc.) interleave on one SSE stream,
+- supports cancelling an in-flight turn,
+- delegates conversation state to LangGraph's checkpointer (keyed by the
+  session id used as ``thread_id``).
+
+This absorbs the ``session_manager`` + ``sse_adapter`` + chat-route plumbing
+that ``cowork-dash`` used to carry in-tree.
+
+Requires: ``pip install langgraph-stream-parser[fastapi]`` for the SSE helper
+(only the JSON framing needs nothing; ``asyncio`` is stdlib).
+"""
+import asyncio
+import json
+import uuid
+from datetime import datetime
+from typing import Any, AsyncIterator
+
+from ..events import CompleteEvent, ErrorEvent, event_to_dict
+from ..parser import StreamParser
+from ..resume import create_resume_input, prepare_agent_input
+
+
+class Session:
+    """State for a single chat session. Outlives any one transport connection."""
+
+    def __init__(self, session_id: str | None = None):
+        self.id: str = session_id or str(uuid.uuid4())
+        self.config: dict[str, Any] = {"configurable": {"thread_id": self.id}}
+        self.event_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self.current_task: asyncio.Task | None = None
+        self.sse_connected: bool = False
+        self.created_at: datetime = datetime.now()
+
+    def cancel_current(self) -> bool:
+        """Cancel the in-flight turn if any. Returns True if one was cancelled."""
+        if self.current_task is not None and not self.current_task.done():
+            self.current_task.cancel()
+            return True
+        return False
+
+    def push(self, event: dict[str, Any]) -> None:
+        """Enqueue a serialized event for SSE consumers (non-blocking)."""
+        # The queue is unbounded, so put_nowait never raises QueueFull and is
+        # safe to call from within an except/cancellation block.
+        self.event_queue.put_nowait(event)
+
+
+class SessionAdapter:
+    """Session-scoped streaming for LangGraph agents.
+
+    Attributes:
+        graph: A compiled LangGraph graph (with a checkpointer for resumption).
+        stream_mode: Stream mode for ``astream`` and the parser. Defaults to
+            dual mode so content streams token-by-token while tool/interrupt
+            events arrive complete.
+        max_result_len: Max length for serialized tool results (see
+            :func:`event_to_dict`).
+        parser_kwargs: Extra kwargs forwarded to each ``StreamParser``
+            (e.g. ``skip_tools``, custom ``extractors`` via registration).
+
+    Example:
+        adapter = SessionAdapter(graph=agent)
+
+        # POST /api/chat  →  start a turn
+        adapter.submit_message(session_id, content, context_parts=[...])
+
+        # GET /api/stream  →  consume events (persistent EventSource)
+        return StreamingResponse(adapter.sse(session_id),
+                                 media_type="text/event-stream")
+
+        # POST /api/chat/interrupt  →  resume from a HITL interrupt
+        adapter.submit_decisions(session_id, decisions)
+
+        # POST /api/chat/cancel
+        adapter.cancel(session_id)
+    """
+
+    def __init__(
+        self,
+        *,
+        graph: Any,
+        stream_mode: str | list[str] = ("updates", "messages"),
+        max_result_len: int = 500,
+        **parser_kwargs: Any,
+    ):
+        self._graph = graph
+        # Normalize tuple default to a list (StreamParser expects str | list).
+        self._stream_mode = list(stream_mode) if isinstance(stream_mode, tuple) else stream_mode
+        self._max_result_len = max_result_len
+        self._parser_kwargs = parser_kwargs
+        self._sessions: dict[str, Session] = {}
+
+    # ── Session lifecycle ────────────────────────────────────────────
+
+    def get_or_create(self, session_id: str | None = None) -> Session:
+        """Resume an existing session by id, or create a fresh one.
+
+        A provided-but-unknown ``session_id`` is honored as the new session's
+        id, so a reconnecting client keeps its ``thread_id`` (and thus its
+        checkpointed history).
+        """
+        if session_id and session_id in self._sessions:
+            return self._sessions[session_id]
+        session = Session(session_id)
+        self._sessions[session.id] = session
+        return session
+
+    def get(self, session_id: str) -> Session | None:
+        """Look up a session by id, or None."""
+        return self._sessions.get(session_id)
+
+    def delete_session(self, session_id: str) -> bool:
+        """Cancel and remove a session. Returns True if it existed."""
+        session = self._sessions.pop(session_id, None)
+        if session is None:
+            return False
+        session.cancel_current()
+        return True
+
+    def list_sessions(self) -> list[dict[str, Any]]:
+        """Summaries of all live sessions."""
+        return [
+            {
+                "session_id": s.id,
+                "created_at": s.created_at.isoformat(),
+                "connected": s.sse_connected,
+            }
+            for s in self._sessions.values()
+        ]
+
+    @property
+    def active_count(self) -> int:
+        """Number of sessions with a connected SSE consumer."""
+        return sum(1 for s in self._sessions.values() if s.sse_connected)
+
+    # ── Producing turns ──────────────────────────────────────────────
+
+    def submit_message(
+        self,
+        session_id: str | None,
+        content: str,
+        *,
+        context_parts: list[str] | None = None,
+    ) -> Session:
+        """Start a turn for a user message. Cancels any in-flight turn first.
+
+        The turn runs as a background task that pushes serialized events onto
+        the session's queue; consume them via :meth:`sse`.
+        """
+        session = self.get_or_create(session_id)
+        session.cancel_current()
+        input_data = prepare_agent_input(message=content, context_parts=context_parts)
+        session.current_task = asyncio.create_task(self._produce(session, input_data))
+        return session
+
+    def submit_decisions(
+        self,
+        session_id: str | None,
+        decisions: list[dict[str, Any]],
+    ) -> Session:
+        """Resume a session from an interrupt with HITL decisions."""
+        session = self.get_or_create(session_id)
+        session.cancel_current()
+        input_data = create_resume_input(decisions=decisions)
+        session.current_task = asyncio.create_task(self._produce(session, input_data))
+        return session
+
+    def cancel(self, session_id: str) -> bool:
+        """Cancel the in-flight turn for a session. Returns True if one ran."""
+        session = self._sessions.get(session_id)
+        if session is None:
+            return False
+        return session.cancel_current()
+
+    def push_event(self, session_id: str | None, event: dict[str, Any]) -> Session:
+        """Push an out-of-band event onto a session's stream (side channel).
+
+        Use for events that don't originate from the agent — e.g. a file
+        watcher pushing ``{"type": "file_changed", ...}`` into the same SSE
+        stream the agent events flow through.
+        """
+        session = self.get_or_create(session_id)
+        session.push(event)
+        return session
+
+    async def _produce(self, session: Session, input_data: Any) -> None:
+        """Run one turn, pushing serialized events onto the session queue."""
+        parser = StreamParser(stream_mode=self._stream_mode, **self._parser_kwargs)
+        try:
+            stream = self._graph.astream(
+                input_data,
+                config=session.config,
+                stream_mode=self._stream_mode,
+            )
+            async for event in parser.aparse(stream):
+                session.push(event_to_dict(event, max_result_len=self._max_result_len))
+                # Terminal events end the turn; the parser emits exactly one.
+                if isinstance(event, (CompleteEvent, ErrorEvent)):
+                    return
+        except asyncio.CancelledError:
+            session.push({"type": "cancelled"})
+            raise
+        except Exception as exc:  # noqa: BLE001 — surfaced to the client, not swallowed
+            session.push({"type": "error", "error": f"{type(exc).__name__}: {exc}"})
+
+    # ── Consuming (SSE) ──────────────────────────────────────────────
+
+    async def sse(
+        self,
+        session_id: str | None = None,
+        *,
+        keepalive: float = 30.0,
+        send_init: bool = True,
+    ) -> AsyncIterator[str]:
+        """Yield Server-Sent Events for a session, persistently.
+
+        Drains the session queue, emitting one ``data: {json}\\n\\n`` frame per
+        event. On idle, emits a ``: keepalive`` comment every ``keepalive``
+        seconds to keep proxies from closing the connection. The generator runs
+        until the consumer stops iterating (e.g. the ASGI server detects the
+        client disconnected), so a single EventSource spans many turns.
+
+        Args:
+            session_id: Resume this session, or create one if None/unknown.
+            keepalive: Seconds between keepalive comments while idle.
+            send_init: Emit a ``session_init`` frame first so the client learns
+                its (possibly newly minted) session id for reconnects.
+        """
+        session = self.get_or_create(session_id)
+        session.sse_connected = True
+        try:
+            if send_init:
+                yield _sse_frame({"type": "session_init", "session_id": session.id})
+            while True:
+                try:
+                    event = await asyncio.wait_for(
+                        session.event_queue.get(), timeout=keepalive
+                    )
+                    yield _sse_frame(event)
+                except asyncio.TimeoutError:
+                    yield ": keepalive\n\n"
+        finally:
+            session.sse_connected = False
+
+
+def _sse_frame(event: dict[str, Any]) -> str:
+    """Format an event dict as a single SSE ``data:`` frame."""
+    return f"data: {json.dumps(event)}\n\n"

--- a/src/langgraph_stream_parser/demo/__init__.py
+++ b/src/langgraph_stream_parser/demo/__init__.py
@@ -1,0 +1,15 @@
+"""A canonical default deep agent for hosts to fall back on.
+
+Hosts used to each ship their own "default agent" so a user could try the tool
+without configuring one. This is the single shared version. It is filesystem
+only by design — each host injects its own domain tools (notebook cells,
+canvas, etc.) via the ``tools`` argument rather than this module trying to be
+everything.
+
+Requires the optional ``deepagents`` dependency:
+
+    pip install langgraph-stream-parser[demo]
+"""
+from .agent import create_default_agent
+
+__all__ = ["create_default_agent"]

--- a/src/langgraph_stream_parser/demo/agent.py
+++ b/src/langgraph_stream_parser/demo/agent.py
@@ -1,0 +1,102 @@
+"""The shared default agent factory.
+
+``deepagents`` and ``langgraph`` are imported lazily inside the factory so the
+base ``langgraph-stream-parser`` install stays dependency-light — importing
+this module does not require the ``[demo]`` extra; only *calling* the factory
+does.
+"""
+from pathlib import Path
+from typing import Any
+
+DEFAULT_MODEL = "anthropic:claude-sonnet-4-6"
+
+DEFAULT_SYSTEM_PROMPT = """You are a helpful AI assistant with access to a \
+filesystem workspace.
+
+- Explain what you are about to do before using a tool, and summarize results \
+after.
+- Use the todo tool to plan multi-step work and keep the user informed of \
+progress.
+- Be proactive in exploring the workspace when it helps, but never run risky \
+or destructive actions without explicit user consent.
+
+The workspace is your sandbox — read, create, and organize files to help the \
+user with their tasks."""
+
+
+def create_default_agent(
+    workspace: str | Path = ".",
+    *,
+    model: str | None = DEFAULT_MODEL,
+    system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+    tools: list[Any] | None = None,
+    name: str = "Deep Agent",
+    virtual_mode: bool = True,
+    checkpointer: Any = None,
+    **extra: Any,
+):
+    """Create a filesystem-backed deep agent for hosts to use as a default.
+
+    This owns the boilerplate (filesystem backend, checkpointer, model wiring)
+    that every host's default agent repeated. Hosts supply their own prompt,
+    tools, and any deepagents extras (``middleware``, ``interrupt_on``, ...) via
+    ``**extra``.
+
+    Args:
+        workspace: Root directory the agent's filesystem backend operates in.
+        model: Model identifier passed to deepagents (e.g.
+            ``"anthropic:claude-sonnet-4-6"``). Requires the matching provider
+            API key in the environment. Pass ``None`` to let deepagents pick its
+            own default model.
+        system_prompt: System prompt for the agent.
+        tools: Extra tools to register. Hosts inject their domain tools here
+            (notebook cells, canvas, ...). Defaults to none — filesystem +
+            built-in deepagents tools only.
+        name: Display name surfaced in host UIs.
+        virtual_mode: Passed to deepagents' ``FilesystemBackend``.
+        checkpointer: Checkpointer for the agent. Defaults to an
+            ``InMemorySaver`` when not provided.
+        **extra: Forwarded verbatim to ``deepagents.create_deep_agent`` —
+            e.g. ``middleware=[...]`` or ``interrupt_on={"bash": True}``.
+
+    Returns:
+        A compiled deep agent (LangGraph ``CompiledGraph``).
+
+    Raises:
+        RuntimeError: If the ``deepagents`` extra is not installed.
+
+    Example:
+        from langgraph_stream_parser.demo import create_default_agent
+        agent = create_default_agent("./workspace")
+
+        # A host layering its own tools + middleware on the shared boilerplate:
+        agent = create_default_agent(
+            "./ws", name="Cowork Dash", system_prompt=PROMPT,
+            tools=MY_TOOLS, middleware=[CanvasMiddleware()],
+            interrupt_on={"bash": True},
+        )
+    """
+    try:
+        from deepagents import create_deep_agent
+        from deepagents.backends import FilesystemBackend
+        from langgraph.checkpoint.memory import InMemorySaver
+    except ImportError as exc:  # pragma: no cover - exercised via message only
+        raise RuntimeError(
+            "create_default_agent requires the 'deepagents' extra. "
+            "Install it with: pip install langgraph-stream-parser[demo]"
+        ) from exc
+
+    backend = FilesystemBackend(root_dir=str(workspace), virtual_mode=virtual_mode)
+
+    kwargs: dict[str, Any] = dict(
+        name=name,
+        system_prompt=system_prompt,
+        backend=backend,
+        tools=tools or [],
+        checkpointer=checkpointer if checkpointer is not None else InMemorySaver(),
+        **extra,
+    )
+    if model is not None:
+        kwargs["model"] = model
+
+    return create_deep_agent(**kwargs)

--- a/src/langgraph_stream_parser/events.py
+++ b/src/langgraph_stream_parser/events.py
@@ -638,7 +638,9 @@ class ErrorEvent:
         }
 
 
-def event_to_dict(event: "StreamEvent") -> dict[str, Any]:
+def event_to_dict(
+    event: "StreamEvent", *, max_result_len: int = 500
+) -> dict[str, Any]:
     """Convert any StreamEvent to a JSON-serializable dict.
 
     This is a convenience function for web APIs that need to serialize
@@ -646,6 +648,10 @@ def event_to_dict(event: "StreamEvent") -> dict[str, Any]:
 
     Args:
         event: Any StreamEvent instance.
+        max_result_len: Maximum length for the ``result`` string of a
+            ``ToolCallEndEvent`` (truncated with an ellipsis if longer).
+            Ignored for every other event type. Raise this when a UI
+            needs to show full tool output instead of a preview.
 
     Returns:
         A dict with a "type" key and event-specific fields.
@@ -653,10 +659,17 @@ def event_to_dict(event: "StreamEvent") -> dict[str, Any]:
     Example:
         for event in parser.parse(stream):
             await websocket.send_json(event_to_dict(event))
+
+        # Show full tool results in a rich UI:
+        event_to_dict(tool_end_event, max_result_len=50_000)
     """
-    if hasattr(event, "to_dict"):
-        return event.to_dict()
-    return {"type": "unknown", "event": str(event)}
+    to_dict = getattr(event, "to_dict", None)
+    if to_dict is None:
+        return {"type": "unknown", "event": str(event)}
+    # Only ToolCallEndEvent.to_dict accepts max_result_len.
+    if isinstance(event, ToolCallEndEvent):
+        return to_dict(max_result_len=max_result_len)
+    return to_dict()
 
 
 # Union type for all events - useful for type hints

--- a/src/langgraph_stream_parser/handlers/updates.py
+++ b/src/langgraph_stream_parser/handlers/updates.py
@@ -305,14 +305,15 @@ class UpdatesHandler:
         content = getattr(message, 'content', None)
         artifact = getattr(message, 'artifact', None)
 
-        # Skip if tool should be skipped
-        if tool_name in self._skip_tools:
-            return
-
         # Check for errors
         is_error, error_message = detect_tool_error(message)
 
-        # Try to extract special content
+        # Try to extract special content FIRST — extractors run even for
+        # skipped tools. Skipping a tool hides its lifecycle (start/end)
+        # events, but the whole point of an extractor is to surface that
+        # tool's content in another form (e.g. write_todos -> todos,
+        # think_tool -> reflection). Gating the extractor on skip_tools would
+        # silently drop those, which is what hosts use skip_tools to keep.
         # Prefer artifact over content (artifact carries full data from
         # tools using response_format="content_and_artifact")
         extractor = self._extractors.get(tool_name) if tool_name else None
@@ -329,6 +330,11 @@ class UpdatesHandler:
             except Exception:
                 # Graceful degradation - continue without extraction
                 pass
+
+        # Skipped tools emit no lifecycle end event (their start was already
+        # suppressed in _process_ai_message).
+        if tool_name in self._skip_tools:
+            return
 
         # Emit ToolCallEndEvent if tracking lifecycle
         if self._track_tool_lifecycle and tool_call_id:

--- a/src/langgraph_stream_parser/host/__init__.py
+++ b/src/langgraph_stream_parser/host/__init__.py
@@ -1,0 +1,15 @@
+"""Host conventions shared across deep-agent surfaces.
+
+Agent-spec loading, the shared ``DEEPAGENT_*`` config schema, and a workspace
+wrapper — the plumbing every host (``cowork-dash``, ``deepagent-lab``,
+``deepagent-code``, ``deepagent-vscode``) needs but used to reimplement.
+"""
+from .config import HostConfig
+from .loader import load_agent_spec
+from .workspace import Workspace
+
+__all__ = [
+    "load_agent_spec",
+    "HostConfig",
+    "Workspace",
+]

--- a/src/langgraph_stream_parser/host/config.py
+++ b/src/langgraph_stream_parser/host/config.py
@@ -1,0 +1,78 @@
+"""Shared ``DEEPAGENT_*`` environment-variable schema for hosts.
+
+``HostConfig`` holds only the keys every host has in common: the agent spec,
+the workspace root, and the bind/title basics. Host-specific keys (theme,
+auth, canvas/files toggles, model name, Jupyter token, virtual mode, ...)
+belong in each host's own subclass — drift below the shared core is fine.
+
+Resolution order is the host's responsibility; the typical chain is
+``Python args > CLI args > env vars > defaults``. Use ``from_env`` to seed
+from the environment and ``merge`` to layer overrides on top.
+"""
+import os
+from dataclasses import dataclass, fields, replace
+from pathlib import Path
+from typing import Any
+
+
+def _env_bool(value: str | None, default: bool = False) -> bool:
+    """Parse an env-var string into a bool."""
+    if value is None or value == "":
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+@dataclass
+class HostConfig:
+    """Shared configuration for deep-agent hosts.
+
+    Subclass to add host-specific fields, and extend ``from_env`` to read
+    their env vars:
+
+        @dataclass
+        class WebConfig(HostConfig):
+            theme: str = "auto"
+
+            @classmethod
+            def from_env(cls):
+                base = super().from_env()
+                return base.merge(theme=os.getenv("DEEPAGENT_THEME", "auto"))
+    """
+
+    agent_spec: str | None = None     # DEEPAGENT_AGENT_SPEC ("path.py:var")
+    workspace_root: Path = Path(".")  # DEEPAGENT_WORKSPACE_ROOT
+    host: str = "localhost"           # DEEPAGENT_HOST
+    port: int = 8050                  # DEEPAGENT_PORT
+    debug: bool = False               # DEEPAGENT_DEBUG
+    title: str = "Deep Agent"         # DEEPAGENT_TITLE
+
+    @classmethod
+    def from_env(cls) -> "HostConfig":
+        """Build config from ``DEEPAGENT_*`` environment variables.
+
+        Subclasses that add fields should call ``super().from_env()`` and
+        ``merge`` their own keys on top.
+        """
+        workspace = os.getenv("DEEPAGENT_WORKSPACE_ROOT")
+        port = os.getenv("DEEPAGENT_PORT")
+        return cls(
+            agent_spec=os.getenv("DEEPAGENT_AGENT_SPEC"),
+            workspace_root=Path(workspace) if workspace else Path("."),
+            host=os.getenv("DEEPAGENT_HOST", "localhost"),
+            port=int(port) if port else 8050,
+            debug=_env_bool(os.getenv("DEEPAGENT_DEBUG")),
+            title=os.getenv("DEEPAGENT_TITLE", "Deep Agent"),
+        )
+
+    def merge(self, **overrides: Any) -> "HostConfig":
+        """Return a copy with non-``None`` overrides applied.
+
+        ``None`` values are ignored so callers can pass through unset CLI
+        flags without clobbering env-derived values.
+        """
+        valid = {f.name for f in fields(self)}
+        applied = {
+            k: v for k, v in overrides.items()
+            if v is not None and k in valid
+        }
+        return replace(self, **applied)

--- a/src/langgraph_stream_parser/host/loader.py
+++ b/src/langgraph_stream_parser/host/loader.py
@@ -1,0 +1,83 @@
+"""Load a LangGraph agent from a ``path:object`` spec string.
+
+This is the canonical agent-spec loader for every deep-agent host
+(``cowork-dash``, ``deepagent-lab``, ``deepagent-code``, ``deepagent-vscode``).
+It replaces the per-host loaders that had drifted apart.
+
+The spec format is **strict**: the ``:variable`` suffix is required. There is
+no implicit ``agent``/``graph`` fallback — explicit beats implicit, and the
+two hosts that disagreed on the fallback now share one rule.
+"""
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_agent_spec(spec: str) -> Any:
+    """Load a LangGraph agent from a ``"path:object"`` spec string.
+
+    Args:
+        spec: ``"path/to/module.py:object_name"`` (file path) or
+            ``"package.module:object_name"`` (dotted module path). The
+            ``:object_name`` suffix is required.
+
+    Returns:
+        The agent object (typically a compiled LangGraph graph).
+
+    Raises:
+        ValueError: If the spec has no ``:object`` suffix.
+        FileNotFoundError: If a ``.py`` file path does not exist.
+        ImportError: If the module cannot be loaded/imported.
+        AttributeError: If the object is not found in the module.
+
+    Example:
+        agent = load_agent_spec("./my_agent.py:agent")
+        agent = load_agent_spec("my_package.agents:research_graph")
+    """
+    if ":" not in spec:
+        raise ValueError(
+            f"Invalid agent spec {spec!r}. Expected "
+            "'path/to/module.py:object_name' or 'package.module:object_name' "
+            "(the ':object_name' suffix is required)."
+        )
+
+    module_path, _, obj_name = spec.rpartition(":")
+    if not module_path or not obj_name:
+        raise ValueError(
+            f"Invalid agent spec {spec!r}. Both a module/file path and an "
+            "object name are required, e.g. 'agent.py:graph'."
+        )
+
+    module = _import_module(module_path)
+
+    if not hasattr(module, obj_name):
+        raise AttributeError(
+            f"Module {module_path!r} has no attribute {obj_name!r}."
+        )
+    return getattr(module, obj_name)
+
+
+def _import_module(module_path: str) -> Any:
+    """Import a module from a file path or a dotted module path."""
+    file_path = Path(module_path)
+
+    # File path: load from source location.
+    if file_path.suffix == ".py" or any(sep in module_path for sep in ("/", "\\")):
+        file_path = file_path.resolve()
+        if not file_path.exists():
+            raise FileNotFoundError(f"Agent file not found: {file_path}")
+
+        # Unique module name so repeated loads of different files don't collide.
+        module_name = f"_lsp_agent_{file_path.stem}_{abs(hash(str(file_path)))}"
+        spec_obj = importlib.util.spec_from_file_location(module_name, file_path)
+        if spec_obj is None or spec_obj.loader is None:
+            raise ImportError(f"Cannot load module from {file_path}")
+        module = importlib.util.module_from_spec(spec_obj)
+        sys.modules[module_name] = module
+        spec_obj.loader.exec_module(module)
+        return module
+
+    # Dotted module path.
+    return importlib.import_module(module_path)

--- a/src/langgraph_stream_parser/host/workspace.py
+++ b/src/langgraph_stream_parser/host/workspace.py
@@ -1,0 +1,42 @@
+"""A small workspace-root wrapper shared by hosts.
+
+Not load-bearing — just removes the repeated ``mkdir`` / safe-join logic and
+gives a single place for the "agent's working directory" concept.
+"""
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Workspace:
+    """The directory an agent operates within."""
+
+    root: Path = field(default_factory=lambda: Path("."))
+
+    def __post_init__(self) -> None:
+        self.root = Path(self.root)
+
+    def ensure(self) -> "Workspace":
+        """Create the workspace root if it does not exist. Returns self."""
+        self.root.mkdir(parents=True, exist_ok=True)
+        return self
+
+    def subpath(self, *parts: str) -> Path:
+        """Join ``parts`` under the root, refusing to escape it.
+
+        Raises:
+            ValueError: If the resolved path would fall outside the root
+                (e.g. via ``..`` traversal).
+        """
+        candidate = self.root.joinpath(*parts).resolve()
+        root_resolved = self.root.resolve()
+        if root_resolved != candidate and root_resolved not in candidate.parents:
+            raise ValueError(
+                f"Path {candidate} escapes workspace root {root_resolved}"
+            )
+        return candidate
+
+    @property
+    def name(self) -> str:
+        """The workspace directory name (for display)."""
+        return self.root.resolve().name

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -151,6 +151,32 @@ class TestStreamGraphUpdates:
         tool_updates = [u for u in updates if "tool_calls" in u]
         assert len(tool_updates) >= 1
 
+    def test_write_todos_surfaces_todo_list(self):
+        """write_todos is in skip_tools (kept out of tool_calls noise) but its
+        result must STILL surface as a todo_list update — consumers like the
+        deepagent-lab todo sidebar depend on it. Regression guard: skip_tools
+        must hide a tool's lifecycle without suppressing its extractor."""
+        mock_agent = MagicMock()
+        mock_agent.stream.return_value = iter([WRITE_TODOS_MESSAGE])
+
+        updates = list(stream_graph_updates(mock_agent, {}))
+
+        todo_updates = [u for u in updates if "todo_list" in u]
+        assert len(todo_updates) == 1
+        # ...and it must not leak as a tool_calls update.
+        assert not [u for u in updates if "tool_calls" in u]
+
+    def test_think_tool_surfaces_as_chunk(self):
+        """think_tool is skipped from tool_calls but its reflection must still
+        surface (as a chunk update) so the UI shows the agent's thinking."""
+        mock_agent = MagicMock()
+        mock_agent.stream.return_value = iter([THINK_TOOL_MESSAGE])
+
+        updates = list(stream_graph_updates(mock_agent, {}))
+
+        chunk_updates = [u for u in updates if "chunk" in u]
+        assert len(chunk_updates) >= 1
+
     def test_interrupt(self):
         mock_agent = MagicMock()
         mock_agent.stream.return_value = iter([INTERRUPT_WITH_ACTIONS])

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,0 +1,36 @@
+"""Tests for the demo default-agent factory.
+
+These avoid actually building an agent (that needs deepagents + an API key).
+They verify the import is lazy and the missing-extra error is helpful.
+"""
+import sys
+
+import pytest
+
+from langgraph_stream_parser.demo import create_default_agent
+
+
+def _deepagents_installed() -> bool:
+    try:
+        import deepagents  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def test_factory_is_importable_and_callable():
+    assert callable(create_default_agent)
+
+
+def test_import_does_not_eagerly_pull_deepagents():
+    # The factory imports deepagents lazily; importing the module must not.
+    if _deepagents_installed():
+        pytest.skip("deepagents installed — laziness check is vacuous")
+    assert "deepagents" not in sys.modules
+
+
+def test_missing_extra_raises_helpful_error():
+    if _deepagents_installed():
+        pytest.skip("deepagents installed — cannot exercise the missing-extra path")
+    with pytest.raises(RuntimeError, match=r"deepagents.*extra|extra.*deepagents"):
+        create_default_agent(".")

--- a/tests/test_host.py
+++ b/tests/test_host.py
@@ -1,0 +1,149 @@
+"""Tests for the host submodule: load_agent_spec, HostConfig, Workspace."""
+import sys
+from pathlib import Path
+
+import pytest
+
+from langgraph_stream_parser.host import HostConfig, Workspace, load_agent_spec
+
+
+# ── load_agent_spec ──────────────────────────────────────────────────
+
+
+class TestLoadAgentSpec:
+    def test_load_from_file(self, tmp_path: Path):
+        agent_file = tmp_path / "my_agent.py"
+        agent_file.write_text("agent = {'name': 'demo'}\n")
+
+        loaded = load_agent_spec(f"{agent_file}:agent")
+        assert loaded == {"name": "demo"}
+
+    def test_load_from_dotted_module(self):
+        # math:pi is a stand-in for a dotted module path.
+        import math
+
+        assert load_agent_spec("math:pi") == math.pi
+
+    def test_missing_separator_raises_value_error(self):
+        with pytest.raises(ValueError, match="suffix is required"):
+            load_agent_spec("just_a_path")
+
+    def test_empty_object_name_raises_value_error(self):
+        with pytest.raises(ValueError):
+            load_agent_spec("module:")
+
+    def test_missing_file_raises_file_not_found(self):
+        with pytest.raises(FileNotFoundError):
+            load_agent_spec("does_not_exist.py:agent")
+
+    def test_missing_attribute_raises_attribute_error(self):
+        with pytest.raises(AttributeError, match="no attribute"):
+            load_agent_spec("math:not_a_real_attr")
+
+    def test_no_implicit_fallback(self, tmp_path: Path):
+        # A file defining only `graph` must NOT be loadable as `:agent`.
+        agent_file = tmp_path / "graph_only.py"
+        agent_file.write_text("graph = 1\n")
+        with pytest.raises(AttributeError):
+            load_agent_spec(f"{agent_file}:agent")
+
+    def test_colon_in_windows_path_uses_last_separator(self, tmp_path: Path):
+        # rpartition(':') must split on the final colon so drive letters
+        # like C:\... in a path still resolve the object name correctly.
+        agent_file = tmp_path / "win_agent.py"
+        agent_file.write_text("graph = 'ok'\n")
+        loaded = load_agent_spec(f"{agent_file}:graph")
+        assert loaded == "ok"
+
+
+# ── HostConfig ───────────────────────────────────────────────────────
+
+
+class TestHostConfig:
+    def test_defaults(self):
+        cfg = HostConfig()
+        assert cfg.agent_spec is None
+        assert cfg.workspace_root == Path(".")
+        assert cfg.host == "localhost"
+        assert cfg.port == 8050
+        assert cfg.debug is False
+        assert cfg.title == "Deep Agent"
+
+    def test_from_env(self, monkeypatch):
+        monkeypatch.setenv("DEEPAGENT_AGENT_SPEC", "agent.py:graph")
+        monkeypatch.setenv("DEEPAGENT_WORKSPACE_ROOT", "/tmp/ws")
+        monkeypatch.setenv("DEEPAGENT_HOST", "0.0.0.0")
+        monkeypatch.setenv("DEEPAGENT_PORT", "9000")
+        monkeypatch.setenv("DEEPAGENT_DEBUG", "true")
+        monkeypatch.setenv("DEEPAGENT_TITLE", "My Agent")
+
+        cfg = HostConfig.from_env()
+        assert cfg.agent_spec == "agent.py:graph"
+        assert cfg.workspace_root == Path("/tmp/ws")
+        assert cfg.host == "0.0.0.0"
+        assert cfg.port == 9000
+        assert cfg.debug is True
+        assert cfg.title == "My Agent"
+
+    def test_from_env_empty_uses_defaults(self, monkeypatch):
+        for key in (
+            "DEEPAGENT_AGENT_SPEC", "DEEPAGENT_WORKSPACE_ROOT", "DEEPAGENT_HOST",
+            "DEEPAGENT_PORT", "DEEPAGENT_DEBUG", "DEEPAGENT_TITLE",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        cfg = HostConfig.from_env()
+        assert cfg.port == 8050
+        assert cfg.workspace_root == Path(".")
+
+    def test_merge_applies_non_none(self):
+        cfg = HostConfig(port=8050, title="A")
+        merged = cfg.merge(port=9001, title=None)
+        assert merged.port == 9001
+        assert merged.title == "A"  # None override ignored
+        assert cfg.port == 8050  # original unchanged
+
+    def test_merge_ignores_unknown_keys(self):
+        cfg = HostConfig()
+        merged = cfg.merge(not_a_field="x", port=1234)
+        assert merged.port == 1234
+        assert not hasattr(merged, "not_a_field")
+
+    def test_subclass_extends(self, monkeypatch):
+        from dataclasses import dataclass
+
+        @dataclass
+        class WebConfig(HostConfig):
+            theme: str = "auto"
+
+        cfg = WebConfig.from_env().merge(theme="dark")
+        assert cfg.theme == "dark"
+        assert cfg.port == 8050
+
+
+# ── Workspace ────────────────────────────────────────────────────────
+
+
+class TestWorkspace:
+    def test_ensure_creates_dir(self, tmp_path: Path):
+        target = tmp_path / "ws" / "nested"
+        ws = Workspace(target).ensure()
+        assert target.is_dir()
+        assert ws.root == target
+
+    def test_subpath_joins_under_root(self, tmp_path: Path):
+        ws = Workspace(tmp_path).ensure()
+        p = ws.subpath("a", "b.txt")
+        assert p == (tmp_path / "a" / "b.txt").resolve()
+
+    def test_subpath_rejects_escape(self, tmp_path: Path):
+        ws = Workspace(tmp_path / "ws").ensure()
+        with pytest.raises(ValueError, match="escapes workspace"):
+            ws.subpath("..", "..", "etc", "passwd")
+
+    def test_name(self, tmp_path: Path):
+        ws = Workspace(tmp_path / "project")
+        assert ws.name == "project"
+
+    def test_str_root_coerced_to_path(self):
+        ws = Workspace(".")
+        assert isinstance(ws.root, Path)

--- a/tests/test_session_adapter.py
+++ b/tests/test_session_adapter.py
@@ -1,0 +1,287 @@
+"""Tests for SessionAdapter — session-scoped queue streaming."""
+import asyncio
+import json
+from typing import Any, AsyncIterator
+
+import pytest
+
+from langgraph_stream_parser.adapters.session import SessionAdapter, Session
+
+from .fixtures.mocks import (
+    SIMPLE_AI_MESSAGE,
+    AI_MESSAGE_WITH_TOOL_CALLS,
+    TOOL_MESSAGE_SUCCESS,
+    INTERRUPT_WITH_ACTIONS,
+)
+
+
+# ── Mock graphs ──────────────────────────────────────────────────────
+
+
+class MockGraph:
+    """Async graph yielding canned chunks per call; records calls."""
+
+    def __init__(self, chunks_per_call: list[list[Any]]):
+        self._chunks_per_call = chunks_per_call
+        self._call_idx = 0
+        self.calls: list[dict[str, Any]] = []
+
+    def astream(self, input_data, config=None, stream_mode="updates") -> AsyncIterator[Any]:
+        self.calls.append({"input": input_data, "config": config, "stream_mode": stream_mode})
+        chunks = self._chunks_per_call[self._call_idx]
+        self._call_idx += 1
+
+        async def gen():
+            for chunk in chunks:
+                yield chunk
+
+        return gen()
+
+
+class SlowGraph:
+    """Async graph that sleeps before yielding, to test cancellation."""
+
+    def astream(self, input_data, config=None, stream_mode="updates"):
+        async def gen():
+            await asyncio.sleep(5)
+            yield SIMPLE_AI_MESSAGE
+
+        return gen()
+
+
+class BoomGraph:
+    """Async graph whose stream raises."""
+
+    def astream(self, input_data, config=None, stream_mode="updates"):
+        async def gen():
+            raise RuntimeError("kaboom")
+            yield  # pragma: no cover
+
+        return gen()
+
+
+def _drain(queue: asyncio.Queue) -> list[dict]:
+    out = []
+    while not queue.empty():
+        out.append(queue.get_nowait())
+    return out
+
+
+# ── Producing turns ──────────────────────────────────────────────────
+
+
+class TestSubmitMessage:
+    async def test_streams_content_and_complete(self):
+        graph = MockGraph([[SIMPLE_AI_MESSAGE]])
+        adapter = SessionAdapter(graph=graph, stream_mode="updates")
+
+        session = adapter.submit_message("s1", "Hello")
+        await session.current_task
+        events = _drain(session.event_queue)
+
+        types = [e["type"] for e in events]
+        assert "content" in types
+        assert types[-1] == "complete"
+        assert graph.calls[0]["config"] == {"configurable": {"thread_id": "s1"}}
+
+    async def test_tool_lifecycle(self):
+        graph = MockGraph([[AI_MESSAGE_WITH_TOOL_CALLS, TOOL_MESSAGE_SUCCESS]])
+        adapter = SessionAdapter(graph=graph, stream_mode="updates")
+
+        session = adapter.submit_message("s-tools", "search")
+        await session.current_task
+        types = [e["type"] for e in _drain(session.event_queue)]
+
+        assert "tool_start" in types
+        assert "tool_end" in types
+        assert "complete" in types
+
+    async def test_context_parts_prepended(self):
+        graph = MockGraph([[SIMPLE_AI_MESSAGE]])
+        adapter = SessionAdapter(graph=graph, stream_mode="updates")
+
+        session = adapter.submit_message(
+            "s-ctx", "What time is it?", context_parts=["[Current time: noon]"]
+        )
+        await session.current_task
+
+        sent = graph.calls[0]["input"]["messages"][0]["content"]
+        assert sent.startswith("[Current time: noon]")
+        assert "What time is it?" in sent
+
+    async def test_default_dual_mode_end_to_end(self):
+        # Exercises the real default stream_mode=("updates","messages"):
+        # content arrives from the messages channel, tool lifecycle from updates.
+        from .fixtures.mocks import (
+            DUAL_MESSAGES_TOKEN_1,
+            DUAL_UPDATES_TOOL_CALL,
+            DUAL_UPDATES_TOOL_RESULT,
+        )
+
+        graph = MockGraph([[
+            DUAL_MESSAGES_TOKEN_1,
+            DUAL_UPDATES_TOOL_CALL,
+            DUAL_UPDATES_TOOL_RESULT,
+        ]])
+        adapter = SessionAdapter(graph=graph)  # default dual mode
+
+        session = adapter.submit_message("s-dual", "hi")
+        await session.current_task
+        types = [e["type"] for e in _drain(session.event_queue)]
+
+        assert "content" in types
+        assert "tool_start" in types
+        assert "tool_end" in types
+        assert types[-1] == "complete"
+
+    async def test_new_message_cancels_previous(self):
+        graph = MockGraph([[SIMPLE_AI_MESSAGE], [SIMPLE_AI_MESSAGE]])
+        adapter = SessionAdapter(graph=SlowGraph())
+        # First turn is slow; submitting again should cancel it.
+        session = adapter.submit_message("s-x", "first")
+        first_task = session.current_task
+        await asyncio.sleep(0.01)
+
+        adapter._graph = graph  # swap to fast graph for the second turn
+        adapter.submit_message("s-x", "second")
+        await asyncio.gather(first_task, return_exceptions=True)
+        assert first_task.cancelled()
+
+
+class TestResume:
+    async def test_interrupt_then_decision(self):
+        graph = MockGraph([
+            [AI_MESSAGE_WITH_TOOL_CALLS, INTERRUPT_WITH_ACTIONS],
+            [TOOL_MESSAGE_SUCCESS],
+        ])
+        adapter = SessionAdapter(graph=graph, stream_mode="updates")
+
+        session = adapter.submit_message("s-int", "run it")
+        await session.current_task
+        turn1 = _drain(session.event_queue)
+        assert any(e["type"] == "interrupt" for e in turn1)
+
+        session = adapter.submit_decisions("s-int", [{"type": "approve"}])
+        await session.current_task
+        turn2 = _drain(session.event_queue)
+        assert any(e["type"] == "tool_end" for e in turn2)
+
+        from langgraph.types import Command
+        assert isinstance(graph.calls[1]["input"], Command)
+
+
+class TestCancel:
+    async def test_cancel_pushes_cancelled_event(self):
+        adapter = SessionAdapter(graph=SlowGraph())
+        session = adapter.submit_message("s-cancel", "hi")
+        await asyncio.sleep(0.01)
+
+        assert adapter.cancel("s-cancel") is True
+        await asyncio.gather(session.current_task, return_exceptions=True)
+
+        events = _drain(session.event_queue)
+        assert {"type": "cancelled"} in events
+
+    async def test_cancel_unknown_session(self):
+        adapter = SessionAdapter(graph=SlowGraph())
+        assert adapter.cancel("nope") is False
+
+
+class TestErrorPath:
+    async def test_stream_error_pushed(self):
+        adapter = SessionAdapter(graph=BoomGraph())
+        session = adapter.submit_message("s-err", "go")
+        await session.current_task
+
+        events = _drain(session.event_queue)
+        err = [e for e in events if e["type"] == "error"]
+        assert err
+        assert "kaboom" in err[0]["error"]
+
+
+class TestSideChannel:
+    async def test_push_event_interleaves(self):
+        graph = MockGraph([[SIMPLE_AI_MESSAGE]])
+        adapter = SessionAdapter(graph=graph)
+        adapter.get_or_create("s-side")
+
+        adapter.push_event("s-side", {"type": "file_changed", "path": "a.txt"})
+        session = adapter.submit_message("s-side", "hi")
+        await session.current_task
+
+        events = _drain(session.event_queue)
+        assert events[0] == {"type": "file_changed", "path": "a.txt"}
+        assert any(e["type"] == "complete" for e in events)
+
+
+# ── Session management ───────────────────────────────────────────────
+
+
+class TestSessionManagement:
+    def test_get_or_create_reuses_known_id(self):
+        adapter = SessionAdapter(graph=MockGraph([]))
+        a = adapter.get_or_create("fixed")
+        b = adapter.get_or_create("fixed")
+        assert a is b
+        assert a.id == "fixed"
+
+    def test_get_or_create_generates_id(self):
+        adapter = SessionAdapter(graph=MockGraph([]))
+        s = adapter.get_or_create()
+        assert s.id
+        assert adapter.get(s.id) is s
+
+    def test_delete_session(self):
+        adapter = SessionAdapter(graph=MockGraph([]))
+        adapter.get_or_create("gone")
+        assert adapter.delete_session("gone") is True
+        assert adapter.get("gone") is None
+        assert adapter.delete_session("gone") is False
+
+    def test_list_and_active_count(self):
+        adapter = SessionAdapter(graph=MockGraph([]))
+        s = adapter.get_or_create("one")
+        s.sse_connected = True
+        adapter.get_or_create("two")
+        listed = {row["session_id"] for row in adapter.list_sessions()}
+        assert listed == {"one", "two"}
+        assert adapter.active_count == 1
+
+
+# ── SSE consumer ─────────────────────────────────────────────────────
+
+
+class TestSSE:
+    async def test_sse_emits_init_then_events(self):
+        adapter = SessionAdapter(graph=MockGraph([]))
+        session = adapter.get_or_create("s-sse")
+        session.push({"type": "content", "content": "hi"})
+        session.push({"type": "complete"})
+
+        gen = adapter.sse("s-sse", keepalive=10)
+        frames = [await asyncio.wait_for(gen.__anext__(), timeout=1) for _ in range(3)]
+        await gen.aclose()
+
+        assert all(f.startswith("data: ") and f.endswith("\n\n") for f in frames)
+        payloads = [json.loads(f[len("data: "):].rstrip()) for f in frames]
+        assert payloads[0]["type"] == "session_init"
+        assert payloads[0]["session_id"] == "s-sse"
+        assert payloads[1] == {"type": "content", "content": "hi"}
+        assert payloads[2] == {"type": "complete"}
+
+    async def test_sse_keepalive_on_idle(self):
+        adapter = SessionAdapter(graph=MockGraph([]))
+        adapter.get_or_create("s-idle")
+
+        gen = adapter.sse("s-idle", keepalive=0.02, send_init=False)
+        frame = await asyncio.wait_for(gen.__anext__(), timeout=1)
+        await gen.aclose()
+        assert frame == ": keepalive\n\n"
+
+    async def test_sse_marks_connected(self):
+        adapter = SessionAdapter(graph=MockGraph([]))
+        gen = adapter.sse("s-conn", keepalive=0.02, send_init=True)
+        await asyncio.wait_for(gen.__anext__(), timeout=1)  # init frame
+        assert adapter.get("s-conn").sse_connected is True
+        await gen.aclose()
+        assert adapter.get("s-conn").sse_connected is False

--- a/tests/test_wire_contract.py
+++ b/tests/test_wire_contract.py
@@ -1,0 +1,140 @@
+"""Wire-contract golden tests.
+
+``event.to_dict()`` is the single inter-process protocol shared by every host
+(FastAPI WebSocket/SSE, Jupyter handler, CLI, the VS Code stdio sidecar) and
+the frontends that render those dicts. These snapshots pin the exact shapes so
+a change to the schema can't silently drift away from the consumers. If you
+intend to change a shape, update this file and every consumer in lockstep.
+"""
+from langgraph_stream_parser.events import (
+    ContentEvent,
+    ReasoningEvent,
+    ToolCallStartEvent,
+    ToolCallEndEvent,
+    ToolExtractedEvent,
+    DisplayEvent,
+    InterruptEvent,
+    UsageEvent,
+    CompleteEvent,
+    ErrorEvent,
+    event_to_dict,
+)
+
+
+class TestEventShapes:
+    def test_content(self):
+        assert ContentEvent(content="hi").to_dict() == {
+            "type": "content",
+            "content": "hi",
+            "role": "assistant",
+            "node": None,
+        }
+
+    def test_content_with_subagent(self):
+        d = ContentEvent(
+            content="x", agent_name="researcher", is_subagent=True,
+            namespace=("researcher:abc",),
+        ).to_dict()
+        assert d["type"] == "content"
+        assert d["agent_name"] == "researcher"
+        assert d["is_subagent"] is True
+        assert d["namespace"] == ["researcher:abc"]
+
+    def test_reasoning(self):
+        assert ReasoningEvent(content="think").to_dict() == {
+            "type": "reasoning",
+            "content": "think",
+            "source": "content_block",
+            "node": None,
+        }
+
+    def test_tool_start(self):
+        assert ToolCallStartEvent(id="c1", name="search", args={"q": "x"}).to_dict() == {
+            "type": "tool_start",
+            "id": "c1",
+            "name": "search",
+            "args": {"q": "x"},
+            "node": None,
+        }
+
+    def test_tool_end(self):
+        assert ToolCallEndEvent(
+            id="c1", name="search", result="ok", status="success",
+        ).to_dict() == {
+            "type": "tool_end",
+            "id": "c1",
+            "name": "search",
+            "result": "ok",
+            "status": "success",
+            "error_message": None,
+            "duration_ms": None,
+        }
+
+    def test_extraction(self):
+        assert ToolExtractedEvent(
+            tool_name="write_todos", extracted_type="todos", data=[{"task": "a"}],
+        ).to_dict() == {
+            "type": "extraction",
+            "tool_name": "write_todos",
+            "extracted_type": "todos",
+            "data": [{"task": "a"}],
+        }
+
+    def test_display(self):
+        d = DisplayEvent(display_type="dataframe", data="<table/>", title="T").to_dict()
+        assert d["type"] == "display"
+        assert d["display_type"] == "dataframe"
+        assert d["status"] == "success"
+        assert d["title"] == "T"
+
+    def test_interrupt(self):
+        d = InterruptEvent(
+            action_requests=[{"tool": "bash", "args": {"command": "ls"}}],
+            review_configs=[{"allowed_decisions": ["approve", "reject"]}],
+        ).to_dict()
+        assert d["type"] == "interrupt"
+        assert d["action_requests"][0]["tool"] == "bash"
+        assert set(d["allowed_decisions"]) == {"approve", "reject"}
+
+    def test_usage(self):
+        assert UsageEvent(input_tokens=10, output_tokens=5, total_tokens=15).to_dict() == {
+            "type": "usage",
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+            "node": None,
+        }
+
+    def test_complete(self):
+        assert CompleteEvent().to_dict() == {"type": "complete"}
+
+    def test_error(self):
+        assert ErrorEvent(error="boom").to_dict() == {"type": "error", "error": "boom"}
+
+
+class TestEventToDictMaxResultLen:
+    def test_default_truncates_long_tool_result(self):
+        long = "x" * 1000
+        d = event_to_dict(ToolCallEndEvent(id="c", name="t", result=long, status="success"))
+        assert d["result"].endswith("...")
+        assert len(d["result"]) == 503  # 500 + "..."
+
+    def test_custom_max_result_len(self):
+        long = "x" * 100_000
+        d = event_to_dict(
+            ToolCallEndEvent(id="c", name="t", result=long, status="success"),
+            max_result_len=50_000,
+        )
+        assert len(d["result"]) == 50_003
+
+    def test_max_result_len_ignored_for_other_events(self):
+        # Passing max_result_len for a non-tool-end event must not error.
+        d = event_to_dict(ContentEvent(content="hi"), max_result_len=10)
+        assert d == {"type": "content", "content": "hi", "role": "assistant", "node": None}
+
+    def test_unknown_event_falls_back(self):
+        class Weird:
+            pass
+
+        d = event_to_dict(Weird())
+        assert d["type"] == "unknown"


### PR DESCRIPTION
Extracts the agent-hosting plumbing the deep-agent surfaces all duplicated into a shared runtime layer.

## What's new
- **`host/`** — `load_agent_spec`, `HostConfig`, `Workspace`
- **`adapters/session.py`** — `SessionAdapter`: session-scoped queue, cancel, side-channel `push_event`, persistent SSE (for web hosts)
- **`demo/`** — `create_default_agent` (filesystem-backed, behind a `[demo]` extra)
- **`event_to_dict(max_result_len=...)`** so hosts can drop their serializer shims

## Fix
- `skip_tools` now hides only a tool's lifecycle events, not its extractor, so `compat.stream_graph_updates` still surfaces `todo_list`/`reflection` content (found by an end-to-end example).

## Tests
54 new (host, session adapter, demo, wire-contract golden file) + 2 compat regression tests; **494 total passing**.

Also adds an SVG header banner to the README.