### PR TITLE
fix: agui --show-config matches the real bind; add --version; README accuracy (0.6.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.6.5] - 2026-06-20
+
+### Fixed
+- **`langstage-agui --show-config` disagreed with the real bind.** It printed
+  HostConfig's `localhost:8050` while the server bound argparse's
+  `127.0.0.1:8000`. host/port now come from the resolved HostConfig (so env /
+  `langstage.toml` host/port work), with `--host`/`--port` applied as overrides —
+  so `--show-config` reflects exactly what `serve()` binds. (Default bind is now
+  the host-config default, `localhost:8050`, instead of `127.0.0.1:8000`.)
+
+### Added
+- `langstage-agui --version` prints the package version (it had no version flag).
+
+### Docs
+- README: corrected the "Zero Dependencies" claim (`langchain-core` is a hard
+  runtime dep) and made the Quick Start runnable — it parses *your* compiled
+  graph (needs `langgraph`), with a keyless `create_stub_agent()` path via the
+  `[demo]` extra.
+
 ## [0.6.4] - 2026-06-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ This is the family's blessed path to the broad AG-UI frontend ecosystem (Copilot
 pip install langgraph-stream-parser
 ```
 
+The core depends only on `langchain-core`. The Quick Start below parses *your*
+compiled LangGraph `graph`, so you'll also have `langgraph` (and your agent's
+deps) installed. To try it end to end with **no API key and no agent of your
+own**, install the demo extra for a bundled stub graph:
+
+```bash
+pip install "langgraph-stream-parser[demo]"
+```
+```python
+from langgraph_stream_parser.demo import create_stub_agent
+graph = create_stub_agent()   # a keyless echo agent you can stream
+```
+
 ## Quick Start
 
 ```python
@@ -79,7 +92,7 @@ for event in parser.parse(graph.stream(input_data, stream_mode="updates")):
 - **Interrupt Handling**: Parse and resume from human-in-the-loop interrupts
 - **Extensible Extractors**: Register custom extractors for domain-specific tools
 - **Async Support**: Both sync and async parsing via `parse()` and `aparse()`
-- **Zero Dependencies**: LangGraph/LangChain imported dynamically only when needed
+- **Dependency-light**: only `langchain-core` at runtime; LangGraph/LangChain (and the demo agent's deps) are imported dynamically only when needed
 - **Backward Compatible**: Legacy dict-based API available for gradual migration
 
 ## Event Types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.4"
+version = "0.6.5"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/agui/__main__.py
+++ b/src/langgraph_stream_parser/agui/__main__.py
@@ -35,8 +35,13 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Serve the built-in keyless demo agent (no API key needed).",
     )
-    parser.add_argument("--host", default="127.0.0.1", help="Bind host (default 127.0.0.1).")
-    parser.add_argument("--port", type=int, default=8000, help="Bind port (default 8000).")
+    # host/port default to None so the resolved HostConfig (env / langstage.toml /
+    # defaults) supplies them and --show-config matches the real bind; an explicit
+    # flag overrides. Previously these defaulted to 127.0.0.1:8000 in argparse
+    # while --show-config printed HostConfig's localhost:8050 — advertised values
+    # disagreed with what the server actually bound (gh #-dogfood).
+    parser.add_argument("--host", default=None, help="Bind host (default from host config).")
+    parser.add_argument("--port", type=int, default=None, help="Bind port (default from host config).")
     parser.add_argument("--path", default="/", help="Endpoint path (default '/').")
     parser.add_argument("--name", default=None, help="Agent display name for AG-UI clients.")
     parser.add_argument(
@@ -44,23 +49,45 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Print the resolved host config and exit.",
     )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print the langgraph-stream-parser version and exit.",
+    )
     args = parser.parse_args(argv)
+
+    if args.version:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            print(f"langstage-agui (langgraph-stream-parser {version('langgraph-stream-parser')})")
+        except PackageNotFoundError:  # pragma: no cover
+            print("langstage-agui (langgraph-stream-parser 0.0.0+local)")
+        return 0
 
     from ..host import HostConfig
 
