### PR TITLE
feat: make legacy DEEPAGENT_* deprecation visible to CLI users (0.6.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.6.9] - 2026-06-22
+
+### Changed
+- **Legacy `DEEPAGENT_*` env vars now emit a *visible* one-line deprecation
+  notice to stderr**, not just a `DeprecationWarning` (which Python's default
+  filter silently swallows, so CLI users never saw the nudge). Fires once per
+  variable, from the shared resolver — so every surface (web, CLI, JupyterLab,
+  VS Code, Hermes) gets it for free, no per-surface change. ASCII-only
+  (cp1252-safe); suppressed under pytest and via
+  `LANGSTAGE_SUPPRESS_LEGACY_NOTICE=1`. (Found by the dogfood routine: the
+  canonical-vs-legacy contract advertised a warning the runtime never showed.)
+
 ## [0.6.8] - 2026-06-22
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.8"
+version = "0.6.9"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/host/config.py
+++ b/src/langgraph_stream_parser/host/config.py
@@ -14,7 +14,8 @@ Legacy vocabulary (the pre-LangStage names) still works everywhere as a
 deprecated fallback: ``DEEPAGENT_*`` env vars, project ``deepagents.toml``,
 global ``~/.deepagents/config.toml``, and ``DEEPAGENTS_CONFIG_HOME``. The
 canonical names win when both are set; using only the legacy env names emits
-a once-per-var ``DeprecationWarning``. Moving the global config out of
+a once-per-var ``DeprecationWarning`` *and* a visible one-line stderr notice
+(silence it with ``LANGSTAGE_SUPPRESS_LEGACY_NOTICE=1``). Moving the global config out of
 ``~/.deepagents/`` also exits the schema collision with LangChain's dcode,
 which owns that directory now.
 
