### PR TITLE
fix: CLIAdapter cp1252-safe (#37) + describe(omit_keys) for stdio stages (0.6.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.6.11] - 2026-06-25
+
+### Fixed
+- **`CLIAdapter` crashed with `UnicodeEncodeError` on a default Windows (cp1252)
+  console.** It prints `⏺`, the braille spinner, box-drawing, and `✓ ✗ ⚠`
+  without ever reconfiguring stdio, so the first styled line raised before any
+  output appeared (and `use_colors=False` didn't help — that strips ANSI, not
+  the glyphs). `CLIAdapter.run()` now reconfigures stdout/stderr to UTF-8
+  (`errors="replace"`) up front, mirroring the `langstage-cli` entry point. The
+  last surface that wasn't cp1252-safe. (gh #37)
+
+### Added
+- **`HostConfig.describe(omit_keys=[...])`** — hide inherited keys a stage
+  doesn't actually honor, so `--show-config` never advertises an env var (with a
+  confident source attribution) that has zero effect on that surface. Used by
+  the stdio sidecar and the JupyterLab launcher to drop the web-only
+  `host`/`port` rows. (gh: langstage-jupyter #30, langstage-vscode #14)
+
 ## [0.6.10] - 2026-06-22
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.10"
+version = "0.6.11"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/adapters/cli.py
+++ b/src/langgraph_stream_parser/adapters/cli.py
@@ -37,6 +37,27 @@ BRIGHT_YELLOW = "\033[93m"
 SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
 
+def _ensure_utf8_stdio() -> None:
+    """Make stdout/stderr able to encode this adapter's glyphs on a non-UTF-8
+    console.
+
+    ``CLIAdapter`` prints ``⏺``, the braille spinner, box-drawing, and
+    ``✓ ✗ ⚠`` — none of which a default Windows (cp1252) console can encode, so
+    the very first styled line raises ``UnicodeEncodeError`` before any output
+    appears. Reconfigure to UTF-8 (with ``errors="replace"`` as a backstop),
+    mirroring what the ``langstage-cli`` entry point already does. Idempotent,
+    best-effort, and a no-op when stdout is already UTF-8.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        enc = (getattr(stream, "encoding", None) or "").lower().replace("-", "")
+        if enc in ("utf8", "utf"):
+            continue
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[union-attr]
+        except (AttributeError, ValueError):  # pragma: no cover - non-reconfigurable stream
+            pass
+
+
 class Spinner:
     """Terminal spinner with elapsed time display."""
 
@@ -130,6 +151,13 @@ class CLIAdapter(BaseAdapter):
         self._use_colors = use_colors
         self._spinner: Spinner | None = None
         self._active_tools: set[str] = set()
+
+    def run(self, *args: Any, **kwargs: Any) -> None:
+        # Make the terminal able to encode our glyphs before any output — on a
+        # default Windows (cp1252) console this prevents a UnicodeEncodeError on
+        # the very first styled line. (gh #37)
+        _ensure_utf8_stdio()
+        return super().run(*args, **kwargs)
 
     def _c(self, code: str) -> str:
         """Return color code if colors enabled, else empty string."""

--- a/src/langgraph_stream_parser/host/config.py
+++ b/src/langgraph_stream_parser/host/config.py
@@ -356,16 +356,24 @@ class HostConfig:
         """Per-field origin from the last ``resolve()`` (field -> source)."""
         return getattr(self, "_sources", {})
 
-    def describe(self) -> str:
+    def describe(self, omit_keys: list[str] | None = None) -> str:
         """Human-readable dump: value, source, and the env var / TOML key.
 
         This is what ``python -m langgraph_stream_parser.host`` prints.
+
+        ``omit_keys`` hides inherited keys a particular stage doesn't actually
+        honor — e.g. a stdio-only sidecar passes ``omit_keys=["host", "port"]``
+        so ``--show-config`` never advertises an env var (with a confident
+        source attribution) that has zero effect on that surface.
         """
+        omit = set(omit_keys or ())
         env_map = type(self)._env_map()
         toml_map = type(self)._toml_map()
         src = self.sources
         lines = ["Resolved config  (value  [source]):", ""]
         for f in fields(self):
+            if f.name in omit:
+                continue
             value = getattr(self, f.name)
             origin = src.get(f.name, "default")
             hints = []

--- a/tests/test_cli_adapter.py
+++ b/tests/test_cli_adapter.py
@@ -50,6 +50,40 @@ class TestCLIAdapterInit:
         assert adapter._todo_types == {"tasks", "checklist"}
 
 
+class TestCLIAdapterCp1252:
+    """A default Windows console is cp1252; CLIAdapter must not crash on it (gh #37)."""
+
+    def test_run_does_not_crash_under_cp1252(self):
+        import os
+        import subprocess
+        import sys
+
+        # The README CLIAdapter example, verbatim, with the keyless stub.
+        script = (
+            "from langgraph_stream_parser.adapters import CLIAdapter\n"
+            "from langgraph_stream_parser.demo import create_stub_agent\n"
+            "CLIAdapter().run(\n"
+            "    graph=create_stub_agent(),\n"
+            "    input_data={'messages': [('user', 'Hello')]},\n"
+            "    config={'configurable': {'thread_id': 't'}},\n"
+            ")\n"
+        )
+        # PYTHONIOENCODING=cp1252 is the canonical default-Windows-console sim.
+        env = {**os.environ, "PYTHONIOENCODING": "cp1252"}
+        r = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=env,
+        )
+        assert r.returncode == 0, f"stdout={r.stdout!r} stderr={r.stderr!r}"
+        assert "UnicodeEncodeError" not in r.stderr
+        # ...and it actually rendered the echoed reply, not just survived.
+        assert "You said: Hello" in r.stdout
+
+
 class TestCLIAdapterColorHelper:
     def test_color_enabled(self):
         adapter = CLIAdapter(use_colors=True)

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -90,6 +90,20 @@ class TestIntrospection:
         ).describe()
         assert "env:DEEPAGENT_PORT" in text
 
