### PR TITLE
Config: layered HostConfig resolution (TOML + env + overrides) + introspection

### DIFF
--- a/src/langgraph_stream_parser/host/__init__.py
+++ b/src/langgraph_stream_parser/host/__init__.py
@@ -4,12 +4,13 @@ Agent-spec loading, the shared ``DEEPAGENT_*`` config schema, and a workspace
 wrapper — the plumbing every host (``cowork-dash``, ``deepagent-lab``,
 ``deepagent-code``, ``deepagent-vscode``) needs but used to reimplement.
 """
-from .config import HostConfig
+from .config import HostConfig, load_toml_config
 from .loader import load_agent_spec
 from .workspace import Workspace
 
 __all__ = [
     "load_agent_spec",
     "HostConfig",
+    "load_toml_config",
     "Workspace",
 ]

--- a/src/langgraph_stream_parser/host/__main__.py
+++ b/src/langgraph_stream_parser/host/__main__.py
@@ -1,0 +1,17 @@
+"""``python -m langgraph_stream_parser.host`` — print the resolved shared config.
+
+Shows each ``DEEPAGENT_*`` value, where it resolved from (default / TOML / env /
+override), and the env var + ``deepagents.toml`` key that set it — so you never
+have to remember the variable names. Hosts can ship their own subclass printer
+for host-specific keys; this covers the shared core.
+"""
+from .config import HostConfig
+
+
+def main() -> int:
+    print(HostConfig.resolve().describe())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/langgraph_stream_parser/host/config.py
+++ b/src/langgraph_stream_parser/host/config.py
@@ -1,42 +1,130 @@
-"""Shared ``DEEPAGENT_*`` environment-variable schema for hosts.
+"""Shared ``DEEPAGENT_*`` configuration for hosts.
 
-``HostConfig`` holds only the keys every host has in common: the agent spec,
-the workspace root, and the bind/title basics. Host-specific keys (theme,
-auth, canvas/files toggles, model name, Jupyter token, virtual mode, ...)
-belong in each host's own subclass — drift below the shared core is fine.
+``HostConfig`` holds the keys every host has in common (agent spec, workspace
+root, bind/title basics) and resolves them from one layered chain:
 
-Resolution order is the host's responsibility; the typical chain is
-``Python args > CLI args > env vars > defaults``. Use ``from_env`` to seed
-from the environment and ``merge`` to layer overrides on top.
+    defaults  <  deepagents.toml  <  DEEPAGENT_* env vars  <  explicit overrides
+
+Host-specific keys (theme, auth, model, Jupyter token, ...) belong in each
+host's own subclass — drift *below* the shared core is fine — but every host
+gets the same resolution order, the same TOML files, and the same env-var
+names, so there's one place to look.
+
+Discoverability: ``HostConfig.resolve().describe()`` (or
+``python -m langgraph_stream_parser.host``) prints each value, where it came
+from, and the env var / TOML key that sets it — so you never have to remember
+whether it's ``DEEPAGENT_SPEC`` or ``DEEPAGENT_AGENT_SPEC`` (it's the latter).
 """
 import os
-from dataclasses import dataclass, fields, replace
+from dataclasses import MISSING, dataclass, fields, replace
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, ClassVar
+
+try:  # tomllib is stdlib on 3.11+; fall back to tomli; else the TOML layer is skipped.
+    import tomllib as _tomllib
+except ModuleNotFoundError:  # pragma: no cover - 3.10 path
+    try:
+        import tomli as _tomllib  # type: ignore
+    except ModuleNotFoundError:
+        _tomllib = None  # type: ignore
+
+GLOBAL_TOML = Path.home() / ".deepagents" / "config.toml"
+PROJECT_TOML = "deepagents.toml"
 
 
 def _env_bool(value: str | None, default: bool = False) -> bool:
     """Parse an env-var string into a bool."""
     if value is None or value == "":
         return default
