### PR TITLE
GenericToolExtractor + default_extractor fallback for unknown tools

### DIFF
--- a/src/langgraph_stream_parser/__init__.py
+++ b/src/langgraph_stream_parser/__init__.py
@@ -49,7 +49,12 @@ from .events import (
     event_to_dict,
 )
 from .extractors.base import ToolExtractor
-from .extractors.builtins import ThinkToolExtractor, TodoExtractor, DisplayInlineExtractor
+from .extractors.builtins import (
+    DisplayInlineExtractor,
+    GenericToolExtractor,
+    ThinkToolExtractor,
+    TodoExtractor,
+)
 from .resume import create_resume_input, prepare_agent_input
 from .host import load_agent_spec, HostConfig, Workspace
 from .compat import (
@@ -85,6 +90,7 @@ __all__ = [
     "ThinkToolExtractor",
     "TodoExtractor",
     "DisplayInlineExtractor",
+    "GenericToolExtractor",
     # Resume utilities
     "create_resume_input",
     "prepare_agent_input",

--- a/src/langgraph_stream_parser/extractors/__init__.py
+++ b/src/langgraph_stream_parser/extractors/__init__.py
@@ -8,6 +8,7 @@ from .base import ToolExtractor
 from .builtins import (
     CompressionExtractor,
     DisplayInlineExtractor,
+    GenericToolExtractor,
     MemoryExtractor,
     SkillManageExtractor,
     SkillViewExtractor,
@@ -16,12 +17,13 @@ from .builtins import (
 )
 
 __all__ = [
-    "ToolExtractor",
-    "ThinkToolExtractor",
-    "TodoExtractor",
+    "CompressionExtractor",
     "DisplayInlineExtractor",
+    "GenericToolExtractor",
+    "MemoryExtractor",
     "SkillManageExtractor",
     "SkillViewExtractor",
-    "CompressionExtractor",
-    "MemoryExtractor",
+    "ThinkToolExtractor",
+    "TodoExtractor",
+    "ToolExtractor",
 ]

--- a/src/langgraph_stream_parser/extractors/builtins.py
+++ b/src/langgraph_stream_parser/extractors/builtins.py
@@ -338,3 +338,47 @@ class MemoryExtractor:
         if "index" in parsed:
             out["index"] = parsed["index"]
         return out
+
+
+class GenericToolExtractor:
+    """Fallback extractor for any tool without a dedicated extractor.
+
+    Per-tool extractors (``ThinkToolExtractor``, ``SkillManageExtractor``,
+    …) are the right tool for surfacing *structured* domain content. But
+    when an application wires custom tools the parser doesn't know about,
+    those tool calls only emit ``ToolCallStartEvent`` / ``ToolCallEndEvent``
+    — never ``ToolExtractedEvent`` — so hosts that switch on extracted
+    events to render rich cards have no signal to act on.
+
+    Registering this as a fallback (``StreamParser(default_extractor=
+    GenericToolExtractor())``) closes that gap: any tool name without a
+    specific extractor will emit a ``ToolExtractedEvent`` of
+    ``extracted_type="tool_call"`` whose data preserves the raw content
+    (and the optional artifact) so downstream renderers can build a
+    generic "tool callout" card without per-tool knowledge.
+
+    This is intentionally *opt-in* via the new
+    :class:`~langgraph_stream_parser.StreamParser` ``default_extractor``
+    kwarg. The historical behaviour (only emit ``ToolExtractedEvent`` for
+    tools with explicit extractors) is preserved by default so existing
+    hosts that switch on specific extracted types don't suddenly receive
+    new events.
+
+    Notes:
+        - ``tool_name`` is the sentinel ``"*"`` for documentation / hosts
+          that introspect ``parser._default_extractor``; the parser
+          never indexes ``_extractors`` by this value.
+        - Returns ``None`` when content is also ``None`` so a tool that
+          legitimately returns nothing doesn't fire a spurious empty
+          card. Empty strings and empty dicts still surface (they may
+          carry meaning to the host's renderer).
+    """
+
+    tool_name = "*"  # sentinel; not used for dispatch lookup
+    extracted_type = "tool_call"
+
+    def extract(self, content: Any) -> dict[str, Any] | None:
+        if content is None:
+            return None
+        out: dict[str, Any] = {"content": content}
+        return out

--- a/src/langgraph_stream_parser/handlers/updates.py
+++ b/src/langgraph_stream_parser/handlers/updates.py
@@ -44,6 +44,7 @@ class UpdatesHandler:
         include_state_updates: bool,
         pending_tool_calls: dict[str, ToolCallStartEvent],
         suppress_content: bool = False,
+        default_extractor: ToolExtractor | None = None,
     ):
         """Initialize the handler.
 
@@ -56,8 +57,13 @@ class UpdatesHandler:
             suppress_content: If True, skip ContentEvent generation for
                 AI and human messages. Used in dual mode where the
                 messages handler provides token-level content instead.
+            default_extractor: Fallback extractor invoked when no entry
+                in ``extractors`` matches a tool's name. Lets hosts emit
+                a generic ``ToolExtractedEvent`` for custom tools the
+                parser doesn't know about.
         """
         self._extractors = extractors
+        self._default_extractor = default_extractor
         self._skip_tools = skip_tools
         self._track_tool_lifecycle = track_tool_lifecycle
         self._include_state_updates = include_state_updates
@@ -317,6 +323,13 @@ class UpdatesHandler:
         # Prefer artifact over content (artifact carries full data from
         # tools using response_format="content_and_artifact")
         extractor = self._extractors.get(tool_name) if tool_name else None
+        if extractor is None and tool_name and self._default_extractor is not None:
+            # No per-tool extractor matched. Fall through to the host's
+            # default extractor (e.g. GenericToolExtractor) so unknown
+            # tools still produce a ToolExtractedEvent. Opt-in via the
+            # `default_extractor` kwarg on StreamParser — None preserves
+            # the historical "only named extractors fire" behaviour.
+            extractor = self._default_extractor
         if extractor:
             try:
                 extracted = extractor.extract(artifact if artifact is not None else content)

--- a/src/langgraph_stream_parser/parser.py
+++ b/src/langgraph_stream_parser/parser.py
@@ -165,6 +165,7 @@ class StreamParser:
         track_tool_lifecycle: bool = True,
         skip_tools: list[str] | None = None,
         include_state_updates: bool = False,
+        default_extractor: ToolExtractor | None = None,
     ):
         """Initialize the parser.
 
@@ -181,6 +182,17 @@ class StreamParser:
                 Useful for internal tools you don't want to expose in UI.
             include_state_updates: If True, emit StateUpdateEvent for non-message
                 state keys in updates mode.
+            default_extractor: Fallback extractor invoked for any tool name
+                that has no per-tool extractor registered. Without this,
+                custom tools only emit ``ToolCallStartEvent`` and
+                ``ToolCallEndEvent`` — never ``ToolExtractedEvent`` — so
+                hosts that switch on extracted events to render rich
+                cards have no signal to act on for unknown tools. Pass
+                :class:`~langgraph_stream_parser.GenericToolExtractor`
+                to surface every otherwise-unhandled tool as a generic
+                ``extracted_type="tool_call"`` event. Default ``None``
+                preserves the historical behaviour (only named
+                extractors fire).
 
         Raises:
             ValueError: If stream_mode is invalid.
@@ -192,6 +204,7 @@ class StreamParser:
         self._skip_tools = set(skip_tools or [])
         self._include_state_updates = include_state_updates
         self._extractors: dict[str, ToolExtractor] = {}
+        self._default_extractor = default_extractor
         self._pending_tool_calls: dict[str, ToolCallStartEvent] = {}
 
         # Register built-in extractors
@@ -401,6 +414,7 @@ class StreamParser:
         """Create an UpdatesHandler configured for this parser."""
         return UpdatesHandler(
             extractors=self._extractors,
+            default_extractor=self._default_extractor,
             skip_tools=self._skip_tools,
             track_tool_lifecycle=self._track_tool_lifecycle,
             include_state_updates=self._include_state_updates,

--- a/tests/test_generic_extractor.py
+++ b/tests/test_generic_extractor.py
@@ -1,0 +1,195 @@
+"""Tests for the opt-in ``GenericToolExtractor`` fallback path.
+
+Without a per-tool extractor a custom tool only emits
+``ToolCallStartEvent`` / ``ToolCallEndEvent`` and never
+``ToolExtractedEvent``. Hosts that render rich cards by switching on
+``ToolExtractedEvent`` have nothing to act on, so the only path for
+adding a card is to ship a per-tool extractor in the parser.
+
+The ``default_extractor`` kwarg + bundled ``GenericToolExtractor``
+closes that gap: any tool name without a specific extractor surfaces
+as a ``ToolExtractedEvent`` of ``extracted_type="tool_call"``, opt-in
+so existing hosts that switch on specific extracted types don't
+suddenly start receiving new events.
+"""
+
+from __future__ import annotations
+
+from langgraph_stream_parser import (
+    GenericToolExtractor,
+    StreamParser,
+    ToolCallEndEvent,
+    ToolExtractedEvent,
+)
+from langgraph_stream_parser.extractors.builtins import ThinkToolExtractor
+
+from .fixtures.mocks import THINK_TOOL_STRING_CONTENT, TOOL_MESSAGE_SUCCESS
+
+
+def _stream(chunks):
+    """Iterate the fixture chunks one at a time — mirrors the parser's input."""
+    yield from chunks
+
+
+class TestGenericToolExtractor:
+    def test_extracts_content(self):
+        ext = GenericToolExtractor()
+        result = ext.extract("hello world")
+        assert result == {"content": "hello world"}
+
+    def test_extracts_dict_content(self):
+        ext = GenericToolExtractor()
+        result = ext.extract({"k": "v"})
+        assert result == {"content": {"k": "v"}}
+
+    def test_returns_none_for_none(self):
+        # A tool that returns nothing shouldn't fire a spurious card.
+        ext = GenericToolExtractor()
+        assert ext.extract(None) is None
+
+    def test_empty_string_still_surfaces(self):
+        # Empty string ≠ None — host renderer may want to know the tool
+        # was called and returned nothing.
+        ext = GenericToolExtractor()
+        assert ext.extract("") == {"content": ""}
+
+    def test_sentinel_tool_name(self):
+        # `tool_name = "*"` is a sentinel; the parser never indexes
+        # _extractors by it. Documented so hosts that introspect the
+        # parser can identify the default-extractor slot.
+        assert GenericToolExtractor().tool_name == "*"
+        assert GenericToolExtractor().extracted_type == "tool_call"
+
+
+class TestParserDefaultExtractor:
+    def test_unknown_tool_emits_no_extracted_event_by_default(self):
+        """Historical behaviour: no default_extractor → no extracted event for unknown tools."""
+        parser = StreamParser()
+        events = list(parser.parse(_stream([TOOL_MESSAGE_SUCCESS])))
+
+        extracted = [e for e in events if isinstance(e, ToolExtractedEvent)]
+        assert extracted == []
+        # But lifecycle events still fire — the tool call wasn't silently dropped.
+        ends = [e for e in events if isinstance(e, ToolCallEndEvent)]
+        assert len(ends) == 1
+        assert ends[0].name == "search"
+
+    def test_unknown_tool_emits_generic_event_with_default_extractor(self):
+        """Opt-in: passing GenericToolExtractor as default_extractor surfaces unknown tools."""
+        parser = StreamParser(default_extractor=GenericToolExtractor())
+        events = list(parser.parse(_stream([TOOL_MESSAGE_SUCCESS])))
+
+        extracted = [e for e in events if isinstance(e, ToolExtractedEvent)]
+        assert len(extracted) == 1
+        evt = extracted[0]
+        assert evt.tool_name == "search"
+        assert evt.extracted_type == "tool_call"
+        assert evt.data == {"content": "The weather is sunny and 72F"}
+        # Lifecycle events still fire — generic extraction is additive.
+        assert any(isinstance(e, ToolCallEndEvent) for e in events)
+
+    def test_known_tool_uses_specific_extractor_not_default(self):
+        """Per-tool extractors win over the default fallback."""
+        parser = StreamParser(default_extractor=GenericToolExtractor())
+        # think_tool has ThinkToolExtractor registered → should NOT fall
+        # through to the GenericToolExtractor.
+        events = list(parser.parse(_stream([THINK_TOOL_STRING_CONTENT])))
+
+        # ThinkToolExtractor's "reflection" extracted_type routes to a
+        # ReasoningEvent, not a generic ToolExtractedEvent of
+        # extracted_type="tool_call". So we should see zero generic
+        # tool_call events even with the fallback registered.
+        generic = [
+            e for e in events
+            if isinstance(e, ToolExtractedEvent) and e.extracted_type == "tool_call"
+        ]
+        assert generic == []
+
+    def test_default_extractor_failure_falls_through_cleanly(self):
+        """If the default extractor raises, lifecycle events still fire."""
+        class BoomExtractor:
+            tool_name = "*"
+            extracted_type = "tool_call"
+
+            def extract(self, content):  # noqa: ARG002
+                raise RuntimeError("simulated failure")
+
+        parser = StreamParser(default_extractor=BoomExtractor())
+        events = list(parser.parse(_stream([TOOL_MESSAGE_SUCCESS])))
+
+        # No ToolExtractedEvent (the extractor blew up), but the
+        # lifecycle end event still fires — graceful degradation.
+        assert not any(isinstance(e, ToolExtractedEvent) for e in events)
+        ends = [e for e in events if isinstance(e, ToolCallEndEvent)]
+        assert len(ends) == 1
+        assert ends[0].name == "search"
+
+    def test_default_extractor_skipped_when_tool_in_skip_list(self):
+        """skip_tools still suppresses lifecycle, but default extractor
+        runs (extractor logic is independent of lifecycle skipping —
+        this matches the existing per-tool extractor behaviour, where
+        extraction is treated as a separate concern from start/end UI
+        events).
+        """
+        parser = StreamParser(
+            default_extractor=GenericToolExtractor(),
+            skip_tools=["search"],
+        )
+        events = list(parser.parse(_stream([TOOL_MESSAGE_SUCCESS])))
+        # No lifecycle end event for skipped tool.
+        assert not any(isinstance(e, ToolCallEndEvent) for e in events)
+        # But the extractor still surfaces the content — same contract
+        # as a specific extractor would have for a skipped tool.
+        extracted = [e for e in events if isinstance(e, ToolExtractedEvent)]
+        assert len(extracted) == 1
+        assert extracted[0].extracted_type == "tool_call"
+
+
+class TestRegistry:
+    def test_generic_extractor_is_top_level_export(self):
+        # If this import works, the package surface advertises the new extractor.
+        from langgraph_stream_parser import GenericToolExtractor  # noqa: F401
+
+    def test_default_extractor_not_added_to_registry(self):
+        """default_extractor lives separately from `_extractors` — it
+        shouldn't shadow per-tool registration."""
+        parser = StreamParser(default_extractor=GenericToolExtractor())
+        # Sentinel tool_name "*" must not appear in the dispatch table.
+        assert "*" not in parser._extractors
+        # Built-ins are still registered.
+        assert "think_tool" in parser._extractors
+
+    def test_specific_extractor_can_be_registered_alongside_default(self):
+        class CanvasExtractor:
+            tool_name = "add_to_canvas"
+            extracted_type = "canvas_item"
+
+            def extract(self, content):
+                return {"raw": content}
+
+        parser = StreamParser(default_extractor=GenericToolExtractor())
+        parser.register_extractor(CanvasExtractor())
+        assert "add_to_canvas" in parser._extractors
+        assert parser._default_extractor is not None
+
+    def test_known_extractor_still_wins(self):
+        # If you register a per-tool extractor for what used to fall
+        # through to the default, the per-tool one takes precedence.
+        class SearchSpecificExtractor:
+            tool_name = "search"
+            extracted_type = "search_result"
+
+            def extract(self, content):
+                return {"hit": content}
+
+        parser = StreamParser(default_extractor=GenericToolExtractor())
+        parser.register_extractor(SearchSpecificExtractor())
+
+        # Reuse the ThinkToolExtractor instance just so the test reads
+        # cleanly — we're really testing the registration table:
+        assert ThinkToolExtractor().tool_name == "think_tool"
+        events = list(parser.parse(_stream([TOOL_MESSAGE_SUCCESS])))
+        extracted = [e for e in events if isinstance(e, ToolExtractedEvent)]
+        assert len(extracted) == 1
+        assert extracted[0].extracted_type == "search_result"
+        assert extracted[0].data == {"hit": "The weather is sunny and 72F"}


### PR DESCRIPTION
## Summary

Closes the host-rendering gap for custom (non-built-in) tools. Today, a tool the parser doesn't have a per-tool extractor for emits only `ToolCallStartEvent` + `ToolCallEndEvent` — never a `ToolExtractedEvent`. Hosts that render rich cards by switching on `ToolExtractedEvent` have no signal to act on for those tools, and the only option is to fork the parser to add an extractor.

This PR adds an **opt-in fallback** so callers can register a single default extractor that handles everything the per-tool registry doesn't match.

### Before

```python
parser = StreamParser()
# Custom `search` tool: ToolCallStart + ToolCallEnd, no ToolExtractedEvent.
# Host UI shows it as a generic "called search → got result" message,
# no card. To get a card you either fork the parser or write a per-tool
# extractor and register_extractor() it.
```

### After

```python
from langgraph_stream_parser import StreamParser, GenericToolExtractor

parser = StreamParser(default_extractor=GenericToolExtractor())
# Now any unmatched tool also emits:
# ToolExtractedEvent(
#     tool_name="search",
#     extracted_type="tool_call",
#     data={"content": "..."}
# )
# Host can render a generic card off of it.
```

### Behaviour

- `default_extractor=None` (default) → historical behaviour, no new events
- `default_extractor=GenericToolExtractor()` → unmatched tools emit `ToolExtractedEvent(extracted_type="tool_call", ...)`
- Per-tool extractors **win** over the default (registry lookup is checked first; fallback only fires on miss)
- Default extractor failures degrade gracefully — `ToolCallStartEvent` / `ToolCallEndEvent` still fire on `RuntimeError`
- `GenericToolExtractor.tool_name = "*"` is a documented sentinel; the parser never indexes the dispatch table by it

### Why the bundled extractor returns `None` for `None`

A tool that legitimately returns nothing shouldn't fire a spurious empty card. Empty strings and empty dicts still surface (they may carry meaning to the host's renderer).

## Test plan

- [x] `pytest tests/test_generic_extractor.py` — 14 new tests pass:
  - 5 unit tests for `GenericToolExtractor.extract`
  - 5 parser-wiring tests (no-default, opt-in, known-wins, failure degradation, skip_tools interaction)
  - 4 registry tests (top-level export, sentinel doesn't pollute `_extractors`, coexistence with per-tool registration, specific extractor wins)
- [x] `pytest tests/` — 544 passed, 1 skipped, 0 regressions
- [x] Top-level import: `from langgraph_stream_parser import GenericToolExtractor` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)