### PR TITLE
fix: dual-mode content fallback for non-streaming nodes (0.6.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.4] - 2026-06-20
+
+### Fixed
+- **Dual-mode (`["updates","messages"]`) dropped content from non-token-streaming
+  nodes.** The updates handler hard-suppressed all content, so a `CompiledGraph`
+  whose node returns a finished `AIMessage` (rule-based / router / retrieval
+  agents, or any LLM call made outside a token-streaming node) produced **no
+  `ContentEvent` at all** — chat surfaces rendered a blank reply. The updates
+  handler now emits a finished message's content as a **fallback** when the
+  messages/token stream did not already deliver it, deduplicated by message id
+  (falling back to node name when a message has no id) so token-streamed content
+  is never doubled. Fixes blank replies in `langstage` (web) and
+  `langstage-vscode` for non-streaming agents.
 
 ### Changed
 - `__version__` is now derived from the installed distribution metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.3"
+version = "0.6.4"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/handlers/messages.py
+++ b/src/langgraph_stream_parser/handlers/messages.py
@@ -25,6 +25,15 @@ class MessagesHandler:
     provides complete tool calls in dual mode).
     """
 
+    def __init__(self) -> None:
+        # Track which messages actually token-streamed text content, so the
+        # dual-mode UpdatesHandler can emit a *fallback* ContentEvent for a
+        # finished AIMessage that never streamed (non-LLM / non-token-streaming
+        # nodes) without double-emitting one that did. Shared by reference with
+        # the updates handler in _parse_multi_mode.
+        self.streamed_content_ids: set[str] = set()
+        self.streamed_content_nodes: set[str] = set()
+
     def process_chunk(self, chunk: Any) -> Iterator[StreamEvent]:
         """Process a single messages-mode chunk.
 
@@ -99,6 +108,14 @@ class MessagesHandler:
         content = clean_tool_dict_from_content(content)
         if not content:
             return
+
+        # Record that this message (by id) and node token-streamed content, so
+        # the dual-mode updates handler knows not to re-emit it as a fallback.
+        msg_id = getattr(chunk, "id", None)
+        if msg_id:
+            self.streamed_content_ids.add(msg_id)
+        if node_name:
+            self.streamed_content_nodes.add(node_name)
 
         yield ContentEvent(
             content=content,

--- a/src/langgraph_stream_parser/handlers/updates.py
+++ b/src/langgraph_stream_parser/handlers/updates.py
@@ -45,6 +45,9 @@ class UpdatesHandler:
         pending_tool_calls: dict[str, ToolCallStartEvent],
         suppress_content: bool = False,
         default_extractor: ToolExtractor | None = None,
+        content_fallback: bool = False,
+        streamed_content_ids: set[str] | None = None,
+        streamed_content_nodes: set[str] | None = None,
     ):
         """Initialize the handler.
 
@@ -55,12 +58,25 @@ class UpdatesHandler:
             include_state_updates: Whether to emit StateUpdateEvents.
             pending_tool_calls: Shared dict tracking pending tool calls.
             suppress_content: If True, skip ContentEvent generation for
-                AI and human messages. Used in dual mode where the
-                messages handler provides token-level content instead.
+                AI and human messages entirely.
             default_extractor: Fallback extractor invoked when no entry
                 in ``extractors`` matches a tool's name. Lets hosts emit
                 a generic ``ToolExtractedEvent`` for custom tools the
                 parser doesn't know about.
+            content_fallback: Dual-mode flag. When True, a finished
+                AIMessage's text is emitted as a ContentEvent ONLY if the
+                messages (token) stream did not already stream it — keyed by
+                ``streamed_content_ids``/``streamed_content_nodes`` shared with
+                the MessagesHandler. This lets non-token-streaming nodes (a
+                node returning a prebuilt AIMessage, a rule-based/router agent)
+                still render content, without double-emitting streamed text.
+                Human messages stay suppressed (the messages stream never
+                echoes them). Mutually exclusive with ``suppress_content``.
+            streamed_content_ids: Shared set of message ids the messages
+                handler token-streamed (consulted when content_fallback).
+            streamed_content_nodes: Shared set of node names the messages
+                handler token-streamed (fallback dedup when a message has
+                no id).
         """
         self._extractors = extractors
         self._default_extractor = default_extractor
@@ -69,6 +85,13 @@ class UpdatesHandler:
         self._include_state_updates = include_state_updates
         self._pending_tool_calls = pending_tool_calls
         self._suppress_content = suppress_content
