### PR TITLE
chore: derive __version__ from installed metadata (no drift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- `__version__` is now derived from the installed distribution metadata
+  (`importlib.metadata.version`) instead of a hard-coded constant, so it can
+  never drift out of sync with `pyproject.toml`. No behavior change — it still
+  reports the installed version.
+
 ## [0.6.3] - 2026-06-18
 
 ### Fixed

--- a/src/langgraph_stream_parser/__init__.py
+++ b/src/langgraph_stream_parser/__init__.py
@@ -29,6 +29,8 @@ Legacy Dict-Based API:
             # Handle interrupt
             ...
 """
+from importlib.metadata import PackageNotFoundError, version
+
 from .parser import StreamParser
 from .events import (
     ContentEvent,
@@ -76,7 +78,12 @@ from .compat import (
     aresume_graph_from_interrupt,
 )
 
-__version__ = "0.6.3"
+# Single source of truth is the installed distribution metadata (driven by
+# pyproject's version), so a hard-coded constant can never drift out of sync.
+try:
+    __version__ = version("langgraph-stream-parser")
+except PackageNotFoundError:  # pragma: no cover - editable/source checkout
+    __version__ = "0.0.0+local"
 
 __all__ = [
     # Main parser


### PR DESCRIPTION
Preventive hardening surfaced by the daily dogfooding routine (langstage-vscode#9 found the same stale-`__version__` drift in sibling packages).

`__version__` was a hard-coded `"0.6.3"`. It's **currently correct**, but a hard-coded constant inevitably drifts (as it did in langstage-cli and langstage-vscode). Switch to deriving it from the installed distribution metadata — the same pattern `langstage` (web) and `langstage-hermes` already use:

```python
from importlib.metadata import PackageNotFoundError, version
try:
    __version__ = version("langgraph-stream-parser")
except PackageNotFoundError:  # editable/source checkout
    __version__ = "0.0.0+local"
```

**No behavior change** — it still reports the installed version. No release needed; this rides the next functional core release (CHANGELOG entry under `[Unreleased]`).

606 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)