### PR TITLE
fix: render dict-form messages in the updates handler (0.6.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.6.6] - 2026-06-21
+
+### Fixed
+- **Dict-form messages rendered nothing** — breaking the "runs any CompiledGraph"
+  promise. LangGraph's `add_messages` reducer accepts dict messages
+  (`{"role": "assistant", "content": ...}` or `{"type": "ai", ...}`), but the
+  updates handler dispatched on the message's class name (`"dict"`), which matched
+  no branch, so a node returning a dict message produced no `ContentEvent`. The
+  handler now coerces dict messages to LangChain Message objects
+  (`convert_to_messages`) before dispatch; existing Message objects pass through
+  unchanged. Fixes blank output for dict-returning agents in langstage-cli /
+  langstage (web) / langstage-vscode. (gh #-dogfood)
+
 ## [0.6.5] - 2026-06-20
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.5"
+version = "0.6.6"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/handlers/updates.py
+++ b/src/langgraph_stream_parser/handlers/updates.py
@@ -29,6 +29,26 @@ from ..extractors.messages import (
 )
 
 
+def _coerce_messages(messages: list) -> list:
+    """Convert any dict-form messages in the list to LangChain Message objects.
+
+    LangGraph's ``add_messages`` reducer accepts dict messages
+    (``{"role": "assistant", "content": ...}`` or ``{"type": "ai", ...}``).
+    ``convert_to_messages`` maps each to the right AIMessage/HumanMessage/
+    ToolMessage so the handler's class-name dispatch recognizes it; existing
+    Message objects pass through unchanged. Falls back to the original list if
+    ``langchain_core`` is unavailable or a message can't be converted.
+    """
+    if not any(isinstance(m, dict) for m in messages):
+        return messages
+    try:
+        from langchain_core.messages import convert_to_messages
+
+        return list(convert_to_messages(messages))
+    except Exception:
+        return messages
+
+
 class UpdatesHandler:
     """Handler for stream_mode='updates' chunks.
 
@@ -168,6 +188,13 @@ class UpdatesHandler:
         # Normalize to list
         if not isinstance(messages, list):
             messages = [messages]
+
+        # Coerce dict-form messages ({"role"/"type": ..., "content": ...}) into
+        # LangChain Message objects. LangGraph's add_messages reducer officially
+        # accepts dict messages, so a node returning {"role":"assistant",...}
+        # produced a dict whose class name matched no branch below and rendered
+        # NOTHING — breaking the "any CompiledGraph" promise. (gh #-dogfood)
+        messages = _coerce_messages(messages)
 
         # Process each message in sequence
         for message in messages:

--- a/tests/test_dict_messages.py
+++ b/tests/test_dict_messages.py
@@ -1,0 +1,69 @@
+"""Dict-form messages must render — LangGraph's add_messages accepts dicts.
+
+Regression (gh #-dogfood): a CompiledGraph whose node returns a dict message
+(`{"role": "assistant", "content": ...}` or `{"type": "ai", ...}`) produced NO
+content — the updates handler dispatched on the message's class name ("dict"),
+which matched no branch. This broke the family's "runs any CompiledGraph" promise
+(found via langstage-cli). The handler now coerces dict messages to LangChain
+Message objects first.
+"""
+from langgraph_stream_parser import (
+    ContentEvent,
+    StreamParser,
+    ToolCallStartEvent,
+)
+
+
+def _content(events):
+    return [e.content for e in events if isinstance(e, ContentEvent)]
+
+
+def test_dict_message_role_form_renders_single_updates():
+    parser = StreamParser(stream_mode="updates")
+    stream = [{"respond": {"messages": [{"role": "assistant", "content": "hello"}]}}]
+    assert _content(parser.parse(iter(stream))) == ["hello"]
+
+
+def test_dict_message_type_form_renders_single_updates():
+    parser = StreamParser(stream_mode="updates")
+    stream = [{"respond": {"messages": [{"type": "ai", "content": "hi there"}]}}]
+    assert _content(parser.parse(iter(stream))) == ["hi there"]
+
+
+def test_dict_message_renders_in_dual_mode():
+    """The surfaces (cli/web/vscode) run dual ["updates","messages"]; a finished
+    dict message with no token stream must still render."""
+    parser = StreamParser(stream_mode=["updates", "messages"])
+    stream = [("updates", {"respond": {"messages": [{"role": "assistant", "content": "dual ok"}]}})]
+    assert _content(parser.parse(iter(stream))) == ["dual ok"]
+
+
+def test_dict_message_tool_call_still_emits_tool_event():
+    parser = StreamParser(stream_mode="updates")
+    stream = [
+        {
+            "agent": {
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {"id": "c1", "name": "search", "args": {"q": "x"}}
+                        ],
+                    }
+                ]
+            }
+        }
+    ]
+    events = list(parser.parse(iter(stream)))
+    tool_starts = [e for e in events if isinstance(e, ToolCallStartEvent)]
+    assert len(tool_starts) == 1 and tool_starts[0].name == "search"
+
+
+def test_object_messages_still_work():
+    """Coercion must not disturb existing LangChain Message objects."""
+    from langchain_core.messages import AIMessage
+
+    parser = StreamParser(stream_mode="updates")
+    stream = [{"respond": {"messages": [AIMessage(content="object ok")]}}]
+    assert _content(parser.parse(iter(stream))) == ["object ok"]


### PR DESCRIPTION
Highest-leverage major from the dogfood re-run — one core fix unblocks dict-returning agents in **cli + web + vscode**.

## Bug
LangGraph's `add_messages` reducer officially accepts **dict messages** (`{"role":"assistant","content":...}` or `{"type":"ai","content":...}`). But the updates handler dispatched on `message.__class__.__name__` — `"dict"` — which matched none of the AIMessage/HumanMessage/ToolMessage branches, so a node returning a dict message produced **zero `ContentEvent`s** and rendered blank. Directly contradicts the family's "runs *any* CompiledGraph" headline. (Found via `langstage-cli`: a dict-returning graph showed nothing; the same graph returning an `AIMessage` object worked.)

## Fix
Coerce dict-form messages to LangChain Message objects via `convert_to_messages` before the type dispatch (handles `role`/`type` forms + `tool_calls`); existing Message objects pass through unchanged. Falls back to the original list if `langchain_core` is unavailable.

## Tests
`tests/test_dict_messages.py` — role form, type form, dual mode (the surfaces' mode), dict-with-tool-call, and object-message passthrough. **619 passed.**

Dependents (`langstage-cli`/`langstage`/`langstage-vscode`) pick this up via their `<0.7` core range; I'll bump their floors to `>=0.6.6` in their own releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)