### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         include:
           # One Windows job for cross-platform coverage (primary dev env).
           - os: windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]


### PR DESCRIPTION
Adds 3.14 to the CI matrix and classifiers. requires-python (>=3.11) already permits it; this PR validates the dependency stack (langgraph/langchain/ag-ui-langgraph/fastapi) actually resolves + tests green on 3.14. 🤖 Generated with [Claude Code](https://claude.com/claude-code)