### PR TITLE
fix: stream_mode=auto detects a pure messages-mode stream (0.6.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.6.13] - 2026-06-27
+
+### Fixed
+- **`stream_mode="auto"` silently dropped all content for a pure `messages`-mode
+  stream.** Auto-detect only recognized multi-mode `(mode, data)` tuples and v2
+  parts; a `messages` stream's first chunk is `(message, metadata)`, which fell
+  through to `"updates"` and matched none of its chunks — rendering an empty turn
+  with no error (the explicit `stream_mode="messages"` rendered fine). `_peek_and_detect`
+  / `_apeek_and_detect` now recognize a token-streaming first chunk and return
+  `"messages"`. (Found by the dogfood routine, gh #41.)
+
 ## [0.6.12] - 2026-06-26
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.12"
+version = "0.6.13"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/parser.py
+++ b/src/langgraph_stream_parser/parser.py
@@ -69,6 +69,26 @@ def _is_multi_mode(chunk: Any) -> bool:
     return False
 
 
+def _is_messages_mode_chunk(chunk: Any) -> bool:
+    """Check if a chunk is from a pure ``messages``-mode stream.
+
+    A ``messages`` stream yields ``(message_chunk, metadata)`` — chunk[0] is a
+    LangChain message token (has ``content``/``type``), chunk[1] is a metadata
+    dict. This is distinct from multi-mode ``(mode_str, data)`` (str first, caught
+    by ``_is_multi_mode``) and subgraph single-mode ``(namespace_tuple, data)``
+    (tuple first). Duck-typed so the parser needn't import ``langchain_core``.
+    """
+    if not isinstance(chunk, tuple) or len(chunk) != 2:
+        return False
+    first, second = chunk
+    return (
+        isinstance(second, dict)
+        and not isinstance(first, (str, tuple, dict))
+        and hasattr(first, "content")
+        and hasattr(first, "type")
+    )
+
+
 def _is_subgraph_single_mode(chunk: Any) -> bool:
     """Check if a chunk is from single-mode streaming with subgraphs=True.
 
@@ -613,6 +633,11 @@ class StreamParser:
         if _is_v2_stream_part(first_chunk):
             return chain([first_chunk], stream), "v2"
 
+        # A pure messages-mode stream's first chunk is (message, metadata); without
+        # this branch it fell through to "updates" and rendered nothing. (gh #41)
+        if _is_messages_mode_chunk(first_chunk):
+            return chain([first_chunk], stream), "messages"
+
         return chain([first_chunk], stream), "updates"
 
     async def _apeek_and_detect(
@@ -629,6 +654,11 @@ class StreamParser:
 
         if _is_v2_stream_part(first_chunk):
             return _async_chain(first_chunk, stream), "v2"
+
+        # A pure messages-mode stream's first chunk is (message, metadata); without
+        # this branch it fell through to "updates" and rendered nothing. (gh #41)
+        if _is_messages_mode_chunk(first_chunk):
+            return _async_chain(first_chunk, stream), "messages"
 
         return _async_chain(first_chunk, stream), "updates"
 

--- a/tests/test_auto_detect_messages.py
+++ b/tests/test_auto_detect_messages.py
@@ -1,0 +1,34 @@
+"""stream_mode="auto" detects a pure messages-mode stream (gh #41).
+
+Auto-detect used to fall through to "updates" for a messages-mode first chunk
+``(message, metadata)`` and emit zero ContentEvents — a silent empty turn.
+"""
+
+from langgraph_stream_parser import StreamParser
+from langgraph_stream_parser.demo import create_stub_agent
+from langgraph_stream_parser.events import ContentEvent
+from langgraph_stream_parser.parser import _is_messages_mode_chunk
+
+
+def _content(parser_mode):
+    graph = create_stub_agent()
+    parser = StreamParser(stream_mode=parser_mode)
+    stream = graph.stream({"messages": [("user", "Hello")]}, stream_mode="messages")
+    return "".join(e.content for e in parser.parse(stream) if isinstance(e, ContentEvent))
+
+
+def test_auto_matches_explicit_messages_mode():
+    explicit = _content("messages")
+    auto = _content("auto")
+    assert "Hello" in explicit          # sanity: messages mode renders content
+    assert auto == explicit             # auto-detect now has parity (was "")
+
+
+def test_detector_recognizes_messages_chunk():
+    from langchain_core.messages import AIMessageChunk
+
+    assert _is_messages_mode_chunk((AIMessageChunk(content="hi"), {"langgraph_node": "x"}))
+    # NOT a messages chunk: multi-mode (str first), subgraph (tuple first), plain dict.
+    assert not _is_messages_mode_chunk(("updates", {}))
+    assert not _is_messages_mode_chunk(((), {}))
+    assert not _is_messages_mode_chunk({"foo": "bar"})


### PR DESCRIPTION
From the daily dogfood routine (Fixes #41). stream_mode=auto only recognized multi-mode (mode, data) tuples and v2 parts; a messages-mode stream's first chunk is (message, metadata), which fell through to updates and matched none of its chunks -- a silent empty turn, while explicit stream_mode=messages rendered fine. _peek_and_detect / _apeek_and_detect now duck-type a token-streaming first chunk (message-like first element + metadata dict) and return messages. Tests: auto vs explicit parity on the stub; detector unit tests.