@@ -24,6 +25,7 @@ from, and the env var / TOML key that sets it — so you never have to remember
 the variable names.
 """
 import os
+import sys
 import warnings
 from dataclasses import MISSING, dataclass, fields, replace
 from pathlib import Path
@@ -70,6 +72,32 @@ def _warn_legacy_env(legacy: str, canonical: str) -> None:
         f"{legacy} is deprecated; use {canonical}.",
         DeprecationWarning,
         stacklevel=4,
+    )
+    _print_legacy_env_notice(legacy, canonical)
+
+
+def _print_legacy_env_notice(legacy: str, canonical: str) -> None:
+    """Print a one-line, user-visible deprecation notice to stderr.
+
+    The ``DeprecationWarning`` above is the correct signal for programmatic /
+    strict consumers, but Python's *default* warning filter silently swallows
+    it — so a real person running any LangStage CLI with a legacy
+    ``DEEPAGENT_*`` env var never sees the nudge. Printing here (once per var,
+    via the ``_warned_legacy_env`` dedupe in the caller) makes the deprecation
+    visible across every surface from the one place they all resolve config —
+    no per-surface code needed. ASCII-only so it can't crash a cp1252 Windows
+    console. Suppressed under pytest (keeps test output clean and can't break
+    other repos' suites) and via ``LANGSTAGE_SUPPRESS_LEGACY_NOTICE``.
+    """
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        return
+    if _env_bool(os.getenv("LANGSTAGE_SUPPRESS_LEGACY_NOTICE")):
+        return
+    print(
+        f"note: {legacy} is deprecated; use {canonical}. "
+        "(Legacy DEEPAGENT_* support will be removed in a future release; "
+        "set LANGSTAGE_SUPPRESS_LEGACY_NOTICE=1 to silence.)",
+        file=sys.stderr,
     )
 
 

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -138,6 +138,41 @@ class TestLangstageVocabulary:
         with pytest.warns(DeprecationWarning, match="LANGSTAGE_TITLE"):
             HostConfig.resolve(env={"DEEPAGENT_TITLE": "Old"}, toml_start=tmp_path)
 
+    def test_legacy_env_prints_visible_notice(self, isolated_global, tmp_path, monkeypatch, capsys):
+        # The DeprecationWarning is swallowed by Python's default filter, so the
+        # resolver ALSO prints a one-line notice to stderr for CLI users. Drop
+        # the pytest marker env so the notice isn't suppressed.
+        import langgraph_stream_parser.host.config as config_mod
+
+        config_mod._warned_legacy_env.discard("DEEPAGENT_PORT")
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("LANGSTAGE_SUPPRESS_LEGACY_NOTICE", raising=False)
+        HostConfig.resolve(env={"DEEPAGENT_PORT": "9000"}, toml_start=tmp_path)
+        err = capsys.readouterr().err
+        assert "DEEPAGENT_PORT is deprecated" in err
+        assert "LANGSTAGE_PORT" in err
+        # ASCII-only — must encode on a cp1252 Windows console.
+        err.encode("cp1252")
+
+    def test_legacy_env_notice_silent_under_pytest(self, isolated_global, tmp_path, capsys):
+        # PYTEST_CURRENT_TEST is set during this test, so no stderr notice fires
+        # (keeps test output clean and can't break captured-output assertions in
+        # the surface repos' suites).
+        import langgraph_stream_parser.host.config as config_mod
+
+        config_mod._warned_legacy_env.discard("DEEPAGENT_DEBUG")
+        HostConfig.resolve(env={"DEEPAGENT_DEBUG": "true"}, toml_start=tmp_path)
+        assert "deprecated" not in capsys.readouterr().err
+
+    def test_legacy_env_notice_suppressed_by_env(self, isolated_global, tmp_path, monkeypatch, capsys):
+        import langgraph_stream_parser.host.config as config_mod
+
+        config_mod._warned_legacy_env.discard("DEEPAGENT_HOST")
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.setenv("LANGSTAGE_SUPPRESS_LEGACY_NOTICE", "1")
+        HostConfig.resolve(env={"DEEPAGENT_HOST": "0.0.0.0"}, toml_start=tmp_path)
+        assert "deprecated" not in capsys.readouterr().err
+
     def test_langstage_toml_preferred_in_same_dir(self, isolated_global, tmp_path):
         (tmp_path / "deepagents.toml").write_text("[server]\nport = 1000\n")
         (tmp_path / "langstage.toml").write_text("[server]\nport = 2000\n")


### PR DESCRIPTION
Addresses the cross-cutting LOW finding from the daily dogfood routine: the canonical-vs-legacy contract *advertised* a deprecation warning the runtime never actually showed.

## The gap
When a legacy `DEEPAGENT_*` env var is used as a fallback, the resolver raises a `DeprecationWarning` — but Python's **default** warning filter silently swallows `DeprecationWarning`, so a real person running any LangStage CLI never sees the nudge. The docs (and `--show-config` source labels) promise "legacy warns"; the runtime didn't deliver it to end users.

## The fix (one place, family-wide)
`_warn_legacy_env` now *also* prints a one-line notice to stderr:

```
note: DEEPAGENT_PORT is deprecated; use LANGSTAGE_PORT. (Legacy DEEPAGENT_* support
will be removed in a future release; set LANGSTAGE_SUPPRESS_LEGACY_NOTICE=1 to silence.)
```

Because every surface resolves config through this one function, **all of them (web, CLI, JupyterLab, VS Code, Hermes) get the visible notice via their `langgraph-stream-parser` dependency — no per-surface release.** Properties:
- Once per variable (existing `_warned_legacy_env` dedupe).
- **ASCII-only** so it can't crash a cp1252 Windows console.
- **Suppressed under pytest** (`PYTEST_CURRENT_TEST`) so it can't add stderr noise to the surface repos' captured-output assertions.
- **Opt-out** via `LANGSTAGE_SUPPRESS_LEGACY_NOTICE=1`.
- The `DeprecationWarning` is still raised for programmatic/strict consumers.

## Tests
- notice prints to stderr + is `cp1252`-encodable;
- silent under pytest;
- silenced by the env flag.

Full suite: 629 passed (the lone failure is the opt-in `test_real_model`, which skips in CI without `OPENROUTER_API_KEY`).
