### PR TITLE
fix: honest stub missing-deps error + full SUPPRESS for legacy notice (0.6.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.6.10] - 2026-06-22
+
+### Fixed
+- **The stub agent's missing-deps error over-claimed and gave no remedy.** When
+  `langgraph` isn't installed, `create_stub_agent()` raised "needs langgraph +
+  langchain-core (every deep-agent surface already installs them)" — which is
+  false for a base `langstage-vscode` install, and never told the user how to
+  fix it. The message now names the actual remedy: the lightweight
+  `pip install "langgraph-stream-parser[stub]"` extra (or `pip install langgraph`).
+  (Found by the dogfood routine.)
+- **`LANGSTAGE_SUPPRESS_LEGACY_NOTICE=1` now silences the `DeprecationWarning`
+  too**, not just the stderr notice. Previously a suppressed run could still leak
+  a raw `DeprecationWarning` (e.g. into a VS Code output channel), making the
+  "set … to silence" hint only half-true. Setting the env var now opts out of
+  every legacy-env deprecation signal. (Found by the dogfood routine.)
+
 ## [0.6.9] - 2026-06-22
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.9"
+version = "0.6.10"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/demo/stub.py
+++ b/src/langgraph_stream_parser/demo/stub.py
@@ -63,8 +63,10 @@ def create_stub_agent(
         from langgraph.graph import END, START, MessagesState, StateGraph
     except ImportError as e:  # pragma: no cover — exercised only without the deps
         raise RuntimeError(
-            "The stub agent needs langgraph + langchain-core "
-            "(every deep-agent surface already installs them): "
+            "The stub agent needs langgraph + langchain-core, which aren't "
+            "installed. Install the lightweight stub extra "
+            '(`pip install "langgraph-stream-parser[stub]"`) — or your stage\'s '
+            "own demo extra, or plain `pip install langgraph`: "
             f"{e}"
         ) from e
 

--- a/src/langgraph_stream_parser/host/config.py
+++ b/src/langgraph_stream_parser/host/config.py
@@ -68,6 +68,13 @@ def _warn_legacy_env(legacy: str, canonical: str) -> None:
     if legacy in _warned_legacy_env:
         return
     _warned_legacy_env.add(legacy)
+    # LANGSTAGE_SUPPRESS_LEGACY_NOTICE silences EVERY legacy-env deprecation
+    # signal — both the Python DeprecationWarning and the stderr notice — so the
+    # "set ... to silence" hint we print is actually honest (a user who sets it
+    # shouldn't still see a stray DeprecationWarning leak through, e.g. into a
+    # VS Code output channel).
+    if _env_bool(os.getenv("LANGSTAGE_SUPPRESS_LEGACY_NOTICE")):
+        return
     warnings.warn(
         f"{legacy} is deprecated; use {canonical}.",
         DeprecationWarning,
@@ -79,19 +86,18 @@ def _warn_legacy_env(legacy: str, canonical: str) -> None:
 def _print_legacy_env_notice(legacy: str, canonical: str) -> None:
     """Print a one-line, user-visible deprecation notice to stderr.
 
-    The ``DeprecationWarning`` above is the correct signal for programmatic /
-    strict consumers, but Python's *default* warning filter silently swallows
-    it — so a real person running any LangStage CLI with a legacy
-    ``DEEPAGENT_*`` env var never sees the nudge. Printing here (once per var,
-    via the ``_warned_legacy_env`` dedupe in the caller) makes the deprecation
-    visible across every surface from the one place they all resolve config —
-    no per-surface code needed. ASCII-only so it can't crash a cp1252 Windows
-    console. Suppressed under pytest (keeps test output clean and can't break
-    other repos' suites) and via ``LANGSTAGE_SUPPRESS_LEGACY_NOTICE``.
+    The ``DeprecationWarning`` raised by the caller is the correct signal for
+    programmatic / strict consumers, but Python's *default* warning filter
+    silently swallows it — so a real person running any LangStage CLI with a
+    legacy ``DEEPAGENT_*`` env var never sees the nudge. Printing here (once per
+    var, via the ``_warned_legacy_env`` dedupe in the caller) makes the
+    deprecation visible across every surface from the one place they all resolve
+    config — no per-surface code needed. ASCII-only so it can't crash a cp1252
+    Windows console. Suppressed under pytest (keeps test output clean and can't
+    break other repos' suites); the ``LANGSTAGE_SUPPRESS_LEGACY_NOTICE`` opt-out
+    is handled by the caller (it gates the warning too).
     """
     if "PYTEST_CURRENT_TEST" in os.environ:
-        return
-    if _env_bool(os.getenv("LANGSTAGE_SUPPRESS_LEGACY_NOTICE")):
         return
     print(
         f"note: {legacy} is deprecated; use {canonical}. "

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -165,13 +165,20 @@ class TestLangstageVocabulary:
         assert "deprecated" not in capsys.readouterr().err
 
     def test_legacy_env_notice_suppressed_by_env(self, isolated_global, tmp_path, monkeypatch, capsys):
+        import warnings
+
         import langgraph_stream_parser.host.config as config_mod
 
         config_mod._warned_legacy_env.discard("DEEPAGENT_HOST")
         monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
         monkeypatch.setenv("LANGSTAGE_SUPPRESS_LEGACY_NOTICE", "1")
-        HostConfig.resolve(env={"DEEPAGENT_HOST": "0.0.0.0"}, toml_start=tmp_path)
+        # SUPPRESS silences BOTH the stderr notice AND the DeprecationWarning,
+        # so the "set ... to silence" hint is honest (no warning leaks through).
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            HostConfig.resolve(env={"DEEPAGENT_HOST": "0.0.0.0"}, toml_start=tmp_path)
         assert "deprecated" not in capsys.readouterr().err
+        assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
 
     def test_langstage_toml_preferred_in_same_dir(self, isolated_global, tmp_path):
         (tmp_path / "deepagents.toml").write_text("[server]\nport = 1000\n")


### PR DESCRIPTION
Two LOW dogfood-routine findings, both in the shared core (so they reach every surface transitively).

**1. Stub missing-deps error over-claimed and gave no remedy.** When `langgraph` isn't installed, `create_stub_agent()` raised "needs langgraph + langchain-core (every deep-agent surface already installs them)" — false for a base `langstage-vscode` install, and with no fix named. Now points at the lightweight `pip install "langgraph-stream-parser[stub]"` extra (or plain `langgraph`).

**2. `LANGSTAGE_SUPPRESS_LEGACY_NOTICE=1` only half-silenced.** It suppressed the stderr notice but a raw `DeprecationWarning` could still leak (e.g. into a VS Code output channel). The env var now gates the warning too — one opt-out for every legacy-env deprecation signal, so the "set … to silence" hint is honest.

Test updated: `SUPPRESS=1` asserted to silence both the notice and the warning. Full suite 629 passed (lone failure is the opt-in `test_real_model`, which skips in CI without `OPENROUTER_API_KEY`).