+        self._content_fallback = content_fallback
+        self._streamed_content_ids = (
+            streamed_content_ids if streamed_content_ids is not None else set()
+        )
+        self._streamed_content_nodes = (
+            streamed_content_nodes if streamed_content_nodes is not None else set()
+        )
 
     def process_chunk(self, chunk: Any) -> Iterator[StreamEvent]:
         """Process a single update chunk.
@@ -157,6 +180,21 @@ class UpdatesHandler:
             elif message_type == "HumanMessage":
                 yield from self._process_human_message(node_name, message)
 
+    def _already_streamed(self, node_name: str, message: Any) -> bool:
+        """Whether this message's content was already token-streamed (dual mode).
+
+        Only meaningful when ``content_fallback`` is set; single-updates mode
+        always returns False (emit everything). Keyed by message id when
+        available, else by node name as a conservative fallback so a streamed
+        message that happens to lack an id isn't duplicated.
+        """
+        if not self._content_fallback:
+            return False
+        msg_id = getattr(message, "id", None)
+        if msg_id is not None:
+            return msg_id in self._streamed_content_ids
+        return node_name in self._streamed_content_nodes
+
     def _process_ai_message(
         self, node_name: str, message: Any
     ) -> Iterator[StreamEvent]:
@@ -188,7 +226,10 @@ class UpdatesHandler:
                 self._pending_tool_calls[tc["id"]] = event
                 yield event
 
-        # Extract and yield content (unless suppressed for dual mode)
+        # Extract and yield content. In single-updates mode this always emits.
+        # In dual mode (content_fallback) it emits only for a finished AIMessage
+        # that the messages/token stream did NOT already deliver — so a
+        # non-token-streaming node still renders, with no duplicate text.
         if not self._suppress_content:
             content = extract_message_content(message)
             content = content.strip() if content else ""
@@ -197,8 +238,8 @@ class UpdatesHandler:
             if content and tool_calls:
                 content = clean_tool_dict_from_content(content)
 
-            # Yield content if non-empty
-            if content:
+            # Yield content if non-empty and not already token-streamed
+            if content and not self._already_streamed(node_name, message):
                 yield ContentEvent(
                     content=content,
                     role="assistant",
@@ -236,7 +277,9 @@ class UpdatesHandler:
         Yields:
             ContentEvent with role="human" (unless content is suppressed).
         """
-        if self._suppress_content:
+        # Suppressed in dual mode too: the messages/token stream never echoes
+        # the human turn, and surfaces already have the user's input.
+        if self._suppress_content or self._content_fallback:
             return
 
         content = extract_message_content(message)

--- a/src/langgraph_stream_parser/parser.py
+++ b/src/langgraph_stream_parser/parser.py
@@ -409,7 +409,12 @@ class StreamParser:
         ))
 
     def _create_updates_handler(
-        self, suppress_content: bool = False
+        self,
+        suppress_content: bool = False,
+        *,
+        content_fallback: bool = False,
+        streamed_content_ids: set[str] | None = None,
+        streamed_content_nodes: set[str] | None = None,
     ) -> UpdatesHandler:
         """Create an UpdatesHandler configured for this parser."""
         return UpdatesHandler(
@@ -420,6 +425,9 @@ class StreamParser:
             include_state_updates=self._include_state_updates,
             pending_tool_calls=self._pending_tool_calls,
             suppress_content=suppress_content,
+            content_fallback=content_fallback,
+            streamed_content_ids=streamed_content_ids,
+            streamed_content_nodes=streamed_content_nodes,
         )
 
     def _create_messages_handler(self) -> MessagesHandler:
