### PR TITLE
feat(tasks): async task-delegation engine + Session.outcome (0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [0.5.0] - 2026-06-14
+
+An **async task-delegation engine** — the reusable core behind a "delegate a
+task, it runs in the background, track it on a board" surface. Single-process,
+dependency-free; surfaces provide a concrete store.
+
+### Added
+- **`langgraph_stream_parser.tasks`** — `TaskRunner` (an asyncio worker pool that
+  drives the shared `SessionAdapter`), a `TaskStore` protocol with a dependency-free
+  `InMemoryTaskStore` reference impl, the `Task` record + `TaskState` machine
+  (`queued → ongoing → review_needed → done/failed/cancelled`), and
+  `set_runner`/`get_runner` so agent tools can reach the runner.
+  `enqueue()` returns a `task_id` immediately (non-blocking); workers run each
+  task as its own session and transition it by the run's outcome; `cancel`,
+  `resume` (HITL), and `retry` round out the controls; orphaned `ongoing` tasks
+  are requeued on `start()`.
+- **`Session.outcome`** (+ `Session.interrupt` / `Session.error`) — a typed
+  terminal-outcome signal set by the session adapter
+  (`complete | interrupted | error | cancelled`). Headless consumers read this
+  instead of re-inspecting the event stream. Correctly distinguishes a HITL
+  pause from completion (the parser always emits a trailing `CompleteEvent`,
+  even after an interrupt).
+
+### Fixed
+- `__version__` was stale at `0.2.1` (pyproject was already ahead); now `0.5.0`.
+
+### Notes
+- Additive and dependency-free. The engine depends only on the `TaskStore`
+  protocol and the public `SessionAdapter` surface, so a surface can back it
+  with any store (in-memory, SQLite, …) and later graduate to a remote Agent
+  Protocol server without changing the engine.
+
 ## [0.4.1] - 2026-06-14
 
 AG-UI bridge robustness — an edge-case audit (`tests/test_agui_matrix.py`, run against purpose-built tool-calling / interrupting / erroring / checkpointer-less agents) surfaced three real issues, now fixed:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.4.1"
-description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, and an AG-UI bridge"
+version = "0.5.0"
+description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.11"

--- a/src/langgraph_stream_parser/__init__.py
+++ b/src/langgraph_stream_parser/__init__.py
@@ -57,6 +57,16 @@ from .extractors.builtins import (
 )
 from .resume import create_resume_input, prepare_agent_input
 from .host import load_agent_spec, HostConfig, Workspace
+from .tasks import (
+    TaskRunner,
+    TaskStore,
+    InMemoryTaskStore,
+    Task,
+    TaskState,
+    set_runner,
+    get_runner,
+    outcome_to_state,
+)
 from .compat import (
     stream_graph_updates,
     astream_graph_updates,
@@ -64,7 +74,7 @@ from .compat import (
     aresume_graph_from_interrupt,
 )
 
-__version__ = "0.2.1"
+__version__ = "0.5.0"
 
 __all__ = [
     # Main parser
@@ -98,6 +108,15 @@ __all__ = [
     "load_agent_spec",
     "HostConfig",
     "Workspace",
+    # Task-delegation engine
+    "TaskRunner",
+    "TaskStore",
+    "InMemoryTaskStore",
+    "Task",
+    "TaskState",
+    "set_runner",
+    "get_runner",
+    "outcome_to_state",
     # Serialization
     "event_to_dict",
     # Legacy/compat functions

--- a/src/langgraph_stream_parser/adapters/session.py
+++ b/src/langgraph_stream_parser/adapters/session.py
@@ -23,7 +23,7 @@ import uuid
 from datetime import datetime
 from typing import Any, AsyncIterator
 
-from ..events import CompleteEvent, ErrorEvent, event_to_dict
+from ..events import CompleteEvent, ErrorEvent, InterruptEvent, event_to_dict
 from ..parser import StreamParser
 from ..resume import create_resume_input, prepare_agent_input
 
@@ -38,6 +38,19 @@ class Session:
         self.current_task: asyncio.Task | None = None
         self.sse_connected: bool = False
         self.created_at: datetime = datetime.now()
+        # Typed terminal outcome of the most recent turn, set by ``_produce``.
+        # One of ``"complete" | "interrupted" | "error" | "cancelled"``, or
+        # ``None`` before the first turn finishes. Headless consumers (e.g. a
+        # task runner) read this instead of re-inspecting the event stream to
+        # tell whether a turn finished, paused on a HITL interrupt, or failed.
+        self.outcome: str | None = None
+        # When ``outcome == "interrupted"``, the serialized InterruptEvent
+        # (``{"type": "interrupt", "action_requests": [...], ...}``) that paused
+        # the turn — everything a consumer needs to render a review gate and
+        # build resume decisions. ``None`` otherwise.
+        self.interrupt: dict[str, Any] | None = None
+        # When ``outcome in {"error"}``, a human-readable error string.
+        self.error: str | None = None
 
     def cancel_current(self) -> bool:
         """Cancel the in-flight turn if any. Returns True if one was cancelled."""
@@ -192,8 +205,18 @@ class SessionAdapter:
         return session
 
     async def _produce(self, session: Session, input_data: Any) -> None:
-        """Run one turn, pushing serialized events onto the session queue."""
+        """Run one turn, pushing serialized events onto the session queue.
+
+        Also records the turn's terminal outcome on the session
+        (``session.outcome`` + ``session.interrupt`` / ``session.error``) so
+        headless consumers don't have to re-inspect the event stream.
+        """
         parser = StreamParser(stream_mode=self._stream_mode, **self._parser_kwargs)
+        # Fresh turn → clear any prior outcome.
+        session.outcome = None
+        session.interrupt = None
+        session.error = None
+        pending_interrupt: dict[str, Any] | None = None
         try:
             stream = self._graph.astream(
                 input_data,
@@ -201,14 +224,33 @@ class SessionAdapter:
                 stream_mode=self._stream_mode,
             )
             async for event in parser.aparse(stream):
-                session.push(event_to_dict(event, max_result_len=self._max_result_len))
-                # Terminal events end the turn; the parser emits exactly one.
-                if isinstance(event, (CompleteEvent, ErrorEvent)):
+                data = event_to_dict(event, max_result_len=self._max_result_len)
+                session.push(data)
+                if isinstance(event, InterruptEvent):
+                    # The graph paused for HITL. The parser still emits a
+                    # trailing CompleteEvent when the stream ends, so remember
+                    # the interrupt and reinterpret that Complete below.
+                    pending_interrupt = data
+                elif isinstance(event, ErrorEvent):
+                    session.outcome = "error"
+                    session.error = event.error
+                    return
+                elif isinstance(event, CompleteEvent):
+                    # A Complete that follows an interrupt means "paused",
+                    # not "finished" — distinguish the two for consumers.
+                    if pending_interrupt is not None:
+                        session.outcome = "interrupted"
+                        session.interrupt = pending_interrupt
+                    else:
+                        session.outcome = "complete"
                     return
         except asyncio.CancelledError:
+            session.outcome = "cancelled"
             session.push({"type": "cancelled"})
             raise
         except Exception as exc:  # noqa: BLE001 — surfaced to the client, not swallowed
+            session.outcome = "error"
+            session.error = f"{type(exc).__name__}: {exc}"
             session.push({"type": "error", "error": f"{type(exc).__name__}: {exc}"})
 
     # ── Consuming (SSE) ──────────────────────────────────────────────

--- a/src/langgraph_stream_parser/tasks/__init__.py
+++ b/src/langgraph_stream_parser/tasks/__init__.py
@@ -1,0 +1,54 @@
+"""Async task-delegation engine for LangGraph agents.
+
+A small, single-process control plane that lets a host accept tasks, run them
+as background agent sessions, and track them through a four-column board
+(queued → ongoing → review_needed → done/failed/cancelled).
+
+- :class:`TaskRunner` — the worker pool that drives a ``SessionAdapter``.
+- :class:`TaskStore` — the persistence protocol (surfaces provide a concrete
+  store; :class:`InMemoryTaskStore` is a dependency-free reference impl).
+- :data:`TASK_TOOLS` — agent tools so an agent can delegate to copies of
+  itself (added in a later release).
+
+Example:
+    from langgraph_stream_parser import SessionAdapter
+    from langgraph_stream_parser.tasks import TaskRunner, InMemoryTaskStore
+
+    runner = TaskRunner(adapter, InMemoryTaskStore(), concurrency=3)
+    await runner.start()
+    task_id = await runner.enqueue(title="research", prompt="...")
+"""
+from __future__ import annotations
+
+from .runner import TaskRunner, get_runner, set_runner
+from .state import (
+    CANCELLED,
+    DONE,
+    FAILED,
+    ONGOING,
+    QUEUED,
+    REVIEW_NEEDED,
+    TERMINAL_STATES,
+    TaskState,
+    outcome_to_state,
+)
+from .store import InMemoryTaskStore, Task, TaskStore, now_iso
+
+__all__ = [
+    "TaskRunner",
+    "set_runner",
+    "get_runner",
+    "TaskStore",
+    "InMemoryTaskStore",
+    "Task",
+    "now_iso",
+    "TaskState",
+    "outcome_to_state",
+    "TERMINAL_STATES",
+    "QUEUED",
+    "ONGOING",
+    "REVIEW_NEEDED",
+    "DONE",
+    "FAILED",
+    "CANCELLED",
+]

--- a/src/langgraph_stream_parser/tasks/runner.py
+++ b/src/langgraph_stream_parser/tasks/runner.py
@@ -1,0 +1,286 @@
+"""TaskRunner: a single-process async worker pool for delegated agent tasks.
+
+Generalizes the cron-scheduler pattern (an asyncio task driving the shared
+``SessionAdapter``) into a durable, board-backed task queue:
+
+- ``enqueue`` writes a ``queued`` row and returns a ``task_id`` immediately —
+  the caller (an HTTP handler or an agent tool) never blocks on the run.
+- ``concurrency`` worker coroutines each claim the oldest ``queued`` task
+  (atomically, via the store), run it as its own ``SessionAdapter`` session,
+  and transition it to ``done`` / ``failed`` / ``review_needed`` based on the
+  session's typed ``outcome``.
+- on ``start`` any ``ongoing`` rows left by a crash are requeued.
+
+The runner depends only on the :class:`TaskStore` protocol and the public
+``SessionAdapter`` surface, so a surface can back it with any store (in-memory,
+SQLite, …) without touching this code.
+
+Single-process by design: the worker count *is* the concurrency cap, and the
+atomic claim is only atomic within one process — run one server worker.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any, Optional
+
+from .state import (
+    CANCELLED,
+    DONE,
+    FAILED,
+    ONGOING,
+    QUEUED,
+    REVIEW_NEEDED,
+    TERMINAL_STATES,
+    outcome_to_state,
+)
+from .store import Task, TaskStore, now_iso
+
+logger = logging.getLogger(__name__)
+
+
+class TaskRunner:
+    """Runs delegated tasks on the app's asyncio loop. See module docstring."""
+
+    def __init__(
+        self,
+        adapter: Any,
+        store: TaskStore,
+        *,
+        concurrency: int = 3,
+        thread_prefix: str = "task-",
+        context_label: str = "Async task",
+        poll_interval: float = 2.0,
+    ) -> None:
+        self._adapter = adapter
+        self._store = store
+        self._concurrency = max(1, concurrency)
+        self._thread_prefix = thread_prefix
+        self._context_label = context_label
+        self._poll_interval = poll_interval
+        self._workers: list[asyncio.Task] = []
+        self._side_tasks: set[asyncio.Task] = set()  # resume runs, etc.
+        self._wake = asyncio.Event()
+        self._started = False
+
+    # ── lifecycle ────────────────────────────────────────────────────
+    async def start(self) -> None:
+        """Set up the store, recover orphans, and spawn worker coroutines."""
+        if self._started:
+            return
+        await self._store.setup()
+        recovered = await self._store.requeue_orphans()
+        if recovered:
+            logger.info("TaskRunner requeued %d orphaned task(s) on startup", recovered)
+        self._started = True
+        self._workers = [
+            asyncio.create_task(self._worker(i)) for i in range(self._concurrency)
+        ]
+        # Kick the workers in case there's already queued work.
+        self._wake.set()
+
+    async def shutdown(self) -> None:
+        tasks = [*self._workers, *self._side_tasks]
+        for t in tasks:
+            t.cancel()
+        # Await the cancellations so no tasks linger past shutdown (otherwise
+        # the event loop can't close cleanly on the way down).
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._workers.clear()
+        self._side_tasks.clear()
+        self._started = False
+
+    # ── public API ───────────────────────────────────────────────────
+    async def enqueue(
+        self,
+        *,
+        title: str,
+        prompt: str,
+        agent_spec: Optional[str] = None,
+        parent_id: Optional[str] = None,
+    ) -> str:
+        """Create a queued task and return its id immediately (non-blocking)."""
+        if not prompt or not prompt.strip():
+            raise ValueError("Task prompt is required.")
+        task_id = uuid.uuid4().hex
+        task: Task = {
+            "task_id": task_id,
+            "parent_id": parent_id,
+            "title": (title or prompt).strip()[:200],
+            "prompt": prompt.strip(),
+            "agent_spec": agent_spec,
+            "state": QUEUED,
+            "thread_id": f"{self._thread_prefix}{task_id}",
+            "created_at": now_iso(),
+            "started_at": None,
+            "finished_at": None,
+            "result": None,
+            "artifacts": None,
+            "error": None,
+            "interrupt": None,
+        }
+        await self._store.create(task)
+        self._wake.set()
+        return task_id
+
+    async def cancel(self, task_id: str) -> bool:
+        """Cancel a task. Stops the in-flight run if it's ``ongoing``."""
+        task = await self._store.get(task_id)
+        if task is None or task.get("state") in TERMINAL_STATES:
+            return False
+        # Mark cancelled first, then interrupt the in-flight run. The worker
+        # awaiting that run sees the run task's CancelledError (its own
+        # ``cancelling()`` is 0) and leaves the already-set state alone.
+        await self._store.update(
+            task_id, state=CANCELLED, finished_at=now_iso()
+        )
+        if task.get("state") == ONGOING:
+            self._adapter.cancel(task["thread_id"])
+        return True
+
+    async def resume(self, task_id: str, decisions: list[dict[str, Any]]) -> bool:
+        """Resume a ``review_needed`` task with HITL decisions (non-blocking).
+
+        Flips the task back to ``ongoing`` and runs the resume in the
+        background so the caller (an approve/reject HTTP handler) returns at
+        once.
+        """
+        task = await self._store.get(task_id)
+        if task is None or task.get("state") != REVIEW_NEEDED:
+            return False
+        await self._store.update(
+            task_id, state=ONGOING, interrupt=None, started_at=now_iso()
+        )
+        t = asyncio.create_task(self._resume_run(task, decisions))
+        self._side_tasks.add(t)
+        t.add_done_callback(self._side_tasks.discard)
+        return True
+
+    async def retry(self, task_id: str) -> bool:
+        """Re-queue a ``failed`` / ``cancelled`` task (same thread → resumes
+        from its last checkpoint where a durable saver is configured)."""
+        task = await self._store.get(task_id)
+        if task is None or task.get("state") not in {FAILED, CANCELLED}:
+            return False
+        await self._store.update(
+            task_id,
+            state=QUEUED,
+            error=None,
+            finished_at=None,
+            started_at=None,
+        )
+        self._wake.set()
+        return True
+
+    # ── internals ────────────────────────────────────────────────────
+    async def _worker(self, idx: int) -> None:
+        while True:
+            try:
+                task = await self._store.claim_next()
+            except Exception:  # pragma: no cover - defensive
+                logger.exception("worker %d: claim_next failed", idx)
+                task = None
+            if task is None:
+                # Nothing to do: sleep until woken or the poll timeout fires
+                # (the timeout self-heals any missed wake signal).
+                try:
+                    await asyncio.wait_for(self._wake.wait(), timeout=self._poll_interval)
+                except asyncio.TimeoutError:
+                    pass
+                self._wake.clear()
+                continue
+            await self._run_one(task)
+
+    async def _run_one(self, task: Task) -> None:
+        task_id = task["task_id"]
+        session = self._adapter.submit_message(
+            task["thread_id"],
+            task["prompt"],
+            context_parts=[f"[{self._context_label}: {task.get('title', task_id)}]"],
+        )
+        await self._await_run(task_id, session)
+
+    async def _resume_run(
+        self, task: Task, decisions: list[dict[str, Any]]
+    ) -> None:
+        task_id = task["task_id"]
+        session = self._adapter.submit_decisions(task["thread_id"], decisions)
+        await self._await_run(task_id, session)
+
+    async def _await_run(self, task_id: str, session: Any) -> None:
+        """Await a session's in-flight turn and record the outcome."""
+        try:
+            run_task = getattr(session, "current_task", None)
+            if run_task is not None:
+                await run_task
+        except asyncio.CancelledError:
+            cur = asyncio.current_task()
+            if cur is not None and cur.cancelling() > 0:
+                # This worker is itself being cancelled (shutdown) → propagate
+                # so it can exit; leave the task ``ongoing`` for restart recovery.
+                raise
+            # Otherwise the *run* task was cancelled via ``cancel()`` — its
+            # state is already set; just drain and stop.
+            self._drain(session)
+            return
+        except Exception:  # pragma: no cover - _produce captures its own errors
+            logger.exception("task %s run raised", task_id)
+
+        events = self._drain(session)
+        await self._record_outcome(task_id, session, events)
+
+    async def _record_outcome(
+        self, task_id: str, session: Any, events: list[dict[str, Any]]
+    ) -> None:
+        outcome = getattr(session, "outcome", None)
+        state = outcome_to_state(outcome)
+        fields: dict[str, Any] = {"state": state}
+        if state in TERMINAL_STATES:
+            fields["finished_at"] = now_iso()
+        if state == DONE:
+            fields["result"] = self._result_text(events)
+        elif state == REVIEW_NEEDED:
+            fields["interrupt"] = getattr(session, "interrupt", None)
+        elif state == FAILED:
+            fields["error"] = getattr(session, "error", None) or "Task run failed."
+        await self._store.update(task_id, **fields)
+
+    @staticmethod
+    def _drain(session: Any) -> list[dict[str, Any]]:
+        """Drain a headless session's event queue (no SSE consumer)."""
+        events: list[dict[str, Any]] = []
+        q = getattr(session, "event_queue", None)
+        if q is None:
+            return events
+        while not q.empty():
+            try:
+                events.append(q.get_nowait())
+            except asyncio.QueueEmpty:  # pragma: no cover
+                break
+        return events
+
+    @staticmethod
+    def _result_text(events: list[dict[str, Any]]) -> Optional[str]:
+        """Reconstruct the assistant's final text from streamed content events."""
+        parts = [
+            e.get("content", "")
+            for e in events
+            if e.get("type") == "content" and e.get("role", "assistant") == "assistant"
+        ]
+        text = "".join(parts).strip()
+        return text or None
+
+
+# ── process-global singleton (so agent tools can reach the runner) ──
+_runner: Optional[TaskRunner] = None
+
+
+def set_runner(runner: Optional[TaskRunner]) -> None:
+    global _runner
+    _runner = runner
+
+
+def get_runner() -> Optional[TaskRunner]:
+    return _runner

--- a/src/langgraph_stream_parser/tasks/state.py
+++ b/src/langgraph_stream_parser/tasks/state.py
@@ -1,0 +1,49 @@
+"""Task states for the async task-delegation engine.
+
+A delegated task moves through a small state machine that maps directly onto a
+four-column task board:
+
+    queued ──▶ ongoing ──▶ done
+                   │
+                   ├──▶ review_needed  (paused on a HITL interrupt; awaits a human)
+                   ├──▶ failed         (the run errored)
+                   └──▶ cancelled      (stopped by a human)
+
+The board groups ``failed``/``cancelled`` under the "Done" column (terminal,
+non-success) or shows them distinctly — that's a presentation choice for the
+surface, not part of the engine.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+TaskState = Literal[
+    "queued", "ongoing", "review_needed", "done", "failed", "cancelled"
+]
+
+QUEUED: TaskState = "queued"
+ONGOING: TaskState = "ongoing"
+REVIEW_NEEDED: TaskState = "review_needed"
+DONE: TaskState = "done"
+FAILED: TaskState = "failed"
+CANCELLED: TaskState = "cancelled"
+
+#: States a task will never leave on its own (no further work without a human).
+TERMINAL_STATES = frozenset({DONE, FAILED, CANCELLED})
+
+#: ``Session.outcome`` value → board state after a run finishes.
+_OUTCOME_TO_STATE: dict[str, TaskState] = {
+    "complete": DONE,
+    "interrupted": REVIEW_NEEDED,
+    "error": FAILED,
+    "cancelled": CANCELLED,
+}
+
+
+def outcome_to_state(outcome: str | None) -> TaskState:
+    """Map a :attr:`Session.outcome` onto a board state.
+
+    An unknown / missing outcome is treated as ``failed`` rather than ``done``
+    — we never silently mark an indeterminate run successful (it can be retried).
+    """
+    return _OUTCOME_TO_STATE.get(outcome or "", FAILED)

--- a/src/langgraph_stream_parser/tasks/store.py
+++ b/src/langgraph_stream_parser/tasks/store.py
@@ -1,0 +1,151 @@
+"""Task store: the persistence contract for the task-delegation engine.
+
+The engine (:class:`~langgraph_stream_parser.tasks.runner.TaskRunner`) depends
+only on the :class:`TaskStore` *protocol* — it never imports a database driver.
+Surfaces provide a concrete store:
+
+- the **web** stage ships a SQLite-backed store (durable across restarts);
+- :class:`InMemoryTaskStore` here is a dependency-free reference implementation,
+  used by the test-suite and fine for ephemeral, single-process surfaces.
+
+The shape of a task record mirrors deepagents' ``AsyncTask`` plus the board
+fields, so a future graduation to an Agent Protocol server (where runs/threads
+live remotely) is a store swap, not a redesign.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any, Optional, Protocol, TypedDict, runtime_checkable
+
+from .state import ONGOING, QUEUED, TaskState
+
+
+def now_iso() -> str:
+    """ISO-8601 UTC timestamp, second precision (``YYYY-MM-DDTHH:MM:SS+00:00``)."""
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+class Task(TypedDict, total=False):
+    """A delegated task record. ``total=False`` so partial updates type-check."""
+
+    task_id: str          # uuid hex (primary key)
+    parent_id: Optional[str]   # delegating task, for sub-agent trees
+    title: str
+    prompt: str
+    agent_spec: Optional[str]  # which agent/spec to run (None = host default)
+    state: TaskState
+    thread_id: str        # langgraph thread / SessionAdapter session id
+    created_at: str
+    started_at: Optional[str]
+    finished_at: Optional[str]
+    result: Optional[str]      # final assistant text
+    artifacts: Optional[list[Any]]
+    error: Optional[str]
+    interrupt: Optional[dict[str, Any]]  # serialized InterruptEvent when review_needed
+
+
+@runtime_checkable
+class TaskStore(Protocol):
+    """Async CRUD + atomic claim for tasks. Implementations must be safe to
+    call concurrently from multiple worker coroutines on one event loop."""
+
+    async def setup(self) -> None:
+        """Create tables / indices if needed. Idempotent."""
+        ...
+
+    async def create(self, task: Task) -> Task:
+        """Insert a new task (already populated with id/state/timestamps)."""
+        ...
+
+    async def get(self, task_id: str) -> Optional[Task]:
+        ...
+
+    async def list(
+        self,
+        *,
+        state: Optional[str] = None,
+        parent_id: Optional[str] = None,
+    ) -> list[Task]:
+        """All tasks, newest first, optionally filtered by state and/or parent."""
+        ...
+
+    async def claim_next(self) -> Optional[Task]:
+        """Atomically take the oldest ``queued`` task → ``ongoing`` and return
+        it, or ``None`` if the queue is empty. The atomicity is what prevents
+        two workers from running the same task."""
+        ...
+
+    async def update(self, task_id: str, **fields: Any) -> Optional[Task]:
+        """Patch the given fields on a task; returns the updated record."""
+        ...
+
+    async def requeue_orphans(self) -> int:
+        """Reset any ``ongoing`` tasks back to ``queued`` (call on startup to
+        recover from a crash). Returns the number requeued."""
+        ...
+
+
+class InMemoryTaskStore:
+    """Dependency-free reference store. Not durable across process restarts.
+
+    Implements :class:`TaskStore`. An :class:`asyncio.Lock` serializes the
+    claim so two workers never grab the same row.
+    """
+
+    def __init__(self) -> None:
+        self._tasks: dict[str, Task] = {}
+        self._lock = asyncio.Lock()
+
+    async def setup(self) -> None:
+        return None
+
+    async def create(self, task: Task) -> Task:
+        self._tasks[task["task_id"]] = dict(task)  # type: ignore[assignment]
+        return self._tasks[task["task_id"]]
+
+    async def get(self, task_id: str) -> Optional[Task]:
+        t = self._tasks.get(task_id)
+        return dict(t) if t is not None else None  # type: ignore[return-value]
+
+    async def list(
+        self,
+        *,
+        state: Optional[str] = None,
+        parent_id: Optional[str] = None,
+    ) -> list[Task]:
+        items = list(self._tasks.values())
+        if state is not None:
+            items = [t for t in items if t.get("state") == state]
+        if parent_id is not None:
+            items = [t for t in items if t.get("parent_id") == parent_id]
+        # newest first by created_at
+        items.sort(key=lambda t: t.get("created_at", ""), reverse=True)
+        return [dict(t) for t in items]  # type: ignore[misc]
+
+    async def claim_next(self) -> Optional[Task]:
+        async with self._lock:
+            queued = [t for t in self._tasks.values() if t.get("state") == QUEUED]
+            if not queued:
+                return None
+            queued.sort(key=lambda t: t.get("created_at", ""))
+            task = queued[0]
+            task["state"] = ONGOING
+            task["started_at"] = now_iso()
+            return dict(task)  # type: ignore[return-value]
+
+    async def update(self, task_id: str, **fields: Any) -> Optional[Task]:
+        task = self._tasks.get(task_id)
+        if task is None:
+            return None
+        task.update(fields)  # type: ignore[typeddict-item]
+        return dict(task)  # type: ignore[return-value]
+
+    async def requeue_orphans(self) -> int:
+        n = 0
+        for task in self._tasks.values():
+            if task.get("state") == ONGOING:
+                task["state"] = QUEUED
+                task["started_at"] = None
+                n += 1
+        return n

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,421 @@
+"""Tests for the async task-delegation engine (tasks/).
+
+Covers:
+- the ``Session.outcome`` terminal-outcome primitive on the adapter,
+- ``InMemoryTaskStore`` (atomic claim, requeue, filters),
+- ``TaskRunner`` end-to-end (enqueue→done/failed/review_needed) and controls
+  (cancel, retry).
+"""
+import asyncio
+from typing import Any, AsyncIterator
+
+import pytest
+
+from langgraph_stream_parser.adapters.session import SessionAdapter
+from langgraph_stream_parser.tasks import (
+    CANCELLED,
+    DONE,
+    FAILED,
+    ONGOING,
+    QUEUED,
+    REVIEW_NEEDED,
+    InMemoryTaskStore,
+    TaskRunner,
+    get_runner,
+    set_runner,
+)
+from langgraph_stream_parser.tasks.store import now_iso
+
+from .fixtures.mocks import (
+    AI_MESSAGE_WITH_TOOL_CALLS,
+    INTERRUPT_WITH_ACTIONS,
+    SIMPLE_AI_MESSAGE,
+    TOOL_MESSAGE_SUCCESS,
+)
+
+
+# ── Mock graphs (mirror test_session_adapter) ────────────────────────
+
+
+class MockGraph:
+    def __init__(self, chunks_per_call: list[list[Any]]):
+        self._chunks_per_call = chunks_per_call
+        self._call_idx = 0
+
+    def astream(self, input_data, config=None, stream_mode="updates") -> AsyncIterator[Any]:
+        chunks = self._chunks_per_call[min(self._call_idx, len(self._chunks_per_call) - 1)]
+        self._call_idx += 1
+
+        async def gen():
+            for chunk in chunks:
+                yield chunk
+
+        return gen()
+
+
+class SlowGraph:
+    def astream(self, input_data, config=None, stream_mode="updates"):
+        async def gen():
+            await asyncio.sleep(5)
+            yield SIMPLE_AI_MESSAGE
+
+        return gen()
+
+
+class BoomGraph:
+    def astream(self, input_data, config=None, stream_mode="updates"):
+        async def gen():
+            raise RuntimeError("kaboom")
+            yield  # pragma: no cover
+
+        return gen()
+
+
+async def _wait_state(store, task_id, *targets, timeout=3.0):
+    loop = asyncio.get_event_loop()
+    end = loop.time() + timeout
+    last = None
+    while loop.time() < end:
+        last = await store.get(task_id)
+        if last and last["state"] in targets:
+            return last
+        await asyncio.sleep(0.02)
+    raise AssertionError(f"task {task_id} never reached {targets}; last={last}")
+
+
+# ── 1. Session.outcome primitive ─────────────────────────────────────
+
+
+class TestOutcomePrimitive:
+    async def test_complete(self):
+        adapter = SessionAdapter(graph=MockGraph([[SIMPLE_AI_MESSAGE]]), stream_mode="updates")
+        session = adapter.submit_message("s", "hi")
+        await session.current_task
+        assert session.outcome == "complete"
+        assert session.interrupt is None
+        assert session.error is None
+
+    async def test_interrupted(self):
+        # A trailing CompleteEvent still follows the interrupt; outcome must
+        # be 'interrupted', not 'complete'.
+        graph = MockGraph([[AI_MESSAGE_WITH_TOOL_CALLS, INTERRUPT_WITH_ACTIONS]])
+        adapter = SessionAdapter(graph=graph, stream_mode="updates")
+        session = adapter.submit_message("s", "run it")
+        await session.current_task
+        assert session.outcome == "interrupted"
+        assert session.interrupt is not None
+        assert session.interrupt["type"] == "interrupt"
+        assert "action_requests" in session.interrupt
+
+    async def test_error(self):
+        adapter = SessionAdapter(graph=BoomGraph())
+        session = adapter.submit_message("s", "go")
+        await session.current_task
+        assert session.outcome == "error"
+        assert session.error and "kaboom" in session.error
+
+    async def test_cancelled(self):
+        adapter = SessionAdapter(graph=SlowGraph())
+        session = adapter.submit_message("s", "hi")
+        await asyncio.sleep(0.01)
+        adapter.cancel("s")
+        await asyncio.gather(session.current_task, return_exceptions=True)
+        assert session.outcome == "cancelled"
+
+    async def test_outcome_resets_between_turns(self):
+        # An interrupt turn then a clean turn → outcome flips back to complete.
+        graph = MockGraph([
+            [AI_MESSAGE_WITH_TOOL_CALLS, INTERRUPT_WITH_ACTIONS],
+            [SIMPLE_AI_MESSAGE],
+        ])
+        adapter = SessionAdapter(graph=graph, stream_mode="updates")
+        session = adapter.submit_message("s", "a")
+        await session.current_task
+        assert session.outcome == "interrupted"
+        session = adapter.submit_decisions("s", [{"type": "approve"}])
+        await session.current_task
+        assert session.outcome == "complete"
+        assert session.interrupt is None
+
+
+# ── 2. InMemoryTaskStore ─────────────────────────────────────────────
+
+
+def _row(task_id: str, state=QUEUED, created_at=None) -> dict:
+    return {
+        "task_id": task_id,
+        "parent_id": None,
+        "title": task_id,
+        "prompt": "do",
+        "agent_spec": None,
+        "state": state,
+        "thread_id": f"task-{task_id}",
+        "created_at": created_at or now_iso(),
+        "started_at": None,
+        "finished_at": None,
+        "result": None,
+        "artifacts": None,
+        "error": None,
+        "interrupt": None,
+    }
+
+
+class TestInMemoryStore:
+    async def test_claim_is_atomic_and_fifo(self):
+        store = InMemoryTaskStore()
+        await store.create(_row("a", created_at="2026-01-01T00:00:00+00:00"))
+        await store.create(_row("b", created_at="2026-01-01T00:00:01+00:00"))
+        # Two concurrent claims must hand back two distinct tasks (no dup).
+        c1, c2 = await asyncio.gather(store.claim_next(), store.claim_next())
+        ids = {c1["task_id"], c2["task_id"]}
+        assert ids == {"a", "b"}
+        assert c1["task_id"] == "a"  # FIFO: oldest first
+        assert all(c["state"] == ONGOING for c in (c1, c2))
+        assert await store.claim_next() is None
+
+    async def test_requeue_orphans(self):
+        store = InMemoryTaskStore()
+        await store.create(_row("x", state=ONGOING))
+        await store.create(_row("y", state=DONE))
+        n = await store.requeue_orphans()
+        assert n == 1
+        assert (await store.get("x"))["state"] == QUEUED
+        assert (await store.get("y"))["state"] == DONE
+
+    async def test_list_filters(self):
+        store = InMemoryTaskStore()
+        await store.create(_row("p", state=DONE))
+        child = _row("c"); child["parent_id"] = "p"
+        await store.create(child)
+        assert {t["task_id"] for t in await store.list(state=DONE)} == {"p"}
+        assert {t["task_id"] for t in await store.list(parent_id="p")} == {"c"}
+
+
+# ── 3. TaskRunner end-to-end ─────────────────────────────────────────
+
+
+class TestRunnerEndToEnd:
+    async def test_enqueue_to_done_with_result(self):
+        adapter = SessionAdapter(graph=MockGraph([[SIMPLE_AI_MESSAGE]]), stream_mode="updates")
+        store = InMemoryTaskStore()
+        runner = TaskRunner(adapter, store, concurrency=2, poll_interval=0.05)
+        await runner.start()
+        try:
+            tid = await runner.enqueue(title="hello", prompt="hi there")
+            row = await _wait_state(store, tid, DONE)
+            assert row["result"]  # captured assistant text
+            assert row["finished_at"]
+            assert row["thread_id"] == f"task-{tid}"
+        finally:
+            await runner.shutdown()
+
+    async def test_failing_task_goes_failed(self):
+        adapter = SessionAdapter(graph=BoomGraph())
+        store = InMemoryTaskStore()
+        runner = TaskRunner(adapter, store, concurrency=1, poll_interval=0.05)
+        await runner.start()
+        try:
+            tid = await runner.enqueue(title="boom", prompt="explode")
+            row = await _wait_state(store, tid, FAILED)
+            assert row["error"] and "kaboom" in row["error"]
+        finally:
+            await runner.shutdown()
+
+    async def test_interrupt_goes_review_needed(self):
+        graph = MockGraph([[AI_MESSAGE_WITH_TOOL_CALLS, INTERRUPT_WITH_ACTIONS]])
+        adapter = SessionAdapter(graph=graph, stream_mode="updates")
+        store = InMemoryTaskStore()
+        runner = TaskRunner(adapter, store, concurrency=1, poll_interval=0.05)
+        await runner.start()
+        try:
+            tid = await runner.enqueue(title="approve me", prompt="run it")
+            row = await _wait_state(store, tid, REVIEW_NEEDED)
+            assert row["interrupt"] and row["interrupt"]["type"] == "interrupt"
+            assert row["finished_at"] is None  # paused, not finished
+        finally:
+            await runner.shutdown()
+
+    async def test_resume_review_to_done(self):
+        graph = MockGraph([
+            [AI_MESSAGE_WITH_TOOL_CALLS, INTERRUPT_WITH_ACTIONS],
+            [TOOL_MESSAGE_SUCCESS, SIMPLE_AI_MESSAGE],
+        ])
+        adapter = SessionAdapter(graph=graph, stream_mode="updates")
+        store = InMemoryTaskStore()
+        runner = TaskRunner(adapter, store, concurrency=1, poll_interval=0.05)
+        await runner.start()
+        try:
+            tid = await runner.enqueue(title="hitl", prompt="run it")
+            await _wait_state(store, tid, REVIEW_NEEDED)
+            assert await runner.resume(tid, [{"type": "approve"}]) is True
+            row = await _wait_state(store, tid, DONE)
+            assert row["interrupt"] is None
+        finally:
+            await runner.shutdown()
+
+
+# ── 4. Runner controls (no workers needed for pure transitions) ──────
+
+
+class TestRunnerControls:
+    async def test_cancel_queued_task(self):
+        adapter = SessionAdapter(graph=MockGraph([[SIMPLE_AI_MESSAGE]]))
+        store = InMemoryTaskStore()
+        runner = TaskRunner(adapter, store)  # not started → no workers
+        tid = await runner.enqueue(title="t", prompt="p")
+        assert await runner.cancel(tid) is True
+        assert (await store.get(tid))["state"] == CANCELLED
+        # cancelling a terminal task is a no-op
+        assert await runner.cancel(tid) is False
+
+    async def test_cancel_ongoing_task(self):
+        adapter = SessionAdapter(graph=SlowGraph())
+        store = InMemoryTaskStore()
+        runner = TaskRunner(adapter, store, concurrency=1, poll_interval=0.05)
+        await runner.start()
+        try:
+            tid = await runner.enqueue(title="slow", prompt="wait")
+            await _wait_state(store, tid, ONGOING)
+            assert await runner.cancel(tid) is True
+            row = await _wait_state(store, tid, CANCELLED)
+            assert row["state"] == CANCELLED
+        finally:
+            await runner.shutdown()
+
+    async def test_retry_failed_task(self):
+        adapter = SessionAdapter(graph=MockGraph([[SIMPLE_AI_MESSAGE]]))
+        store = InMemoryTaskStore()
+        runner = TaskRunner(adapter, store)  # not started
+        tid = await runner.enqueue(title="t", prompt="p")
+        await store.update(tid, state=FAILED, error="boom", finished_at=now_iso())
+        assert await runner.retry(tid) is True
+        row = await store.get(tid)
+        assert row["state"] == QUEUED and row["error"] is None
+        # retry only applies to failed/cancelled
+        await store.update(tid, state=DONE)
+        assert await runner.retry(tid) is False
+
+    async def test_runner_singleton(self):
+        store = InMemoryTaskStore()
+        runner = TaskRunner(SessionAdapter(graph=MockGraph([[]])), store)
+        set_runner(runner)
+        assert get_runner() is runner
+        set_runner(None)
+        assert get_runner() is None
+
+
+# ── 5. Hardening: concurrency, recovery, resilience, edge cases ──────
+
+
+class RecordingGraph:
+    """Records the thread_id of every astream call; yields one content chunk
+    after a brief delay (so concurrent workers actually overlap)."""
+
+    def __init__(self) -> None:
+        self.threads: list[str] = []
+
+    def astream(self, input_data, config=None, stream_mode="updates"):
+        tid = (config or {}).get("configurable", {}).get("thread_id")
+        self.threads.append(tid)
+
+        async def gen():
+            await asyncio.sleep(0.02)
+            yield SIMPLE_AI_MESSAGE
+
+        return gen()
+
+
+class FlakyClaimStore(InMemoryTaskStore):
+    """Raises on the first claim_next to simulate a transient store error."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._raised = False
+
+    async def claim_next(self):
+        if not self._raised:
+            self._raised = True
+            raise RuntimeError("transient store error")
+        return await super().claim_next()
+
+
+class TestRunnerHardening:
+    async def test_shutdown_during_active_run_does_not_hang(self):
+        # Regression for the worker/shutdown cancel deadlock: shutting down
+        # while a task is mid-run must not block.
+        adapter = SessionAdapter(graph=SlowGraph())
+        store = InMemoryTaskStore()
+        runner = TaskRunner(adapter, store, concurrency=1, poll_interval=0.05)
+        await runner.start()
+        tid = await runner.enqueue(title="slow", prompt="wait")
+        await _wait_state(store, tid, ONGOING)
+        await asyncio.wait_for(runner.shutdown(), timeout=5)  # must not hang
+        assert (await store.get(tid))["state"] == ONGOING  # left for recovery
+
+    async def test_many_tasks_run_once_each_across_workers(self):
+        # No double-execution and full drain with N workers / M>N tasks.
+        graph = RecordingGraph()
+        adapter = SessionAdapter(graph=graph, stream_mode="updates")
+        store = InMemoryTaskStore()
+        runner = TaskRunner(adapter, store, concurrency=3, poll_interval=0.02)
+        await runner.start()
+        try:
+            ids = [await runner.enqueue(title=f"t{i}", prompt=f"p{i}") for i in range(8)]
+            for tid in ids:
+                await _wait_state(store, tid, DONE, timeout=6)
+            threads = graph.threads
+            expected = {f"task-{tid}" for tid in ids}
+            assert set(threads) == expected            # every task ran
+            assert len(threads) == len(expected)       # exactly once — no dup
+        finally:
+            await runner.shutdown()
+
+    async def test_retry_actually_reruns_to_done(self):
+        # stream_mode must match the raw chunks the healed MockGraph yields.
+        adapter = SessionAdapter(graph=BoomGraph(), stream_mode="updates")
+        store = InMemoryTaskStore()
+        runner = TaskRunner(adapter, store, concurrency=1, poll_interval=0.05)
+        await runner.start()
+        try:
+            tid = await runner.enqueue(title="t", prompt="p")
+            await _wait_state(store, tid, FAILED)
+            adapter._graph = MockGraph([[SIMPLE_AI_MESSAGE]])  # heal the graph
+            assert await runner.retry(tid) is True
+            row = await _wait_state(store, tid, DONE, timeout=4)
+            assert row["error"] is None and row["result"]
+        finally:
+            await runner.shutdown()
+
+    async def test_worker_survives_claim_error(self):
+        adapter = SessionAdapter(graph=MockGraph([[SIMPLE_AI_MESSAGE]]), stream_mode="updates")
+        store = FlakyClaimStore()
+        runner = TaskRunner(adapter, store, concurrency=1, poll_interval=0.05)
+        await runner.start()
+        try:
+            tid = await runner.enqueue(title="t", prompt="p")
+            row = await _wait_state(store, tid, DONE, timeout=4)
+            assert row["state"] == DONE  # worker recovered from the claim error
+        finally:
+            await runner.shutdown()
+
+    async def test_enqueue_requires_prompt(self):
+        runner = TaskRunner(SessionAdapter(graph=MockGraph([[]])), InMemoryTaskStore())
+        with pytest.raises(ValueError):
+            await runner.enqueue(title="x", prompt="   ")
+
+    async def test_result_text_dual_mode(self):
+        # The real default stream mode is dual ("updates","messages"); make sure
+        # result reconstruction works there too, not just in updates mode.
+        from .fixtures.mocks import DUAL_MESSAGES_TOKEN_1, DUAL_MESSAGES_TOKEN_2
+
+        graph = MockGraph([[DUAL_MESSAGES_TOKEN_1, DUAL_MESSAGES_TOKEN_2]])
+        adapter = SessionAdapter(graph=graph)  # default dual mode
+        store = InMemoryTaskStore()
+        runner = TaskRunner(adapter, store, concurrency=1, poll_interval=0.05)
+        await runner.start()
+        try:
+            tid = await runner.enqueue(title="d", prompt="hi")
+            row = await _wait_state(store, tid, DONE, timeout=4)
+            assert row["result"]  # tokens concatenated into the final text
+        finally:
+            await runner.shutdown()


### PR DESCRIPTION
## Async task-delegation engine + `Session.outcome` (0.5.0)

The reusable, single-process core behind a "delegate a task → it runs in the background → track it on a board" surface. Additive and dependency-free; surfaces provide a concrete store.

### Added — `langgraph_stream_parser.tasks`
- **`TaskRunner`** — asyncio worker pool (generalized from `CronScheduler`) driving the shared `SessionAdapter`. Non-blocking `enqueue` (returns a `task_id` immediately), `cancel`, `resume` (HITL), `retry`, and orphan requeue on `start()`. Worker count is the concurrency cap.
- **`TaskStore`** protocol + dependency-free **`InMemoryTaskStore`** reference impl. Surfaces back it with their own store (e.g. SQLite) and can later graduate to a remote Agent Protocol server without changing the engine.
- **`Task` / `TaskState`** machine: `queued → ongoing → review_needed → done/failed/cancelled`.

### Added — `Session.outcome`
Typed terminal-outcome signal (`complete|interrupted|error|cancelled`) + `Session.interrupt` / `Session.error`, set by the session adapter so headless consumers don't re-inspect the event stream. Correctly treats the parser's trailing `CompleteEvent`-after-interrupt as **paused**, not done.

### Fixed
- Stale `__version__` (`0.2.1` → `0.5.0`).

### Tests
`tests/test_tasks.py` (22 tests): outcome primitive, store atomicity/recovery, runner `enqueue→done/failed/review_needed`, resume, cancel (queued + ongoing), retry, plus a hardening matrix — **shutdown-mid-run deadlock regression**, **multi-worker no-double-execution**, worker resilience to store errors, dual-mode result reconstruction. **Full suite: 590 passed.**

### Notes / honest scope
- Tested at unit level against mock graphs (not a live LLM agent — by choice; needs a billable key).
- The in-memory store's atomic claim uses an `asyncio.Lock`; a SQLite store must prove its own claim atomicity separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
