### PR TITLE
fix: tool_end name, agui --demo preflight, host --help, [stub] extra (0.6.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [0.6.7] - 2026-06-21
+
+### Fixed
+- **`tool_end` reported `name="unknown"`** when a `ToolMessage` lacked a `name`,
+  even though the correlated `tool_start` (same id) carried it. The end event now
+  backfills the name from the tracked start event. (Found via langstage-vscode.)
+- **`langstage-agui --demo` without the `[agui]` extra** printed a success-looking
+  `Serving … at http://…` banner and *then* a traceback. It now pre-flights the
+  AG-UI deps and exits 2 with a clean install hint (no fake banner). New
+  `agui.ensure_available()`.
+- **`python -m langgraph_stream_parser.host` ignored all args** — `--help` was a
+  silent no-op. Added a tiny argparse so `-h/--help` works and unknown flags error.
+
+### Added
+- A lightweight **`[stub]` extra** (`langgraph` only) for the keyless stub agent /
+  `--demo` path, so trying the echo demo no longer drags in the full `[demo]` /
+  deepagents ML stack (~50 pkgs). README + `demo/__init__` docstring now point the
+  keyless path at `[stub]`.
+
 ## [0.6.6] - 2026-06-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ pip install langgraph-stream-parser
 The core depends only on `langchain-core`. The Quick Start below parses *your*
 compiled LangGraph `graph`, so you'll also have `langgraph` (and your agent's
 deps) installed. To try it end to end with **no API key and no agent of your