@@ -453,8 +461,12 @@ class StreamParser:
         Handles both regular ``(mode, data)`` and subgraph
         ``(namespace, mode, data)`` chunk formats.
         """
-        updates_handler = self._create_updates_handler(suppress_content=True)
         messages_handler = self._create_messages_handler()
+        updates_handler = self._create_updates_handler(
+            content_fallback=True,
+            streamed_content_ids=messages_handler.streamed_content_ids,
+            streamed_content_nodes=messages_handler.streamed_content_nodes,
+        )
 
         for chunk in stream:
             if not _is_multi_mode(chunk):
@@ -477,8 +489,12 @@ class StreamParser:
         self, stream: AsyncIterator[Any]
     ) -> AsyncIterator[StreamEvent]:
         """Async version of _parse_multi_mode."""
-        updates_handler = self._create_updates_handler(suppress_content=True)
         messages_handler = self._create_messages_handler()
+        updates_handler = self._create_updates_handler(
+            content_fallback=True,
+            streamed_content_ids=messages_handler.streamed_content_ids,
+            streamed_content_nodes=messages_handler.streamed_content_nodes,
+        )
 
         async for chunk in stream:
             if not _is_multi_mode(chunk):

--- a/tests/fixtures/mocks.py
+++ b/tests/fixtures/mocks.py
@@ -31,7 +31,11 @@ AIMessage = _create_mock_class(
 AIMessageChunk = _create_mock_class(
     "AIMessageChunk",
     {"content": Any, "id": str, "tool_calls": list, "tool_call_chunks": list},
-    {"id": "chunk_123", "tool_calls": list, "tool_call_chunks": list}
+    # In a real LangGraph dual stream, the streamed AIMessageChunks and the
+    # final accumulated AIMessage for the same generation share one id. Default
+    # to the same id as AIMessage ("msg_123") so dual-mode dedup tests reflect
+    # reality (the updates fallback dedups against streamed content by id).
+    {"id": "msg_123", "tool_calls": list, "tool_call_chunks": list}
 )
 
 ToolMessage = _create_mock_class(

--- a/tests/test_dual_mode.py
+++ b/tests/test_dual_mode.py
@@ -254,14 +254,21 @@ class TestDualModeDeduplication:
         assert len(interrupt_events) == 1
         assert interrupt_events[0].needs_approval is True
 
-    def test_no_content_from_updates_in_dual_mode(self):
-        """Updates mode suppresses ContentEvent in dual mode."""
+    def test_unstreamed_updates_message_emits_fallback_content(self):
+        """A finished AIMessage that never token-streamed emits fallback content.
+
+        This is the dual-mode content fallback: when no messages/token stream
+        delivered the content (e.g. a node returning a prebuilt AIMessage), the
+        updates handler renders it instead of dropping it. Streamed content is
+        still deduped — see test_content_from_messages_only.
+        """
         parser = StreamParser(stream_mode=["updates", "messages"])
         chunks = [DUAL_UPDATES_SIMPLE]
         events = list(parser.parse(make_stream(chunks)))
 
         content_events = [e for e in events if isinstance(e, ContentEvent)]
-        assert len(content_events) == 0
+        assert len(content_events) == 1
+        assert content_events[0].content == "Hello, how can I help?"
 
 
 # ── Full interleaved conversation ────────────────────────────────────
@@ -484,14 +491,16 @@ class TestParseChunkDualMode:
 
 
 class TestSuppressContent:
-    def test_suppress_content_no_content_event(self):
-        """With suppress_content, updates handler emits no ContentEvent."""
+    def test_unstreamed_content_falls_back_to_updates(self):
+        """Dual mode renders a finished AIMessage's content when nothing
+        token-streamed it (the content fallback), rather than suppressing it."""
         parser = StreamParser(stream_mode=["updates", "messages"])
         chunks = [DUAL_UPDATES_SIMPLE]
         events = list(parser.parse(make_stream(chunks)))
 
         content_events = [e for e in events if isinstance(e, ContentEvent)]
-        assert len(content_events) == 0
+        assert len(content_events) == 1
+        assert content_events[0].content == "Hello, how can I help?"
 
     def test_suppress_content_tool_events_unaffected(self):
         """With suppress_content, tool events still come through."""
@@ -663,13 +672,15 @@ class TestSubgraphMultiMode:
         assert len(content_events) == 1
         assert content_events[0].content == "Sub token"
 
-    def test_child_updates_suppresses_content(self):
-        """In dual mode, updates from subgraph still suppress ContentEvent."""
+    def test_child_unstreamed_updates_emits_fallback_content(self):
+        """A subgraph updates message that never token-streamed still renders
+        (content fallback), with the namespace preserved."""
         parser = StreamParser(stream_mode=["updates", "messages"])
         events = list(parser.parse(make_stream([SUBGRAPH_MULTI_PARENT_UPD])))
 
         content_events = [e for e in events if isinstance(e, ContentEvent)]
-        assert len(content_events) == 0
+        assert len(content_events) == 1
+        assert content_events[0].content == "Hello, how can I help?"
 
     def test_child_tool_lifecycle(self):
         parser = StreamParser(stream_mode=["updates", "messages"])

--- a/tests/test_multi_mode_content_fallback.py
+++ b/tests/test_multi_mode_content_fallback.py
@@ -1,0 +1,72 @@
+"""Dual-mode content fallback: a finished AIMessage from a non-token-streaming
+node must still produce a ContentEvent — without double-emitting content that
+the messages/token stream already delivered.
+
+Regression for the family-wide "custom CompiledGraph replies with nothing in
+chat" bug (langstage + langstage-vscode): the parser ran
+``stream_mode=["updates","messages"]`` with the updates handler hard-suppressing
+content, so a node returning a prebuilt AIMessage (rule-based / router /
+retrieval agents, or any LLM call made outside a token-streaming node) emitted
+no content at all.
+"""
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
+
+from langgraph_stream_parser import ContentEvent, StreamParser
+
+
+def _contents(events):
+    return [e.content for e in events if isinstance(e, ContentEvent)]
+
+
+def _parse(stream):
+    return list(StreamParser(stream_mode=["updates", "messages"]).parse(iter(stream)))
+
+
+def test_finished_aimessage_with_no_token_stream_emits_content():
+    """The bug: a node that returns a prebuilt AIMessage (no AIMessageChunk)."""
+    stream = [
+        ("updates", {"respond": {"messages": [AIMessage(content="hello world", id="m1")]}}),
+    ]
+    assert _contents(_parse(stream)) == ["hello world"]
+
+
+def test_token_streamed_message_is_not_duplicated_by_updates():
+    """Streamed content comes from `messages`; the final updates AIMessage with
+    the same id must NOT re-emit it."""
+    stream = [
+        ("messages", (AIMessageChunk(content="he", id="m1"), {"langgraph_node": "agent"})),
+        ("messages", (AIMessageChunk(content="llo", id="m1"), {"langgraph_node": "agent"})),
+        ("updates", {"agent": {"messages": [AIMessage(content="hello", id="m1")]}}),
+    ]
+    # Only the two streamed fragments — no third "hello" from updates.
+    assert _contents(_parse(stream)) == ["he", "llo"]
+
+
+def test_no_id_streaming_dedupes_by_node():
+    """If chunks carry no id, the final no-id AIMessage from the same node is
+    still treated as already-streamed (conservative: avoid a duplicate)."""
+    stream = [
+        ("messages", (AIMessageChunk(content="hi", id=None), {"langgraph_node": "agent"})),
+        ("updates", {"agent": {"messages": [AIMessage(content="hi", id=None)]}}),
+    ]
+    assert _contents(_parse(stream)) == ["hi"]
+
+
+def test_distinct_unstreamed_message_still_emits_alongside_streamed_one():
+    """A streamed message in node A and a separate prebuilt message in node B
+    (never streamed) both render."""
+    stream = [
+        ("messages", (AIMessageChunk(content="streamed", id="a1"), {"langgraph_node": "A"})),
+        ("updates", {"A": {"messages": [AIMessage(content="streamed", id="a1")]}}),
+        ("updates", {"B": {"messages": [AIMessage(content="prebuilt", id="b1")]}}),
+    ]
+    assert _contents(_parse(stream)) == ["streamed", "prebuilt"]
+
+
+def test_human_message_is_not_echoed_in_dual_mode():
+    """The updates stream's HumanMessage echo stays suppressed in dual mode."""
+    stream = [
+        ("updates", {"__start__": {"messages": [HumanMessage(content="user input")]}}),
+        ("updates", {"respond": {"messages": [AIMessage(content="reply", id="m1")]}}),
+    ]
+    assert _contents(_parse(stream)) == ["reply"]


