### PR TITLE
Don't forward parser-only stream modes to graph.stream() (#45)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.14"
+version = "0.6.15"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/adapters/base.py
+++ b/src/langgraph_stream_parser/adapters/base.py
@@ -31,6 +31,27 @@ from ..parser import StreamParser
 from ..resume import create_resume_input
 
 
+def graph_stream_mode(stream_mode: str | list[str]) -> str | list[str]:
+    """Translate a parser-side stream_mode into one ``graph.stream()`` accepts.
+
+    ``"auto"`` and ``"v2"`` are parser-side concepts that LangGraph's
+    ``graph.stream()`` / ``astream()`` do not understand — forwarding them
+    verbatim yields zero chunks and a silent blank turn. For ``"auto"`` we drive
+    the graph with real multi-mode streaming and let the parser auto-detect the
+    shape; ``"v2"`` cannot be produced by ``graph.stream()`` at all, so we fail
+    loudly instead of rendering nothing. Every other mode passes through. (gh #45)
+    """
+    if stream_mode == "auto":
+        return ["updates", "messages"]
+    if stream_mode == "v2":
+        raise ValueError(
+            "stream_mode='v2' is a parser-only format that graph.stream()/astream() "
+            "cannot produce. Use 'updates', 'messages', 'values', 'custom', 'auto', "
+            "or a list of modes."
+        )
+    return stream_mode
+
+
 class ToolStatus(Enum):
     """Status of a tool in its lifecycle."""
     PENDING = "pending"
@@ -213,7 +234,7 @@ class BaseAdapter(ABC):
             stream = graph.stream(
                 current_input,
                 config=config,
-                stream_mode=stream_mode,
+                stream_mode=graph_stream_mode(stream_mode),
                 **stream_kwargs,
             )
 

--- a/src/langgraph_stream_parser/adapters/fastapi.py
+++ b/src/langgraph_stream_parser/adapters/fastapi.py
@@ -29,6 +29,7 @@ from ..events import (
 )
 from ..parser import StreamParser
 from ..resume import create_resume_input, prepare_agent_input
+from .base import graph_stream_mode
 
 
 class FastAPIAdapter:
@@ -268,7 +269,7 @@ class FastAPIAdapter:
                 stream = self._graph.astream(
                     input_data,
                     config=config,
-                    stream_mode=self._stream_mode,
+                    stream_mode=graph_stream_mode(self._stream_mode),
                 )
                 async for event in parser.aparse(stream):
                     yield event

--- a/tests/test_adapter_auto_mode.py
+++ b/tests/test_adapter_auto_mode.py
@@ -1,0 +1,53 @@
+"""Adapters must not forward parser-only stream modes to graph.stream() (gh #45).
+
+`stream_mode="auto"` is advertised, but it's a parser-side concept: LangGraph's
+graph.stream() doesn't understand it and yields zero chunks, so an adapter that
+forwarded it verbatim rendered a silent blank turn. The adapter now drives the
+graph with a real multi-mode stream and lets the parser auto-detect; "v2" (which
+graph.stream cannot produce) fails loudly instead of rendering nothing.
+"""
+
+import io
+from contextlib import redirect_stdout
+
+import pytest
+
+from langgraph_stream_parser.adapters.base import graph_stream_mode
+from langgraph_stream_parser.adapters.print import PrintAdapter
+from langgraph_stream_parser.demo import create_stub_agent
+
+
+def test_graph_stream_mode_maps_auto_and_passthrough():
+    # "auto" becomes a real multi-mode the graph can stream + the parser detects.
+    assert graph_stream_mode("auto") == ["updates", "messages"]
+    # Real modes pass through untouched.
+    for m in ("updates", "messages", "custom", "values"):
+        assert graph_stream_mode(m) == m
+    assert graph_stream_mode(["updates", "messages"]) == ["updates", "messages"]
+
+
+def test_graph_stream_mode_rejects_v2():
+    with pytest.raises(ValueError, match="parser-only"):
+        graph_stream_mode("v2")
+
+
+def _run(stream_mode: str) -> str:
+    g = create_stub_agent()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        PrintAdapter().run(graph=g, input_data={"messages": [("user", "Hi")]}, stream_mode=stream_mode)
+    return buf.getvalue()
+
+
+def test_auto_renders_the_turn_like_updates():
+    auto = _run("auto")
+    updates = _run("updates")
+    # Previously `auto` rendered nothing; now it renders the reply, same as updates.
+    assert "You said: Hi" in auto, f"auto rendered nothing: {auto!r}"
+    assert "You said: Hi" in updates
+
+
+def test_v2_via_adapter_raises_not_blank():
+    g = create_stub_agent()
+    with pytest.raises(ValueError, match="parser-only"):
+        PrintAdapter().run(graph=g, input_data={"messages": [("user", "Hi")]}, stream_mode="v2")

--- a/uv.lock
+++ b/uv.lock
@@ -913,7 +913,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-stream-parser"
-version = "0.6.14"
+version = "0.6.15"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
## Problem

`stream_mode="auto"` is advertised (README "Dual Stream Mode" + the config-options list), and `StreamParser` accepts it. But `"auto"` is a **parser-side** concept — LangGraph's `graph.stream()` doesn't understand it and yields **zero chunks**. Both `BaseAdapter.run()` and `FastAPIAdapter` forwarded `stream_mode` *verbatim* to the graph, so calling any adapter with `stream_mode="auto"` rendered **nothing** — a silent blank turn, no error. The adapter owns the `graph.stream()` call, so this is the library's bug, not user error.

```python
PrintAdapter().run(graph=g, input_data=..., stream_mode="auto")     # rendered nothing
PrintAdapter().run(graph=g, input_data=..., stream_mode="updates")  # rendered the reply
```

Fixes #45.

## Fix

`graph_stream_mode()` translates parser-only modes before they reach the graph:
- `"auto"` → drive the graph with real multi-mode `["updates", "messages"]` streaming and let the parser auto-detect the shape (so `auto` renders the same as `updates`/`messages`).
- `"v2"` → a parser-only format `graph.stream()` cannot produce; raise a clear error instead of rendering nothing.
- every real mode passes through untouched.

Applied in both the sync `BaseAdapter.run()` and the async `FastAPIAdapter._iter_events()`.

## Tests

New `tests/test_adapter_auto_mode.py`: the mapping (auto→multi, passthrough, v2 rejected) + an integration check that `PrintAdapter.run(stream_mode="auto")` now renders the turn like `updates`. 46 passed across the adapter suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
