### PR TITLE
fix: langstage-agui --show-config omits keys the server ignores (0.6.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.6.12] - 2026-06-26
+
+### Fixed
+- **`langstage-agui --show-config` advertised `workspace_root` / `debug` /
+  `title`, which the AG-UI server ignores.** The server consumes only
+  `agent_spec`, `host`, and `port`, but `--show-config` printed all six inherited
+  `HostConfig` rows with confident env-var sources — the exact inconsistency
+  0.6.11's `describe(omit_keys=…)` was added to fix for sibling surfaces, never
+  applied to the agui CLI. It now passes `omit_keys=["workspace_root", "debug",
+  "title"]`, matching the stdio sidecar and JupyterLab launcher. (gh #39)
+
 ## [0.6.11] - 2026-06-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.11"
+version = "0.6.12"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/agui/__main__.py
+++ b/src/langgraph_stream_parser/agui/__main__.py
@@ -76,7 +76,15 @@ def main(argv: list[str] | None = None) -> int:
         host_port["port"] = args.port
 
     if args.show_config:
-        print(HostConfig.resolve(overrides=host_port).describe())
+        # The AG-UI server consumes only agent_spec/host/port. Drop the inherited
+        # workspace_root/debug/title rows so --show-config doesn't advertise env
+        # vars that have no effect on this surface (same omit_keys treatment the
+        # stdio sidecar and JupyterLab launcher already use). (gh #39)
+        print(
+            HostConfig.resolve(overrides=host_port).describe(
+                omit_keys=["workspace_root", "debug", "title"]
+            )
+        )
         return 0
 
     if args.demo and args.agent:

--- a/tests/test_agui_cli.py
+++ b/tests/test_agui_cli.py
@@ -32,3 +32,15 @@ def test_show_config_default_host_port_present(capsys):
     out = capsys.readouterr().out
     # host/port are shown (from HostConfig) — what the server will bind by default.
     assert "host" in out and "port" in out
+
+
+def test_show_config_omits_keys_the_server_ignores(capsys):
+    # The AG-UI server consumes only agent_spec/host/port; workspace_root/debug/
+    # title are inherited but inert on this surface, so --show-config must not
+    # advertise them (gh #39).
+    rc = main(["--show-config"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "agent_spec" in out and "host" in out and "port" in out
+    for inert in ("workspace_root", "debug", "title", "LANGSTAGE_TITLE", "LANGSTAGE_DEBUG"):
+        assert inert not in out, inert


### PR DESCRIPTION
From the daily dogfood routine (Fixes #39). The AG-UI server consumes only agent_spec/host/port, but --show-config printed all six inherited HostConfig rows (workspace_root/debug/title too) with confident env-var sources -- the same advertised-vs-honored inconsistency 0.6.11's describe(omit_keys) fixed for the stdio sidecar and JupyterLab launcher, just never applied to the agui CLI. Now passes omit_keys for the three inert keys. Test: agui --show-config shows agent_spec/host/port, not the inert rows.