### PR DESCRIPTION
Highest-leverage fix from the comprehensive dogfood run — one core change unblocks blank replies in **both** `langstage` (web) and `langstage-vscode`.

## Bug
In `stream_mode=["updates","messages"]`, the updates handler was built with `suppress_content=True`, so content flowed **only** from the token (`messages`) stream. A `CompiledGraph` whose node returns a finished `AIMessage` — rule-based / router / retrieval agents, or any LLM call made outside a token-streaming node — produced **zero `ContentEvent`s**. Chat rendered an empty assistant turn, directly contradicting the family's "write once — any CompiledGraph works out of the box."

## Fix
The updates handler now emits a finished message's content as a **fallback** when the messages/token stream didn't already deliver it:
- `MessagesHandler` records the message ids (and nodes) it token-streamed.
- `UpdatesHandler` gains a `content_fallback` mode: it emits an `AIMessage`'s content only if that message wasn't already streamed — deduped by **message id** (which the streamed chunks and final message share in real LangGraph streams), falling back to **node name** when a message has no id. Human-message echo stays suppressed.

So: streamed agents are unchanged (no double content); non-streaming agents now render. `v2` mode and single-`updates` mode are untouched.

## Tests
- New `tests/test_multi_mode_content_fallback.py` (5 cases: finished-message emits; streamed not duplicated; no-id node dedup; distinct unstreamed message still emits; human not echoed).
- Updated the dual-mode tests that encoded the old suppress-everything behavior, and made the mock `AIMessageChunk` id match the final `AIMessage` id (reflecting real streams).
- **611 passed.**

Ships with the already-merged `__version__`-from-metadata change as **0.6.4** (dependents pin `<0.7`, so this stays adoptable by a floor bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)