-    return value.strip().lower() in ("1", "true", "yes", "on")
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+# ── TOML layer ───────────────────────────────────────────────────────
+
+
+def _global_toml_path() -> Path:
+    override = os.getenv("DEEPAGENTS_CONFIG_HOME")
+    return (Path(override).expanduser() / "config.toml") if override else GLOBAL_TOML
+
+
+def _find_project_toml(start: Path | None = None) -> Path | None:
+    """Walk up from ``start`` (or cwd) looking for ``deepagents.toml``."""
+    here = (start or Path.cwd()).resolve()
+    for directory in (here, *here.parents):
+        candidate = directory / PROJECT_TOML
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _deep_merge(base: dict, overlay: dict) -> dict:
+    result = dict(base)
+    for key, value in overlay.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _read_toml(path: Path) -> dict:
+    if _tomllib is None:  # pragma: no cover
+        return {}
+    with path.open("rb") as f:
+        return _tomllib.load(f)
+
+
+def load_toml_config(start: Path | None = None) -> tuple[dict, list[Path]]:
+    """Load + deep-merge the global and project ``deepagents.toml`` files.
+
+    Global is ``~/.deepagents/config.toml`` (override the dir with
+    ``DEEPAGENTS_CONFIG_HOME``); project is the nearest ``deepagents.toml`` at
+    or above ``start``/cwd. Project wins on conflicts. Returns
+    ``(merged_config, sources_used)``; ``({}, [])`` if no TOML reader is
+    available (Python 3.10 without ``tomli``).
+    """
+    sources: list[Path] = []
+    merged: dict = {}
+    if _tomllib is None:  # pragma: no cover
+        return merged, sources
+    gpath = _global_toml_path()
+    if gpath.is_file():
+        merged = _deep_merge(merged, _read_toml(gpath))
+        sources.append(gpath)
+    ppath = _find_project_toml(start)
+    if ppath is not None:
+        merged = _deep_merge(merged, _read_toml(ppath))
+        sources.append(ppath)
+    return merged, sources
+
+
+def _get_dotted(data: dict, dotted_key: str) -> Any:
+    node: Any = data
+    for part in dotted_key.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return None
+        node = node[part]
+    return node
+
+
+# ── Config dataclass ─────────────────────────────────────────────────
 
 
 @dataclass
 class HostConfig:
     """Shared configuration for deep-agent hosts.
 
-    Subclass to add host-specific fields, and extend ``from_env`` to read
-    their env vars:
+    Subclass to add host-specific fields and extend the ``_ENV`` / ``_TOML``
+    maps so they resolve through the same chain:
 
         @dataclass
         class WebConfig(HostConfig):
             theme: str = "auto"
+            _ENV = {"theme": ("DEEPAGENT_THEME", str)}
+            _TOML = {"theme": "ui.theme"}
 
-            @classmethod
-            def from_env(cls):
-                base = super().from_env()
-                return base.merge(theme=os.getenv("DEEPAGENT_THEME", "auto"))
+    ``resolve()`` merges the maps across the MRO, so the subclass inherits all
+    of ``HostConfig``'s keys and adds its own.
     """
 
     agent_spec: str | None = None     # DEEPAGENT_AGENT_SPEC ("path.py:var")
@@ -46,33 +134,158 @@ class HostConfig:
     debug: bool = False               # DEEPAGENT_DEBUG
     title: str = "Deep Agent"         # DEEPAGENT_TITLE
 
+    # field -> (DEEPAGENT_* env var, caster). DEEPAGENT_AGENT_SPEC is canonical.
+    _ENV: ClassVar[dict[str, tuple[str, Callable[[str], Any]]]] = {
+        "agent_spec": ("DEEPAGENT_AGENT_SPEC", str),
+        "workspace_root": ("DEEPAGENT_WORKSPACE_ROOT", Path),
+        "host": ("DEEPAGENT_HOST", str),
+        "port": ("DEEPAGENT_PORT", int),
+        "debug": ("DEEPAGENT_DEBUG", _env_bool),
+        "title": ("DEEPAGENT_TITLE", str),
+    }
+    # field -> dotted key in deepagents.toml
+    _TOML: ClassVar[dict[str, str]] = {
+        "agent_spec": "agent.spec",
+        "workspace_root": "workspace.root",
+        "host": "server.host",
+        "port": "server.port",
+        "debug": "debug",
+        "title": "ui.title",
+    }
+
+    # ---- map collection across the subclass MRO ----
+
+    @classmethod
+    def _env_map(cls) -> dict[str, tuple[str, Callable[[str], Any]]]:
+        merged: dict[str, tuple[str, Callable[[str], Any]]] = {}
+        for klass in reversed(cls.__mro__):
+            merged.update(getattr(klass, "_ENV", {}))
+        return merged
+
+    @classmethod
+    def _toml_map(cls) -> dict[str, str]:
+        merged: dict[str, str] = {}
+        for klass in reversed(cls.__mro__):
+            merged.update(getattr(klass, "_TOML", {}))
+        return merged
+
+    # ---- resolution ----
+
     @classmethod
     def from_env(cls) -> "HostConfig":