-own**, install the demo extra for a bundled stub graph:
+own**, install the lightweight `stub` extra (just `langgraph`) for a bundled
+stub graph:
 
 ```bash
-pip install "langgraph-stream-parser[demo]"
+pip install "langgraph-stream-parser[stub]"
 ```
 ```python
 from langgraph_stream_parser.demo import create_stub_agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.6"
+version = "0.6.7"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}
@@ -43,6 +43,13 @@ jupyter = [
 ]
 fastapi = [
     "fastapi>=0.100",
+]
+# Minimal extra for the keyless stub agent (create_stub_agent / the --demo path):
+# the stub needs only langgraph + langchain-core, so this avoids dragging in the
+# full deepagents ML stack (anthropic + google-genai + cryptography, ~50 pkgs)
+# just to run an echo demo. `[demo]` (deepagents) is for create_default_agent.
+stub = [
+    "langgraph>=1.1",
 ]
 demo = [
     "deepagents>=0.3",

--- a/src/langgraph_stream_parser/agui/__init__.py
+++ b/src/langgraph_stream_parser/agui/__init__.py
@@ -29,7 +29,14 @@ Quick start::
 # RunAgentInput as the request body; PEP 604 unions work natively on >=3.11.
 from typing import Any
 
-__all__ = ["build_agent", "add_agui_endpoint", "build_app", "serve", "DEFAULT_AGENT_NAME"]
+__all__ = [
+    "build_agent",
+    "add_agui_endpoint",
+    "build_app",
+    "serve",
+    "ensure_available",
+    "DEFAULT_AGENT_NAME",
+]
 
 DEFAULT_AGENT_NAME = "LangStage Agent"
 
@@ -37,6 +44,20 @@ _IMPORT_HINT = (
     "AG-UI support needs the 'agui' extra: "
     'pip install "langgraph-stream-parser[agui]"'
 )
+
+
+def ensure_available() -> None:
+    """Raise the agui-extra ``RuntimeError`` if the AG-UI server deps are missing.
+
+    Lets a caller fail fast with the clean install hint *before* any user-facing
+    output (e.g. a "Serving … at <url>" banner), instead of mid-serve.
+    """
+    try:
+        import ag_ui_langgraph  # noqa: F401
+        import fastapi  # noqa: F401
+        import uvicorn  # noqa: F401
+    except ImportError as e:  # pragma: no cover - only without the [agui] extra
+        raise RuntimeError(_IMPORT_HINT) from e
 
 
 def _is_langgraph_agent(obj: Any) -> bool:

--- a/src/langgraph_stream_parser/agui/__main__.py
+++ b/src/langgraph_stream_parser/agui/__main__.py
@@ -97,7 +97,16 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    from . import DEFAULT_AGENT_NAME, serve
+    from . import DEFAULT_AGENT_NAME, ensure_available, serve
+
+    # Fail fast on a missing [agui] extra with a clean hint to stderr — before the
+    # "Serving … at <url>" banner, so the user doesn't see a fake success line
+    # followed by a traceback (gh #-dogfood).
+    try:
+        ensure_available()
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
 
     name = args.name or ("Demo Agent" if args.demo else DEFAULT_AGENT_NAME)
     # cfg.host/cfg.port are the resolved values --show-config prints, so the

--- a/src/langgraph_stream_parser/demo/__init__.py
+++ b/src/langgraph_stream_parser/demo/__init__.py
@@ -12,8 +12,9 @@ Requires the optional ``deepagents`` dependency:
 
 This package also ships the keyless **stub agent** behind every surface's
 ``--demo`` mode (:func:`create_stub_agent` / spec
-``langgraph_stream_parser.demo.stub:graph``) — that one needs no extra and no
-API key.
+``langgraph_stream_parser.demo.stub:graph``) — that one needs no API key and only
+``langgraph`` (installed by any host surface, or via the lightweight ``[stub]``
+extra), not the full ``[demo]``/deepagents stack.
 """
 from .agent import create_default_agent
 from .stub import create_stub_agent

--- a/src/langgraph_stream_parser/handlers/updates.py
+++ b/src/langgraph_stream_parser/handlers/updates.py
@@ -430,9 +430,13 @@ class UpdatesHandler:
                     datetime.now() - start_event.timestamp
                 ).total_seconds() * 1000
 
+            # A ToolMessage often lacks ``name``; backfill from the correlated
+            # start event (same tool_call_id) so tool_end carries the real tool
+            # name for clients that key off name rather than id (gh #-dogfood).
+            end_name = tool_name or (start_event.name if start_event else None) or "unknown"
             yield ToolCallEndEvent(
                 id=tool_call_id,
-                name=tool_name or "unknown",
+                name=end_name,
                 result=content,
                 status="error" if is_error else "success",
                 error_message=error_message,

--- a/src/langgraph_stream_parser/host/__main__.py
+++ b/src/langgraph_stream_parser/host/__main__.py
@@ -6,10 +6,24 @@ where it resolved from (default / TOML / env / override), and the env var +
 variable names. Hosts can ship their own subclass printer for host-specific
 keys; this covers the shared core.
 """
+import argparse
+
 from .config import HostConfig
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    # A tiny parser so `-h/--help` works and unknown flags error, instead of
+    # every arg (including --help) being a silent no-op (gh #-dogfood).
+    parser = argparse.ArgumentParser(
+        prog="python -m langgraph_stream_parser.host",
+        description="Print the resolved shared host config (value, source, env/TOML key) and exit.",
+    )
+    parser.add_argument(
+        "--show-config",
+        action="store_true",
+        help="Print the resolved config (the default action — accepted for symmetry with langstage-agui).",
+    )
+    parser.parse_args(argv)
     print(HostConfig.resolve().describe())
     return 0
 

--- a/tests/test_host_cli.py
+++ b/tests/test_host_cli.py
@@ -1,0 +1,34 @@
+"""`python -m langgraph_stream_parser.host` argparse (gh #-dogfood).
+
+It used to ignore all args — including --help, which was a silent no-op. It now
+has a tiny argparse so -h/--help works and unknown flags error.
+"""
+import subprocess
+import sys
+
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, "-m", "langgraph_stream_parser.host", *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_help_shows_usage_and_exits_zero():
+    r = _run("--help")
+    assert r.returncode == 0
+    assert "usage:" in r.stdout.lower()
+
+
+def test_unknown_flag_errors():
+    r = _run("--bogus")
+    assert r.returncode != 0
+    assert "unrecognized arguments" in r.stderr.lower() or "error" in r.stderr.lower()
+
+
+def test_no_args_prints_config():
+    r = _run()
+    assert r.returncode == 0
+    # describe() output includes the canonical env-var hints.
+    assert "LANGSTAGE_" in r.stdout

--- a/tests/test_tool_end_name.py
+++ b/tests/test_tool_end_name.py
@@ -1,0 +1,53 @@
+"""tool_end must carry the real tool name, not "unknown" (gh #-dogfood).
+
+A ToolMessage often lacks a ``name``; tool_end then reported name="unknown" even
+though the correlated tool_start (same id) carried the name. Found via the
+langstage-vscode sidecar. The handler now backfills the name from the tracked
+start event.
+"""
+from langchain_core.messages import AIMessage, ToolMessage
+
+from langgraph_stream_parser import (
+    StreamParser,
+    ToolCallEndEvent,
+    ToolCallStartEvent,
+)
+
+
+def test_tool_end_backfills_name_from_start_event():
+    stream = [
+        {
+            "agent": {
+                "messages": [
+                    AIMessage(
+                        content="",
+                        tool_calls=[{"id": "c1", "name": "add", "args": {"a": 2, "b": 3}}],
+                    )
+                ]
+            }
+        },
+        # ToolMessage with NO name (the case that produced "unknown").
+        {"tools": {"messages": [ToolMessage(content="5", tool_call_id="c1")]}},
+    ]
+    events = list(StreamParser(stream_mode="updates").parse(iter(stream)))
+    starts = [e.name for e in events if isinstance(e, ToolCallStartEvent)]
+    ends = [e.name for e in events if isinstance(e, ToolCallEndEvent)]
+    assert starts == ["add"]
+    assert ends == ["add"], f"tool_end name not backfilled: {ends}"
+
+
+def test_tool_end_uses_message_name_when_present():
+    """When the ToolMessage carries a name, it's still used (no regression)."""
+    stream = [
+        {
+            "agent": {
+                "messages": [
+                    AIMessage(content="", tool_calls=[{"id": "c1", "name": "add", "args": {}}])
+                ]
+            }
+        },
+        {"tools": {"messages": [ToolMessage(content="5", name="add", tool_call_id="c1")]}},
+    ]
+    events = list(StreamParser(stream_mode="updates").parse(iter(stream)))
+    ends = [e.name for e in events if isinstance(e, ToolCallEndEvent)]
+    assert ends == ["add"]


### PR DESCRIPTION
Minor/nit/enhancement fixes from the dogfood re-run.

- **`tool_end` reported `name="unknown"`** when a `ToolMessage` lacked a `name`, though the correlated `tool_start` (same id) carried it. Backfilled from the tracked start event. (Found via the langstage-vscode sidecar; benefits all surfaces.)
- **`langstage-agui --demo` without `[agui]`** printed a success-looking `Serving … at <url>` banner *then* a traceback. Now pre-flights the AG-UI deps (`agui.ensure_available()`) and exits 2 with a clean install hint — no fake banner.
- **`python -m langgraph_stream_parser.host`** ignored all args (`--help` was a silent no-op). Added a tiny argparse.
- **New lightweight `[stub]` extra** (`langgraph` only) for the keyless stub / `--demo` path — trying the echo demo no longer drags in the full `[demo]`/deepagents stack (~50 pkgs incl. anthropic + google-genai + crypto). README + `demo/__init__` docstring repoint the keyless path at `[stub]`.

Tests: `test_tool_end_name.py`, `test_host_cli.py`. **624 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)