+    def test_describe_omit_keys_hides_inert_keys(self, isolated_global, tmp_path):
+        # A stdio-only stage hides keys it doesn't honor so --show-config never
+        # advertises an env var with no effect on that surface (gh: jupyter #30,
+        # vscode #14).
+        cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
+        full = cfg.describe()
+        assert "host" in full and "port" in full
+        trimmed = cfg.describe(omit_keys=["host", "port"])
+        assert "\n  host " not in trimmed
+        assert "\n  port " not in trimmed
+        assert "LANGSTAGE_HOST" not in trimmed and "LANGSTAGE_PORT" not in trimmed
+        # keys it DOES honor are still shown
+        assert "agent_spec" in trimmed and "workspace_root" in trimmed
+
 
 class TestSubclass:
     def test_subclass_adds_keys_to_same_chain(self, isolated_global, tmp_path):


### PR DESCRIPTION
Two daily-dogfood findings.

## 1. CLIAdapter crashed on a default Windows (cp1252) console (MAJOR, #37)
It prints the message bullet, braille spinner, box-drawing, and check/cross/warn glyphs without reconfiguring stdio, so the first styled line raised UnicodeEncodeError before any output appeared (and use_colors=False only strips ANSI, not the glyphs). run() now reconfigures stdout/stderr to UTF-8 (errors=replace) up front, mirroring the langstage-cli entry point. The last surface that wasn't cp1252-safe.

Fixes #37

## 2. describe(omit_keys=[...]) for stdio stages
Added a HostConfig.describe(omit_keys=[...]) parameter so a stage can hide inherited keys it does not honor. The stdio sidecar (langstage-vscode #14) and JupyterLab launcher (langstage-jupyter #30) both advertise web-only host/port rows in --show-config -- with env-var source attributions -- that do nothing on those surfaces. Those fixes land in their repos and use this param.

## Tests
- subprocess cp1252 run of the README CLIAdapter example: exit 0, no UnicodeEncodeError, renders the echoed reply.
- describe(omit_keys) hides the named rows + their env vars, keeps honored keys.

Full suite 631 passed (lone failure is the opt-in test_real_model, skips in CI).