-        """Build config from ``DEEPAGENT_*`` environment variables.
+        """Resolve from env vars + defaults only (no TOML, no overrides).
 
-        Subclasses that add fields should call ``super().from_env()`` and
-        ``merge`` their own keys on top.
+        Kept for back-compat; ``resolve()`` is the fuller entry point.
         """
-        workspace = os.getenv("DEEPAGENT_WORKSPACE_ROOT")
-        port = os.getenv("DEEPAGENT_PORT")
-        return cls(
-            agent_spec=os.getenv("DEEPAGENT_AGENT_SPEC"),
-            workspace_root=Path(workspace) if workspace else Path("."),
-            host=os.getenv("DEEPAGENT_HOST", "localhost"),
-            port=int(port) if port else 8050,
-            debug=_env_bool(os.getenv("DEEPAGENT_DEBUG")),
-            title=os.getenv("DEEPAGENT_TITLE", "Deep Agent"),
-        )
+        return cls.resolve(use_toml=False)
+
+    @classmethod
+    def resolve(
+        cls,
+        *,
+        overrides: dict[str, Any] | None = None,
+        toml_start: Path | None = None,
+        env: dict[str, str] | None = None,
+        use_toml: bool = True,
+    ) -> "HostConfig":
+        """Resolve config through ``defaults < TOML < env < overrides``.
+
+        Each field's origin is recorded for ``describe()`` / ``sources``.
+
+        Args:
+            overrides: Highest-precedence values (e.g. CLI flags / Python args).
+                ``None`` values are ignored so unset flags don't clobber.
+            toml_start: Directory to start the ``deepagents.toml`` search from.
+            env: Environment mapping (defaults to ``os.environ``).
+            use_toml: Set False to skip the TOML layer entirely.
+        """
+        overrides = {k: v for k, v in (overrides or {}).items() if v is not None}
+        env = os.environ if env is None else env
+        toml_data, toml_paths = (load_toml_config(toml_start) if use_toml else ({}, []))
+        env_map = cls._env_map()
+        toml_map = cls._toml_map()
+
+        values: dict[str, Any] = {}
+        sources: dict[str, str] = {}
+        for f in fields(cls):
+            name = f.name
+            if f.default is not MISSING:
+                val: Any = f.default
+            elif f.default_factory is not MISSING:  # type: ignore[misc]
+                val = f.default_factory()  # type: ignore[misc]
+            else:
+                val = None
+            src = "default"
+
+            tkey = toml_map.get(name)
+            if tkey is not None:
+                tv = _get_dotted(toml_data, tkey)
+                if tv is not None:
+                    val = _coerce(f, tv)
+                    src = f"toml ({toml_paths[-1].name})" if toml_paths else "toml"
+
+            if name in env_map:
+                var, caster = env_map[name]
+                ev = env.get(var)
+                if ev is not None and ev != "":
+                    val = caster(ev)
+                    src = f"env:{var}"
+
+            if name in overrides:
+                val = overrides[name]
+                src = "override"
+
+            values[name] = val
+            sources[name] = src
+
+        obj = cls(**values)
+        obj._sources = sources           # type: ignore[attr-defined]
+        obj._toml_paths = toml_paths     # type: ignore[attr-defined]
+        return obj
 
     def merge(self, **overrides: Any) -> "HostConfig":
-        """Return a copy with non-``None`` overrides applied.
-
-        ``None`` values are ignored so callers can pass through unset CLI
-        flags without clobbering env-derived values.
-        """
+        """Return a copy with non-``None`` overrides applied."""
         valid = {f.name for f in fields(self)}
-        applied = {
-            k: v for k, v in overrides.items()
-            if v is not None and k in valid
-        }
+        applied = {k: v for k, v in overrides.items() if v is not None and k in valid}
         return replace(self, **applied)
+
+    # ---- introspection ----
+
+    @property
+    def sources(self) -> dict[str, str]:
+        """Per-field origin from the last ``resolve()`` (field -> source)."""
+        return getattr(self, "_sources", {})
+
+    def describe(self) -> str:
+        """Human-readable dump: value, source, and the env var / TOML key.
+
+        This is what ``python -m langgraph_stream_parser.host`` prints.
+        """
+        env_map = type(self)._env_map()
+        toml_map = type(self)._toml_map()
+        src = self.sources
+        lines = ["Resolved config  (value  [source]):", ""]
+        for f in fields(self):
+            value = getattr(self, f.name)
+            origin = src.get(f.name, "default")
+            hints = []
+            if f.name in env_map:
+                hints.append(f"env: {env_map[f.name][0]}")
+            if f.name in toml_map:
+                hints.append(f"toml: {toml_map[f.name]}")
+            hint = f"   ({', '.join(hints)})" if hints else ""
+            lines.append(f"  {f.name:<16} = {str(value):<26} [{origin}]{hint}")
+        toml_paths = getattr(self, "_toml_paths", [])
+        lines.append("")
+        if toml_paths:
+            lines.append("  TOML read from: " + ", ".join(str(p) for p in toml_paths))
+        else:
+            lines.append("  TOML: no deepagents.toml found")
+        return "\n".join(lines)
+
+
+def _coerce(f: Any, value: Any) -> Any:
+    """Coerce a TOML value to the field's expected shape (Path fields only)."""
+    if isinstance(getattr(f, "default", None), Path) and not isinstance(value, Path):
+        return Path(value)
+    return value

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -1,0 +1,120 @@
+"""Tests for the layered HostConfig resolver (defaults < TOML < env < overrides)."""
+from dataclasses import dataclass
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from langgraph_stream_parser.host import HostConfig
+
+
+@pytest.fixture
+def isolated_global(tmp_path, monkeypatch):
+    """Point the global deepagents config at an empty dir so the host machine's
+    ~/.deepagents/config.toml can't leak into tests."""
+    gdir = tmp_path / "global"
+    gdir.mkdir()
+    monkeypatch.setenv("DEEPAGENTS_CONFIG_HOME", str(gdir))
+    return gdir
+
+
+def _toml(dir_: Path, body: str) -> Path:
+    p = dir_ / "deepagents.toml"
+    p.write_text(body)
+    return p
+
+
+class TestResolveLayers:
+    def test_defaults(self, isolated_global, tmp_path):
+        cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
+        assert cfg.port == 8050
+        assert cfg.agent_spec is None
+        assert cfg.workspace_root == Path(".")
+        assert set(cfg.sources.values()) == {"default"}
+
+    def test_env_layer(self, isolated_global, tmp_path):
+        cfg = HostConfig.resolve(
+            env={"DEEPAGENT_AGENT_SPEC": "a.py:g", "DEEPAGENT_PORT": "9000",
+                 "DEEPAGENT_DEBUG": "true"},
+            toml_start=tmp_path,
+        )
+        assert cfg.agent_spec == "a.py:g"
+        assert cfg.port == 9000
+        assert cfg.debug is True
+        assert cfg.sources["agent_spec"] == "env:DEEPAGENT_AGENT_SPEC"
+
+    def test_toml_layer(self, isolated_global, tmp_path):
+        _toml(tmp_path, '[agent]\nspec = "x.py:graph"\n[server]\nport = 7000\n')
+        cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
+        assert cfg.agent_spec == "x.py:graph"
+        assert cfg.port == 7000
+        assert cfg.sources["agent_spec"].startswith("toml")
+
+    def test_precedence_toml_env_override(self, isolated_global, tmp_path):
+        _toml(tmp_path, "[server]\nport = 1111\n")
+        # toml only
+        assert HostConfig.resolve(env={}, toml_start=tmp_path).port == 1111
+        # env beats toml
+        assert HostConfig.resolve(
+            env={"DEEPAGENT_PORT": "2222"}, toml_start=tmp_path
+        ).port == 2222
+        # override beats env
+        cfg = HostConfig.resolve(
+            env={"DEEPAGENT_PORT": "2222"}, overrides={"port": 3333}, toml_start=tmp_path
+        )
+        assert cfg.port == 3333
+        assert cfg.sources["port"] == "override"
+
+    def test_none_override_ignored(self, isolated_global, tmp_path):
+        cfg = HostConfig.resolve(
+            env={"DEEPAGENT_PORT": "2222"}, overrides={"port": None}, toml_start=tmp_path
+        )
+        assert cfg.port == 2222
+
+    def test_workspace_root_coerced_to_path(self, isolated_global, tmp_path):
+        _toml(tmp_path, '[workspace]\nroot = "/tmp/ws"\n')
+        cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
+        assert cfg.workspace_root == Path("/tmp/ws")
+
+
+class TestIntrospection:
+    def test_describe_lists_var_names_and_keys(self, isolated_global, tmp_path):
+        text = HostConfig.resolve(env={}, toml_start=tmp_path).describe()
+        assert "DEEPAGENT_AGENT_SPEC" in text   # the var you can never remember
+        assert "agent.spec" in text             # its TOML key
+        assert "[default]" in text
+
+    def test_describe_marks_source(self, isolated_global, tmp_path):
+        text = HostConfig.resolve(
+            env={"DEEPAGENT_PORT": "9000"}, toml_start=tmp_path
+        ).describe()
+        assert "env:DEEPAGENT_PORT" in text
+
+
+class TestSubclass:
+    def test_subclass_adds_keys_to_same_chain(self, isolated_global, tmp_path):
+        @dataclass
+        class WebConfig(HostConfig):
+            theme: str = "auto"
+            _ENV: ClassVar[dict] = {"theme": ("DEEPAGENT_THEME", str)}
+            _TOML: ClassVar[dict] = {"theme": "ui.theme"}
+
+        _toml(tmp_path, '[ui]\ntheme = "solarized"\n')
+        # toml provides theme...
+        cfg = WebConfig.resolve(env={}, toml_start=tmp_path)
+        assert cfg.theme == "solarized"
+        # ...env overrides it, and base keys still resolve
+        cfg = WebConfig.resolve(env={"DEEPAGENT_THEME": "dark"}, toml_start=tmp_path)
+        assert cfg.theme == "dark"
+        assert cfg.port == 8050
+        assert cfg.sources["theme"] == "env:DEEPAGENT_THEME"
+        assert "DEEPAGENT_THEME" in cfg.describe()
+
+
+class TestFromEnvBackCompat:
+    def test_from_env_skips_toml(self, isolated_global, tmp_path, monkeypatch):
+        _toml(tmp_path, "[server]\nport = 1234\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DEEPAGENT_PORT", raising=False)
+        # from_env ignores TOML even though deepagents.toml is in cwd
+        assert HostConfig.from_env().port == 8050


