### PR TITLE
fix: slugify agent name for OpenAI-compatible providers (0.6.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.6.3] - 2026-06-18
+
+### Fixed
+- `create_default_agent` now slugifies the agent `name` for the LLM message
+  `name` field, and its default name is space-free (`"Deep Agent"` -> `"deep-agent"`).
+  OpenAI-compatible providers (incl. OpenRouter) require that field to match
+  `^[^\s<|\/>]+$`, so an agent named with a space hit a cryptic `400` on the
+  second turn. Names with unsafe characters are now slugified with a warning, so
+  any human-readable name works. (Surfaced via langstage-jupyter #23, whose shipped
+  default `"Default Agent"` tripped it.)
+
 ## [0.6.2] - 2026-06-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.2"
+version = "0.6.3"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/__init__.py
+++ b/src/langgraph_stream_parser/__init__.py
@@ -76,7 +76,7 @@ from .compat import (
     aresume_graph_from_interrupt,
 )
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 __all__ = [
     # Main parser

--- a/src/langgraph_stream_parser/demo/agent.py
+++ b/src/langgraph_stream_parser/demo/agent.py
@@ -5,10 +5,32 @@ base ``langgraph-stream-parser`` install stays dependency-light — importing
 this module does not require the ``[demo]`` extra; only *calling* the factory
 does.
 """
+import re
+import warnings
 from pathlib import Path
 from typing import Any
 
 DEFAULT_MODEL = "anthropic:claude-sonnet-4-6"
+
+# OpenAI (and OpenAI-compatible providers, e.g. via OpenRouter) require the
+# message `name` field to match ^[^\s<|\\/>]+$ — no spaces or <|\/>. An agent's
+# display name flows into that field, so a name with a space 400s on the second
+# turn. Slugify unsafe names so any human-readable name "just works".
+_UNSAFE_AGENT_NAME = re.compile(r"[\s<|\\/>]+")
+
+
+def _safe_agent_name(name: str) -> str:
+    """Return a name safe for the LLM message `name` field (slugify spaces /
+    <|\\/>), warning if it had to change."""
+    safe = _UNSAFE_AGENT_NAME.sub("-", name).strip("-") or "agent"
+    if safe != name:
+        warnings.warn(
+            f"Agent name {name!r} contains characters not allowed in the LLM "
+            f"message 'name' field (spaces or <|\\/>); using {safe!r}. "
+            "OpenAI-compatible providers reject the original on multi-turn calls.",
+            stacklevel=3,
+        )
+    return safe
 
 DEFAULT_SYSTEM_PROMPT = """You are a helpful AI assistant with access to a \
 filesystem workspace.
@@ -30,7 +52,7 @@ def create_default_agent(
     model: str | None = DEFAULT_MODEL,
     system_prompt: str = DEFAULT_SYSTEM_PROMPT,
     tools: list[Any] | None = None,
-    name: str = "Deep Agent",
+    name: str = "deep-agent",
     virtual_mode: bool = True,
     checkpointer: Any = None,
     **extra: Any,
@@ -89,7 +111,7 @@ def create_default_agent(
     backend = FilesystemBackend(root_dir=str(workspace), virtual_mode=virtual_mode)
 
     kwargs: dict[str, Any] = dict(
-        name=name,
+        name=_safe_agent_name(name),
         system_prompt=system_prompt,
         backend=backend,
         tools=tools or [],

--- a/tests/test_agent_name.py
+++ b/tests/test_agent_name.py
@@ -1,0 +1,44 @@
+"""Regression for the agent-name -> OpenAI message `name` 400 (langstage-jupyter #23).
+
+OpenAI-compatible providers require the message `name` field to match
+^[^\\s<|\\\\/>]+$. The agent's display name flows into that field, so a name with a
+space 400s on the second turn. create_default_agent now slugifies the name.
+"""
+import inspect
+import warnings
+
+import pytest
+
+from langgraph_stream_parser.demo.agent import _safe_agent_name, create_default_agent
+
+
+def test_default_name_is_provider_safe():
+    default = inspect.signature(create_default_agent).parameters["name"].default
+    assert " " not in default
+    assert _safe_agent_name(default) == default  # default is already a no-op slug
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("deep-agent", "deep-agent"),
+        ("Default Agent", "Default-Agent"),
+        ("My Cool Agent", "My-Cool-Agent"),
+        ("a/b\\c|d>e<f", "a-b-c-d-e-f"),
+        ("  spaced  ", "spaced"),
+        ("   ", "agent"),
+    ],
+)
+def test_safe_agent_name(raw, expected):
+    assert _safe_agent_name(raw) == expected
+
+
+def test_warns_when_name_changed():
+    with pytest.warns(UserWarning, match="name"):
+        _safe_agent_name("Has Space")
+
+
+def test_no_warning_when_already_safe():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning becomes an error
+        assert _safe_agent_name("already-safe") == "already-safe"


### PR DESCRIPTION
Root-cause fix for **dkedar7/langstage-jupyter#23**. OpenAI-compatible providers require the message `name` field to match `^[^\s<|\/>]+$`; the agent display name flows into it, so a spaced name 400s on the second turn. `create_default_agent` now slugifies the name (with a warning) and ships a space-free default (`Deep Agent`→`deep-agent`) — any human-readable name now works, family-wide. +5 tests; suite 606 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)