### PR TITLE
v0.2.1: Add Release workflow + bump for GenericToolExtractor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+# Mirrors the deepagent-hermes release.yml: tag-driven publish to PyPI.
+# Tag any commit with `v*` (e.g. `v0.2.1`) and this builds + uploads.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install build
+        run: pip install build
+      - name: Build wheel + sdist
+        # `python -m build` (no flag) runs sdist → wheel-from-sdist,
+        # matching the publish path local pre-flight checks should
+        # exercise. See deepagent-hermes v0.1.2 incident for why this
+        # matters: a wheel built directly with --wheel can ship fine
+        # while the wheel-from-sdist drops every Python file because
+        # of a restrictive [tool.hatch.build.targets.sdist] include.
+        run: python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.2.0"
+version = "0.2.1"
 description = "Universal parser for LangGraph streaming outputs"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/__init__.py
+++ b/src/langgraph_stream_parser/__init__.py
@@ -64,7 +64,7 @@ from .compat import (
     aresume_graph_from_interrupt,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = [
     # Main parser


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` so future PyPI releases are tag-driven (mirror of deepagent-hermes's pattern: push a `v*` tag → workflow builds with `python -m build` → uploads via `pypa/gh-action-pypi-publish`).
- Bumps version to **v0.2.1** to package the four commits since v0.2.0 (CI workflow, real-model test, GenericToolExtractor PR #16, and this release-workflow add).

## What v0.2.1 adds for users

PR #16's `GenericToolExtractor` + `default_extractor` kwarg — opt-in fallback so unknown tools surface as `ToolExtractedEvent(extracted_type="tool_call")` instead of only emitting `ToolCallStart/End` lifecycle events. Hosts that switch on `ToolExtractedEvent` to render rich cards can now act on custom tools without per-tool extractor work:

```python
from langgraph_stream_parser import StreamParser, GenericToolExtractor
parser = StreamParser(default_extractor=GenericToolExtractor())
```

## Pre-publish verify

Ran the runbook from the `feedback_python_publish_verify_with_full_build` memory (the one we wrote after the deepagent-hermes v0.1.2 wheel-from-sdist incident):

- [x] `python -m build` (no flags — sdist + wheel-from-sdist, matching what release CI runs)
- [x] Clean-venv `pip install dist/langgraph_stream_parser-0.2.1-py3-none-any.whl`
- [x] `from langgraph_stream_parser import StreamParser, GenericToolExtractor, __version__` → all importable, `__version__ == "0.2.1"`
- [x] `StreamParser(default_extractor=GenericToolExtractor())` constructs without error

## After merge

Tag `v0.2.1` to trigger the new release workflow → publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)