### PR DESCRIPTION
Streamlines env/config management so there's **one** resolution chain and **one** place to look. Addresses the "I can never remember how to set DEEPAGENT_SPEC" problem.

> Stacked on #10 (`feat/runtime-host-layer`) — merge that first; GitHub will retarget this to `main`.

## What's new
- **One chain:** `defaults < deepagents.toml < DEEPAGENT_* env < overrides`, with per-field **source tracking**.
- **TOML layer** (`load_toml_config`): global `~/.deepagents/config.toml` (+ `DEEPAGENTS_CONFIG_HOME`) and the nearest project `deepagents.toml`, deep-merged. This promotes deepagent-code's TOML mechanism so every host can share one file.
- **`HostConfig.resolve(overrides=, toml_start=, env=)`** with `_ENV`/`_TOML` maps that merge across the subclass MRO — hosts add their keys to the same chain.
- **Introspection:** `HostConfig.describe()` and `python -m langgraph_stream_parser.host` print each value, where it resolved from, and the env var + TOML key that sets it:

```
agent_spec  = ./my_agent.py:graph  [env:DEEPAGENT_AGENT_SPEC]   (env: DEEPAGENT_AGENT_SPEC, toml: agent.spec)
port        = 9000                 [env:DEEPAGENT_PORT]         (env: DEEPAGENT_PORT, toml: server.port)
...
```

`DEEPAGENT_AGENT_SPEC` is the canonical spec var. `from_env()` retained for back-compat.

## Tests
10 new; **504 total**.

## Follow-up (separate PRs, after the host migrations merge)
- cowork-dash / deepagent-lab / deepagent-code subclass `HostConfig` and add their keys to `_ENV`/`_TOML`.
- deepagent-code drops its own TOML loader and reconciles `DEEPAGENT_SPEC` → `DEEPAGENT_AGENT_SPEC` (keeping the old name as a deprecated alias).
- Each host ships a `--show-config` that prints its full (subclassed) config.