### PR TITLE
chore(tasks): sharpen start_async_task description (0.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.6.1] - 2026-06-15
+
+### Changed
+- Sharpened the `start_async_task` tool description so models reliably prefer
+  async delegation for long-running / parallelizable / background work (instead
+  of doing it inline or via a blocking sub-agent). Docstring-only; no behavior
+  change.
+
 ## [0.6.0] - 2026-06-14
 
 Make delegated tasks **interactive** — a per-task event transcript, agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.0"
+version = "0.6.1"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/__init__.py
+++ b/src/langgraph_stream_parser/__init__.py
@@ -76,7 +76,7 @@ from .compat import (
     aresume_graph_from_interrupt,
 )
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 __all__ = [
     # Main parser

--- a/src/langgraph_stream_parser/tasks/tools.py
+++ b/src/langgraph_stream_parser/tasks/tools.py
@@ -21,15 +21,23 @@ _UNAVAILABLE = "Async task delegation is unavailable in this context."
 
 @langchain_tool
 async def start_async_task(title: str, prompt: str) -> str:
-    """Delegate a task to a background copy of yourself.
+    """Delegate a self-contained piece of work to a background copy of yourself.
 
-    Returns a task_id immediately; the task runs in the background while you
-    keep working. Do NOT wait or poll — report the task_id to the user and move
-    on. Use this for long or parallelizable work.
+    PREFER THIS over doing the work inline or spawning a blocking sub-agent
+    whenever a task is long-running, can run in parallel with other work, or can
+    simply proceed in the background while you keep talking to the user. It
+    returns a task_id immediately and the work continues asynchronously — you are
+    NOT blocked, so do NOT wait or poll. Report the task_id and carry on.
+
+    Ideal for: research, multi-step builds or analyses, batch jobs, fan-out
+    (launch several at once), or anything the user would otherwise have to wait
+    on. Each task runs as its own copy of you with the same tools; check on it
+    later with check_async_task only when the user asks.
 
     Args:
-        title: A short human-readable name for the task.
-        prompt: The full instruction for the background agent to carry out.
+        title: A short human-readable name for the task (shown on the board).
+        prompt: The full, self-contained instruction for the background agent —
+            it does not see this conversation, so include everything it needs.
     """
     runner = get_runner()
     if runner is None:


### PR DESCRIPTION
Docstring-only tuning so models prefer async delegation for long/parallel/background work over inline execution or deepagents' blocking sub-agent. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)