+    # CLI --host/--port are overrides on the resolved config so --show-config and
+    # the actual bind always agree (and env / langstage.toml host/port work).
+    host_port = {}
+    if args.host is not None:
+        host_port["host"] = args.host
+    if args.port is not None:
+        host_port["port"] = args.port
+
     if args.show_config:
-        print(HostConfig.resolve().describe())
+        print(HostConfig.resolve(overrides=host_port).describe())
         return 0
 
     if args.demo and args.agent:
         print("error: --demo and --agent are mutually exclusive", file=sys.stderr)
         return 2
 
-    if args.demo:
-        spec: str | None = DEMO_SPEC
-    else:
-        cfg = HostConfig.resolve(overrides={"agent_spec": args.agent})
-        spec = cfg.agent_spec
+    overrides = dict(host_port)
+    if not args.demo:
+        overrides["agent_spec"] = args.agent
+    cfg = HostConfig.resolve(overrides=overrides)
+    spec: str | None = DEMO_SPEC if args.demo else cfg.agent_spec
 
     if not spec:
         print(
@@ -73,8 +100,10 @@ def main(argv: list[str] | None = None) -> int:
     from . import DEFAULT_AGENT_NAME, serve
 
     name = args.name or ("Demo Agent" if args.demo else DEFAULT_AGENT_NAME)
-    print(f"Serving {spec!r} over AG-UI at http://{args.host}:{args.port}{args.path}")
-    serve(spec, host=args.host, port=args.port, path=args.path, name=name)
+    # cfg.host/cfg.port are the resolved values --show-config prints, so the
+    # advertised config and the real bind agree.
+    print(f"Serving {spec!r} over AG-UI at http://{cfg.host}:{cfg.port}{args.path}")
+    serve(spec, host=cfg.host, port=cfg.port, path=args.path, name=name)
     return 0
 
 

--- a/tests/test_agui_cli.py
+++ b/tests/test_agui_cli.py
@@ -1,0 +1,34 @@
+"""agui CLI: --version and host/port consistency (dogfood cluster 3).
+
+These paths return before importing the AG-UI server, so they don't need the
+[agui] extra. Regression: `--show-config` advertised localhost:8050 while the
+server actually bound 127.0.0.1:8000 — the shown config and the real bind
+disagreed. host/port now come from the resolved HostConfig (CLI flags override),
+so --show-config reflects exactly what serve() binds.
+"""
+from langgraph_stream_parser.agui.__main__ import main
+
+
+def test_version_returns_zero_and_prints_pkg(capsys):
+    rc = main(["--version"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "langgraph-stream-parser" in out
+
+
+def test_show_config_reflects_port_override(capsys):
+    rc = main(["--port", "9123", "--host", "0.0.0.0", "--show-config"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # The CLI flags appear as overrides — the same values serve() will bind.
+    assert "9123" in out
+    assert "0.0.0.0" in out
+    assert "[override]" in out
+
+
+def test_show_config_default_host_port_present(capsys):
+    rc = main(["--show-config"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # host/port are shown (from HostConfig) — what the server will bind by default.
+    assert "host" in out and "port" in out


### PR DESCRIPTION
Cluster 3 (agui) + core README doc-gaps from the comprehensive dogfood run.

## `langstage-agui --show-config` lied about host/port (minor)
`--show-config` printed HostConfig's `localhost:8050` while the server actually bound argparse's `127.0.0.1:8000` — the advertised config disagreed with reality. host/port now come from the resolved `HostConfig` (so env / `langstage.toml` host/port work too), with `--host`/`--port` applied as overrides. So `--show-config` reflects exactly what `serve()` binds, and a `--port`/`--host` flag shows as `[override]`.
- **Behavior change:** the default bind is now the host-config default (`localhost:8050`) instead of `127.0.0.1:8000`.

## Added `--version` (enhancement)
`langstage-agui` had no version flag; it now prints the package version and exits.

## README accuracy (docs)
- "Zero Dependencies" was false — `langchain-core` is a hard runtime dep. Reworded to "dependency-light".
- Made the Quick Start runnable: it parses *your* compiled graph (needs `langgraph`), with a documented keyless `create_stub_agent()` path via the `[demo]` extra.

## Tests
`tests/test_agui_cli.py` — `--version` and `--show-config` override consistency (no `[agui]` extra needed; these paths return before importing the server). **614 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)