### PR TITLE
Add CI (test suite on push/PR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        include:
+          # One Windows job for cross-platform coverage (primary dev env).
+          - os: windows-latest
+            python-version: "3.12"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Test
+        run: pytest -ra --cov=langgraph_stream_parser --cov-report=term-missing


### PR DESCRIPTION
## Why
The shared runtime had **530 passing tests but no CI**. It's the substrate under cowork-dash, deepagent-lab, and deepagent-hermes — a regression here breaks all of them, with nothing to catch it before publish. This adds the gate.

## What
- Run the suite on a **Python 3.10–3.13** matrix (ubuntu) + one Windows job.
- Installs via `uv`, runs `pytest` with coverage.
- The existing `test_wire_contract.py` + `test_session_adapter` / `test_fastapi_adapter` / `test_host*` / `test_compat` / `test_dual_mode` tests serve as the **contract net** for downstream consumers.

## Note
Lint is intentionally **deferred**: the package re-exports its public API in `__init__`, which ruff flags as F401. That needs a careful pass (not a blind `--fix`), so it's out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)