### PR TITLE
fix: keyless Quick Start no longer silently blank + BOM-safe TOML (0.6.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [0.6.8] - 2026-06-22
+
+### Fixed
+- **The keyless Quick Start failed *silently*.** `create_stub_agent()` compiled
+  the echo demo with a default `MemorySaver`, so streaming it the way the README
+  Quick Start shows — with no `config`/`thread_id` — raised a "checkpointer
+  requires thread_id" error that the parser surfaced as a lone `ErrorEvent` and a
+  **blank reply (exit 0)** for anyone copy-pasting the docs. The stub now compiles
+  **without** a checkpointer by default, so the documented config-free path just
+  works; pass `checkpointer=...` (or rely on AG-UI's auto-attach) when you want
+  threaded state. (Found by the dogfood routine.)
+- **A UTF-8 BOM in `langstage.toml` crashed config loading on Windows.** Notepad
+  and PowerShell's `Out-File -Encoding utf8` both write a BOM by default;
+  `tomllib.load()` (binary) rejects it with a cryptic "Invalid statement (at line
+  1, column 1)". Because surfaces resolve config eagerly, this could brick a whole
+  stage at import (notably `langstage-jupyter`). `_read_toml` now decodes with
+  `utf-8-sig`, stripping the BOM. Fixes every stage at once. (Found by the dogfood
+  routine.)
+
+### Docs
+- `python -m langgraph_stream_parser.host --help` no longer prints an em-dash that
+  rendered as mojibake (`�`) on a default Windows (cp1252) console.
+- README: `langstage-agui` serves at `http://localhost:8050` (the host-config
+  default), not the stale `127.0.0.1:8000`.
+
 ## [0.6.7] - 2026-06-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Any LangGraph agent can be served over the **[AG-UI protocol](https://github.com
 
 ```bash
 pip install "langgraph-stream-parser[agui]"
-langstage-agui --agent my_agent.py:graph     # serve over AG-UI at http://127.0.0.1:8000
+langstage-agui --agent my_agent.py:graph     # serve over AG-UI at http://localhost:8050
 langstage-agui --demo                          # keyless echo agent, no API key
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.7"
+version = "0.6.8"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/demo/stub.py
+++ b/src/langgraph_stream_parser/demo/stub.py
@@ -41,8 +41,12 @@ def create_stub_agent(
     Args:
         name: Display name surfaced in host UIs.
         reply_prefix: Prepended to the echoed user message in every reply.
-        checkpointer: LangGraph checkpointer. Defaults to an in-memory saver
-            so multi-turn threads work out of the box.
+        checkpointer: Optional LangGraph checkpointer. Defaults to ``None`` —
+            the graph is compiled **without** a checkpointer so it streams with
+            zero ``config``/``thread_id`` bookkeeping (the documented keyless
+            Quick Start just works). Pass one if you want multi-turn
+            persistence; hosts that need threaded state (e.g. AG-UI) attach one
+            automatically.
 
     Returns:
         A compiled LangGraph graph that replies to each user message with
@@ -56,7 +60,6 @@ def create_stub_agent(
         from langchain_core.language_models import BaseChatModel
         from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage
         from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
-        from langgraph.checkpoint.memory import MemorySaver
         from langgraph.graph import END, START, MessagesState, StateGraph
     except ImportError as e:  # pragma: no cover — exercised only without the deps
         raise RuntimeError(
@@ -122,7 +125,12 @@ def create_stub_agent(
     builder.add_edge(START, "respond")
     builder.add_edge("respond", END)
 
-    graph = builder.compile(checkpointer=checkpointer or MemorySaver())
+    # No default checkpointer: a checkpointer requires a ``thread_id`` in the
+    # stream config, and without one LangGraph raises — which the parser turns
+    # into a lone ErrorEvent and a silent, blank reply for anyone running the
+    # documented config-free Quick Start. Hosts that need threaded state (AG-UI)
+    # attach a checkpointer themselves.
+    graph = builder.compile(checkpointer=checkpointer)
     graph.name = name
     return graph
 

--- a/src/langgraph_stream_parser/host/__main__.py
+++ b/src/langgraph_stream_parser/host/__main__.py
@@ -21,7 +21,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--show-config",
         action="store_true",
-        help="Print the resolved config (the default action — accepted for symmetry with langstage-agui).",
+        help="Print the resolved config (the default action - accepted for symmetry with langstage-agui).",
     )
     parser.parse_args(argv)
     print(HostConfig.resolve().describe())

--- a/src/langgraph_stream_parser/host/config.py
+++ b/src/langgraph_stream_parser/host/config.py
@@ -121,8 +121,12 @@ def _deep_merge(base: dict, overlay: dict) -> dict:
 def _read_toml(path: Path) -> dict:
     if _tomllib is None:  # pragma: no cover
         return {}
-    with path.open("rb") as f:
-        return _tomllib.load(f)
+    # Decode with utf-8-sig so a leading UTF-8 BOM is stripped. Notepad and
+    # PowerShell's `Out-File -Encoding utf8` both write a BOM by default on
+    # Windows, and `tomllib.load()` (binary) chokes on it with a cryptic
+    # "Invalid statement (at line 1, column 1)" — which, because jupyter's
+    # config resolves at import time, bricked the whole extension. (gh #-dogfood)
+    return _tomllib.loads(path.read_text(encoding="utf-8-sig"))
 
 
 def load_toml_config(start: Path | None = None) -> tuple[dict, list[Path]]:

--- a/tests/test_demo_stub.py
+++ b/tests/test_demo_stub.py
@@ -6,7 +6,7 @@ exercise it end to end through the parser.
 """
 from langgraph_stream_parser import StreamParser, load_agent_spec, prepare_agent_input
 from langgraph_stream_parser.demo import create_stub_agent
-from langgraph_stream_parser.events import CompleteEvent, ContentEvent
+from langgraph_stream_parser.events import CompleteEvent, ContentEvent, ErrorEvent
 
 STREAM_MODE = ["updates", "messages"]
 
@@ -41,8 +41,32 @@ def test_streams_token_by_token():
     assert len(content_events) > 1
 
 
-def test_multi_turn_thread_persists():
+def test_streams_config_free():
+    """The documented keyless Quick Start streams with NO config/thread_id.
+
+    Regression (gh #-dogfood): the stub used to compile with a *default*
+    MemorySaver, so a config-free ``.stream()`` raised a "checkpointer requires
+    thread_id" error — which the parser turned into a lone ErrorEvent and a
+    silent, blank reply for anyone copy-pasting the README Quick Start. The stub
+    now compiles without a checkpointer by default, so it just works.
+    """
     graph = create_stub_agent()
+    parser = StreamParser(stream_mode=STREAM_MODE)
+    events = list(
+        parser.parse(
+            graph.stream(prepare_agent_input(message="no config"), stream_mode=STREAM_MODE)
+        )
+    )
+    assert "(demo agent) You said: no config" in _content(events)
+    assert isinstance(events[-1], CompleteEvent)
+    assert not any(isinstance(e, ErrorEvent) for e in events)
+
+
+def test_multi_turn_thread_persists():
+    # Multi-turn persistence is now opt-in: pass an explicit checkpointer.
+    from langgraph.checkpoint.memory import MemorySaver
+
+    graph = create_stub_agent(checkpointer=MemorySaver())
     _run_turn(graph, "first", thread_id="conv")
     state = graph.get_state({"configurable": {"thread_id": "conv"}})
     _run_turn(graph, "second", thread_id="conv")

--- a/tests/test_host_cli.py
+++ b/tests/test_host_cli.py
@@ -21,6 +21,14 @@ def test_help_shows_usage_and_exits_zero():
     assert "usage:" in r.stdout.lower()
 
 
+def test_help_is_cp1252_clean():
+    # The --help text must encode on a default Windows console (cp1252) without
+    # mojibake — no em-dashes / smart punctuation. (gh #-dogfood)
+    r = _run("--help")
+    assert r.returncode == 0
+    r.stdout.encode("cp1252")  # raises UnicodeEncodeError if a stray em-dash crept back in
+
+
 def test_unknown_flag_errors():
     r = _run("--bogus")
     assert r.returncode != 0

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -149,6 +149,17 @@ class TestLangstageVocabulary:
         cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
         assert cfg.port == 1234
 
+    def test_toml_with_utf8_bom_is_read(self, isolated_global, tmp_path):
+        # Notepad / PowerShell `Out-File -Encoding utf8` prepend a UTF-8 BOM on
+        # Windows; tomllib.load() (binary) chokes on it. The reader must strip it
+        # rather than crash. (gh #-dogfood: a BOM'd langstage.toml bricked jupyter
+        # at import time.)
+        (tmp_path / "langstage.toml").write_bytes(
+            b"\xef\xbb\xbf" + b"[server]\nport = 8123\n"
+        )
+        cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
+        assert cfg.port == 8123
+
     def test_nearest_toml_wins_across_dirs(self, isolated_global, tmp_path):
         # langstage.toml in the parent must NOT beat deepagents.toml in cwd.
         (tmp_path / "langstage.toml").write_text("[server]\nport = 1000\n")


### PR DESCRIPTION
Two findings from the daily library-health dogfood routine — both highest-leverage because they live in the shared core and fix every surface at once.

## 1. Keyless Quick Start failed *silently* (MAJOR)
`create_stub_agent()` compiled the echo demo with a default `MemorySaver`. Streaming it the way the README Quick Start shows — no `config`/`thread_id` — raised a "checkpointer requires thread_id" error, which the parser surfaced as a lone `ErrorEvent` and a **blank reply at exit 0** for anyone copy-pasting the docs.

Fix: compile the stub **without** a checkpointer by default. Persistence is now opt-in (`create_stub_agent(checkpointer=...)`); AG-UI still auto-attaches one for interrupts/resume.

## 2. UTF-8 BOM in `langstage.toml` crashed config loading on Windows (HIGH)
`_read_toml` used `tomllib.load()` (binary), which rejects a leading UTF-8 BOM with a cryptic `Invalid statement (at line 1, column 1)`. Notepad and PowerShell's `Out-File -Encoding utf8` both write a BOM by default, so a hand-created config bricked config loading at import time — notably crashing **langstage-jupyter** on `import`. Now decodes with `utf-8-sig`. Fixes all stages.

## Nits
- `host --help` em-dash → ASCII (cp1252-clean console).
- README: `langstage-agui` serves at `http://localhost:8050` (host-config default), not stale `127.0.0.1:8000`.

## Tests
- Config-free stub stream yields content + no `ErrorEvent` (the regression).
- Multi-turn persistence test now passes an explicit checkpointer.
- BOM'd `langstage.toml` resolves instead of crashing.
- `host --help` output is cp1252-encodable.

Full suite: 626 passed. (The one local failure is `test_real_model`, the opt-in live-LLM test — it skips in CI without `OPENROUTER_API_KEY`; the local key is over its weekly quota.)
