### PR TITLE
Add four built-in extractors for agentskills.io / Hermes pattern

### DIFF
--- a/src/langgraph_stream_parser/extractors/__init__.py
+++ b/src/langgraph_stream_parser/extractors/__init__.py
@@ -5,11 +5,23 @@ This module provides the ToolExtractor protocol and built-in extractors
 for common tools like think_tool and write_todos.
 """
 from .base import ToolExtractor
-from .builtins import ThinkToolExtractor, TodoExtractor, DisplayInlineExtractor
+from .builtins import (
+    CompressionExtractor,
+    DisplayInlineExtractor,
+    MemoryExtractor,
+    SkillManageExtractor,
+    SkillViewExtractor,
+    ThinkToolExtractor,
+    TodoExtractor,
+)
 
 __all__ = [
     "ToolExtractor",
     "ThinkToolExtractor",
     "TodoExtractor",
     "DisplayInlineExtractor",
+    "SkillManageExtractor",
+    "SkillViewExtractor",
+    "CompressionExtractor",
+    "MemoryExtractor",
 ]

--- a/src/langgraph_stream_parser/extractors/builtins.py
+++ b/src/langgraph_stream_parser/extractors/builtins.py
@@ -164,3 +164,177 @@ class DisplayInlineExtractor:
             return content
 
         return None
+
+
+def _parse_json_content(content: Any) -> dict[str, Any] | None:
+    """Best-effort JSON parse — accepts str or dict, returns None otherwise."""
+    if isinstance(content, dict):
+        return content
+    if isinstance(content, str):
+        try:
+            parsed = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+class SkillManageExtractor:
+    """Extractor for skill_manage tool calls (agentskills.io standard).
+
+    Agents that follow the agentskills.io specification expose a tool
+    (commonly named ``skill_manage``) for creating, patching, deleting,
+    or pinning SKILL.md files in a procedural-memory library. This
+    extractor surfaces those mutations as inline events so hosts can
+    render "skill created: pdf-merging" alongside the raw tool result.
+
+    Handles formats:
+        - JSON string with ``action`` + ``name`` keys
+        - Dict with the same keys
+        - Plain text containing one of the known action verbs
+
+    Action → extracted_subtype mapping:
+        create / write_file → skill_created
+        patch               → skill_updated
+        pin / unpin         → skill_updated
+        delete              → skill_deleted
+    """
+
+    tool_name = "skill_manage"
+    extracted_type = "skill_event"
+
+    _ACTION_TO_TYPE = {
+        "create": "skill_created",
+        "patch": "skill_updated",
+        "write_file": "skill_updated",
+        "delete": "skill_deleted",
+        "pin": "skill_updated",
+        "unpin": "skill_updated",
+    }
+
+    def extract(self, content: Any) -> dict[str, Any] | None:
+        """Extract skill action + name from a skill_manage result.
+
+        Args:
+            content: JSON string, dict, or plain text from the tool.
+
+        Returns:
+            Dict with ``action``, ``name`` (when present), and
+            ``extracted_subtype``. ``None`` when the content doesn't
+            look like a skill_manage result.
+        """
+        parsed = _parse_json_content(content)
+        if parsed is None:
+            if not isinstance(content, str) or not content:
+                return None
+            text = content.lower()
+            for action, etype in self._ACTION_TO_TYPE.items():
+                if action in text:
+                    return {"action": action, "extracted_subtype": etype}
+            return None
+
+        action = parsed.get("action")
+        name = parsed.get("name")
+        if action is None:
+            return None
+        etype = self._ACTION_TO_TYPE.get(action, "skill_event")
+        out: dict[str, Any] = {"action": action, "extracted_subtype": etype}
+        if name is not None:
+            out["name"] = name
+        return out
+
+
+class SkillViewExtractor:
+    """Extractor for skill_view tool calls (agentskills.io standard).
+
+    Emits a ``skill_loaded`` event when the agent pulls a SKILL.md body
+    into its context via the ``skill_view(name)`` tool. Hosts can render
+    this differently from creation / update — it's a read, not a
+    mutation, and represents the agent activating procedural memory.
+    """
+
+    tool_name = "skill_view"
+    extracted_type = "skill_loaded"
+
+    def extract(self, content: Any) -> dict[str, Any] | None:
+        """Note that a skill body was loaded; carry the size as data."""
+        if not content:
+            return None
+        return {"loaded": True, "body_chars": len(str(content))}
+
+
+class CompressionExtractor:
+    """Extractor for context-compression events.
+
+    When an agent's compression middleware (e.g.
+    ``langchain.agents.middleware.SummarizationMiddleware`` or a custom
+    implementation) replaces the middle of a long conversation with a
+    summary, it can emit a synthetic ``__compression__`` tool message
+    so the host UI can show a banner like "context compressed: 47k →
+    9k tokens (5x)".
+
+    Expected payload (all fields optional, extractor surfaces what it
+    finds):
+        - before_tokens: int
+        - after_tokens: int
+        - ratio: float
+        - section_count: int
+        - skipped: bool
+        - reason: str
+    """
+
+    tool_name = "__compression__"
+    extracted_type = "compression_summary"
+
+    def extract(self, content: Any) -> dict[str, Any] | None:
+        parsed = _parse_json_content(content)
+        if parsed is None:
+            return None
+        keys = {"before_tokens", "after_tokens", "ratio", "section_count", "skipped", "reason"}
+        out = {k: parsed[k] for k in keys if k in parsed}
+        return out or None
+
+
+class MemoryExtractor:
+    """Extractor for memory tool actions.
+
+    Agents that expose a frozen-snapshot memory tool (commonly named
+    ``memory``) for managing persistent MEMORY.md / USER.md files
+    surface their action through this extractor. Distinguishes ``target``
+    so the two streams render separately.
+
+    Action → extracted_subtype mapping:
+        add     → memory_added
+        replace → memory_replaced
+        remove  → memory_removed
+        read    → memory_read
+    """
+
+    tool_name = "memory"
+    extracted_type = "memory_updated"
+
+    _ACTION_TO_TYPE = {
+        "add": "memory_added",
+        "replace": "memory_replaced",
+        "remove": "memory_removed",
+        "read": "memory_read",
+    }
+
+    def extract(self, content: Any) -> dict[str, Any] | None:
+        parsed = _parse_json_content(content)
+        if parsed is None:
+            return None
+        action = parsed.get("action")
+        target = parsed.get("target")
+        if action is None or target is None:
+            return None
+        etype = self._ACTION_TO_TYPE.get(action, "memory_updated")
+        out: dict[str, Any] = {
+            "action": action,
+            "target": target,
+            "extracted_subtype": etype,
+        }
+        if "index" in parsed:
+            out["index"] = parsed["index"]
+        return out

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -3,9 +3,13 @@ import pytest
 import json
 
 from langgraph_stream_parser.extractors.builtins import (
+    CompressionExtractor,
+    DisplayInlineExtractor,
+    MemoryExtractor,
+    SkillManageExtractor,
+    SkillViewExtractor,
     ThinkToolExtractor,
     TodoExtractor,
-    DisplayInlineExtractor,
 )
 from langgraph_stream_parser.extractors.messages import (
     extract_message_content,
@@ -368,3 +372,164 @@ class TestProcessInterrupt:
         assert result["action_requests"][0]["tool"] == "bash"
         assert len(result["review_configs"]) == 1
         assert "approve" in result["review_configs"][0]["allowed_decisions"]
+
+
+# ── agentskills.io / Hermes-pattern extractors ────────────────────────
+
+
+class TestSkillManageExtractor:
+    def setup_method(self):
+        self.extractor = SkillManageExtractor()
+
+    def test_protocol_attrs(self):
+        assert self.extractor.tool_name == "skill_manage"
+        assert self.extractor.extracted_type == "skill_event"
+
+    def test_extract_create_from_json(self):
+        result = self.extractor.extract(json.dumps({"action": "create", "name": "pdf-merging"}))
+        assert result == {
+            "action": "create",
+            "name": "pdf-merging",
+            "extracted_subtype": "skill_created",
+        }
+
+    def test_extract_patch_from_dict(self):
+        result = self.extractor.extract({"action": "patch", "name": "csv-cleaning"})
+        assert result == {
+            "action": "patch",
+            "name": "csv-cleaning",
+            "extracted_subtype": "skill_updated",
+        }
+
+    def test_extract_write_file_maps_to_updated(self):
+        result = self.extractor.extract({"action": "write_file", "name": "x"})
+        assert result["extracted_subtype"] == "skill_updated"
+
+    def test_extract_delete(self):
+        result = self.extractor.extract({"action": "delete", "name": "stale-skill"})
+        assert result["extracted_subtype"] == "skill_deleted"
+
+    def test_extract_pin_unpin(self):
+        for action in ("pin", "unpin"):
+            result = self.extractor.extract({"action": action, "name": "x"})
+            assert result["extracted_subtype"] == "skill_updated"
+
+    def test_extract_without_name(self):
+        # action without name is still useful — surfaces the event class
+        result = self.extractor.extract({"action": "create"})
+        assert result == {"action": "create", "extracted_subtype": "skill_created"}
+
+    def test_extract_falls_back_to_text_scan(self):
+        result = self.extractor.extract("Skill created successfully.")
+        assert result == {"action": "create", "extracted_subtype": "skill_created"}
+
+    def test_extract_returns_none_on_empty(self):
+        assert self.extractor.extract(None) is None
+        assert self.extractor.extract("") is None
+        assert self.extractor.extract(123) is None
+
+    def test_extract_returns_none_on_unrelated_text(self):
+        assert self.extractor.extract("Some unrelated response") is None
+
+    def test_extract_unknown_action_uses_generic_subtype(self):
+        result = self.extractor.extract({"action": "frobnicate", "name": "x"})
+        assert result["extracted_subtype"] == "skill_event"
+
+
+class TestSkillViewExtractor:
+    def setup_method(self):
+        self.extractor = SkillViewExtractor()
+
+    def test_protocol_attrs(self):
+        assert self.extractor.tool_name == "skill_view"
+        assert self.extractor.extracted_type == "skill_loaded"
+
+    def test_extract_body(self):
+        body = "Here is how to merge PDFs: ..."
+        result = self.extractor.extract(body)
+        assert result == {"loaded": True, "body_chars": len(body)}
+
+    def test_extract_none_on_empty(self):
+        assert self.extractor.extract(None) is None
+        assert self.extractor.extract("") is None
+        assert self.extractor.extract(0) is None
+
+
+class TestCompressionExtractor:
+    def setup_method(self):
+        self.extractor = CompressionExtractor()
+
+    def test_protocol_attrs(self):
+        assert self.extractor.tool_name == "__compression__"
+        assert self.extractor.extracted_type == "compression_summary"
+
+    def test_extract_full_payload(self):
+        payload = {
+            "before_tokens": 47000,
+            "after_tokens": 9000,
+            "ratio": 5.2,
+            "section_count": 13,
+        }
+        result = self.extractor.extract(json.dumps(payload))
+        assert result == payload
+
+    def test_extract_partial_payload(self):
+        result = self.extractor.extract({"ratio": 2.0, "skipped": False})
+        assert result == {"ratio": 2.0, "skipped": False}
+
+    def test_extract_ignores_unknown_keys(self):
+        result = self.extractor.extract({"ratio": 1.5, "irrelevant": "foo"})
+        assert result == {"ratio": 1.5}
+
+    def test_extract_none_on_empty_or_malformed(self):
+        assert self.extractor.extract(None) is None
+        assert self.extractor.extract("") is None
+        assert self.extractor.extract("not json") is None
+        assert self.extractor.extract({}) is None
+
+
+class TestMemoryExtractor:
+    def setup_method(self):
+        self.extractor = MemoryExtractor()
+
+    def test_protocol_attrs(self):
+        assert self.extractor.tool_name == "memory"
+        assert self.extractor.extracted_type == "memory_updated"
+
+    def test_extract_add_user(self):
+        result = self.extractor.extract(
+            json.dumps({"action": "add", "target": "user", "entry": "..."})
+        )
+        assert result == {
+            "action": "add",
+            "target": "user",
+            "extracted_subtype": "memory_added",
+        }
+
+    def test_extract_replace_with_index(self):
+        result = self.extractor.extract(
+            {"action": "replace", "target": "memory", "index": 3, "entry": "..."}
+        )
+        assert result == {
+            "action": "replace",
+            "target": "memory",
+            "extracted_subtype": "memory_replaced",
+            "index": 3,
+        }
+
+    def test_extract_remove(self):
+        result = self.extractor.extract({"action": "remove", "target": "memory", "index": 0})
+        assert result["extracted_subtype"] == "memory_removed"
+
+    def test_extract_read(self):
+        result = self.extractor.extract({"action": "read", "target": "memory"})
+        assert result["extracted_subtype"] == "memory_read"
+
+    def test_extract_requires_action_and_target(self):
+        assert self.extractor.extract({"action": "add"}) is None
+        assert self.extractor.extract({"target": "user"}) is None
+
+    def test_extract_none_on_empty(self):
+        assert self.extractor.extract(None) is None
+        assert self.extractor.extract("") is None
+        assert self.extractor.extract("not json") is None


### PR DESCRIPTION
## Summary

Adds four new built-in tool extractors so every host on the parser surfaces inline events for the agentskills.io standard + the frozen-snapshot memory / compression patterns that the deepagent-* host family is converging on. With these wired into `builtins`, hosts get the events automatically through `compat.stream_graph_updates` — no per-host registration step needed.

| Extractor | Tool name | extracted_type | Purpose |
|---|---|---|---|
| `SkillManageExtractor` | `skill_manage` | `skill_event` | Skill mutations (create / patch / write_file / delete / pin / unpin → `skill_created` / `skill_updated` / `skill_deleted` subtypes) |
| `SkillViewExtractor` | `skill_view` | `skill_loaded` | Procedural memory activated (`skill_view(name)`) |
| `CompressionExtractor` | `__compression__` | `compression_summary` | Context-compression banner data (before/after tokens, ratio) |
| `MemoryExtractor` | `memory` | `memory_updated` | MEMORY.md / USER.md tool actions; preserves `target` |

## Why now

[`deepagent-hermes`](https://github.com/dkedar7/deepagent-hermes) (Hermes-style closed-loop reflection / skill agent — new June 2026) lands these patterns in production. The agent currently registers these extractors via its own `extractors.py`; upstreaming them means [cowork-dash](https://github.com/dkedar7/cowork-dash) / [deepagent-lab](https://github.com/dkedar7/deepagent-lab) / [deepagent-code](https://github.com/dkedar7/deepagent-code) / [deepagent-vscode](https://github.com/dkedar7/deepagent-vscode) automatically render skill creation banners, memory updates, and compression events when running this agent — no host changes required.

The extractor protocol is unchanged. The added classes follow `ThinkToolExtractor` / `TodoExtractor` / `DisplayInlineExtractor` style exactly.

## Compatibility

- No changes to the existing `ToolExtractor` protocol or any of the existing three built-in extractors.
- Hosts that don't run agents emitting these tool names see no behavior change.
- Branch is off `main` and orthogonal to the open #10 / #11 stacked PRs.

## Test plan

- [x] 25 new tests in `tests/test_extractors.py` cover positive and negative cases for each extractor.
- [x] `pytest tests/test_extractors.py` — 72 pass (existing 47 + 25 new).
- [x] Full repo suite (excluding optional `fastapi` / `jupyter` extras) — 416 pass total.
- [ ] Smoke against `deepagent-hermes` agent inside a host (manual, after this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)