### PR TITLE
fix: declare langchain-core dep + minimal-install guard (0.6.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,23 @@ jobs:
 
       - name: Test
         run: pytest -ra --cov=langgraph_stream_parser --cov-report=term-missing
+
+  minimal-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install with NO extras (declared deps only)
+        run: uv pip install --system .
+
+      - name: Import smoke on a minimal install
+        run: |
+          python -c "import langgraph_stream_parser; from langgraph_stream_parser import StreamParser, load_agent_spec; from langgraph_stream_parser.tasks import TaskRunner, TASK_TOOLS; print('ok')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.6.2] - 2026-06-16
+
+### Fixed
+- **Declare `langchain-core` as a dependency.** `langgraph_stream_parser.tasks.tools`
+  imports `langchain_core.tools` at module top level (reached by a plain
+  `import langgraph_stream_parser`), but the package declared `dependencies = []` — so a
+  bare `pip install langgraph-stream-parser` failed with `ModuleNotFoundError:
+  langchain_core`. Now a hard dependency. (Found by rolling the minimal-install CI guard
+  across the family; `langgraph` stays optional — its imports are lazy.)
+
+### CI
+- Added a `minimal-install` job (install with no extras + import smoke) to guard against
+  undeclared dependencies going forward.
+
 ## [0.6.1] - 2026-06-15
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.1"
+version = "0.6.2"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}
@@ -29,7 +29,12 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 
-dependencies = []
+dependencies = [
+    # Base import chain imports `langchain_core.tools` at module top level
+    # (langgraph_stream_parser.tasks.tools). This must be a hard dependency so a
+    # bare `pip install langgraph-stream-parser` can `import langgraph_stream_parser`.
+    "langchain-core>=1.4",
+]
 
 [project.optional-dependencies]
 jupyter = [

--- a/src/langgraph_stream_parser/__init__.py
+++ b/src/langgraph_stream_parser/__init__.py
@@ -76,7 +76,7 @@ from .compat import (
     aresume_graph_from_interrupt,
 )
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 __all__ = [
     # Main parser


### PR DESCRIPTION
A bare `pip install langgraph-stream-parser` was broken: `tasks/tools.py` imports `langchain_core.tools` at module top level but `dependencies` was `[]` → `ModuleNotFoundError: langchain_core`. It only worked because dev/CI installed `.[dev]`. Now declared (`langgraph` stays optional — lazy imports). Plus the family `minimal-install` CI guard. Found by rolling the langstage 0.11.1 guard across the family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)