### PR TITLE
Make the FastAPI example run on the documented install (#47)

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable examples for langgraph-stream-parser."""

--- a/examples/agent.py
+++ b/examples/agent.py
@@ -1,97 +1,36 @@
-import os
-import subprocess
+"""A minimal, self-contained agent for the FastAPI streaming example.
 
-from deepagents import create_deep_agent
-from deepagents.backends import FilesystemBackend
+Keyless and dependency-light, so the WebSocket example runs with just the
+documented install — `pip install 'langgraph-stream-parser[fastapi]' uvicorn` —
+with no API key and no extra packages. It echoes the user's message back through
+a one-node LangGraph graph compiled with a checkpointer (the adapter requires one
+for threaded per-session state).
+
+Swap in your own compiled LangGraph agent for real use — e.g. a `deepagents`
+agent with real tools and a model::
+
+    pip install deepagents langchain-anthropic   # + export ANTHROPIC_API_KEY
+    from deepagents import create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    agent = create_deep_agent(name="Example", checkpointer=InMemorySaver())
+
+The adapter takes any ``CompiledGraph``.
+"""
+
+from langchain_core.messages import AIMessage
 from langgraph.checkpoint.memory import InMemorySaver
-
-# Add a think tool
-def think_tool(reflection: str) -> str:
-    """A tool to reflect on your actions and reasoning.
-
-    This tool allows you to pause and think about your next steps,
-    evaluate your current state, or reconsider your approach. Use 
-    this tool to generate internal reflections that the user can see.
-
-    Args:
-        reflection: The reflection text
-    Returns:
-        str: The recorded reflection
-    """
-    return reflection
+from langgraph.graph import END, START, MessagesState, StateGraph
 
 
-def bash(command: str, timeout: int = 60) -> dict:
-    """Execute a bash command and return the output.
+def respond(state: MessagesState) -> dict:
+    user = state["messages"][-1].content if state["messages"] else ""
+    return {"messages": [AIMessage(content=f"You said: {user}")]}
 
-    Runs the command in the workspace directory. Use this for file operations,
-    git commands, installing packages, or any shell operations.
 
-    In virtual filesystem mode (Linux only), commands run in a bubblewrap sandbox
-    with network disabled for security.
+_builder = StateGraph(MessagesState)
+_builder.add_node("respond", respond)
+_builder.add_edge(START, "respond")
+_builder.add_edge("respond", END)
 
-    Args:
-        command: The bash command to execute
-        timeout: Maximum time in seconds to wait for the command (default: 60)
-
-    Returns:
-        Dictionary containing:
-        - stdout: Standard output from the command
-        - stderr: Standard error output
-        - return_code: Exit code (0 typically means success)
-        - status: "success" or "error"
-
-    Examples:
-        # List files
-        bash("ls -la")
-
-        # Check git status
-        bash("git status")
-
-        # Install a package
-        bash("pip install pandas")
-
-        # Run a script
-        bash("python script.py")
-    """
-
-    try:
-        result = subprocess.run(
-            command,
-            shell=True,
-            cwd=os.getcwd(),
-            capture_output=True,
-            text=True,
-            timeout=timeout
-        )
-
-        return {
-            "stdout": result.stdout,
-            "stderr": result.stderr,
-            "return_code": result.returncode,
-            "status": "success" if result.returncode == 0 else "error"
-        }
-
-    except subprocess.TimeoutExpired:
-        return {
-            "stdout": "",
-            "stderr": f"Command timed out after {timeout} seconds",
-            "return_code": -1,
-            "status": "error"
-        }
-    except Exception as e:
-        return {
-            "stdout": "",
-            "stderr": str(e),
-            "return_code": -1,
-            "status": "error"
-        }
-
-backend = FilesystemBackend(root_dir=os.getcwd(), virtual_mode=True)
-agent = create_deep_agent(
-    name="Example",
-    backend=backend,
-    tools=[think_tool, bash],
-    interrupt_on=dict(bash=True),
-    checkpointer=InMemorySaver()
-)
+# The FastAPIAdapter requires a checkpointer (threaded state per session).
+agent = _builder.compile(checkpointer=InMemorySaver())

--- a/examples/fastapi_websocket.py
+++ b/examples/fastapi_websocket.py
@@ -18,11 +18,17 @@ import uuid
 
 from fastapi import FastAPI, WebSocket
 from fastapi.responses import HTMLResponse
-from dotenv import load_dotenv
 
 from langgraph_stream_parser.adapters import FastAPIAdapter
 
-load_dotenv()
+# python-dotenv is optional — only needed if you load API keys from a .env (e.g.
+# when you swap in a model-backed agent). Don't make the example crash without it.
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    pass
 
 from .agent import agent
 

--- a/tests/test_example_fastapi.py
+++ b/tests/test_example_fastapi.py
@@ -1,0 +1,37 @@
+"""The README's FastAPI example must run on the documented install (gh #47).
+
+`pip install 'langgraph-stream-parser[fastapi]' uvicorn` does not pull deepagents
+or python-dotenv, yet the example used to import both at module load — crashing
+immediately with ModuleNotFoundError. The example is now self-contained; import
+it with those packages simulated-absent to prove the documented command works.
+"""
+
+import builtins
+import sys
+
+import pytest
+
+pytest.importorskip("fastapi")  # the example imports fastapi (the [fastapi] extra)
+
+
+def test_fastapi_example_imports_without_deepagents_or_dotenv(monkeypatch):
+    orig = builtins.__import__
+
+    def blocked(name, *args, **kwargs):
+        if name.split(".")[0] in ("deepagents", "dotenv"):
+            raise ImportError(f"simulated-missing: {name}")
+        return orig(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked)
+    for mod in [k for k in sys.modules if k.startswith("examples")]:
+        del sys.modules[mod]
+
+    import examples.fastapi_websocket as ex
+
+    assert ex.app is not None  # the FastAPI app builds
+    from langchain_core.messages import HumanMessage
+
+    out = ex.agent.invoke(
+        {"messages": [HumanMessage(content="hi")]}, {"configurable": {"thread_id": "t"}}
+    )
+    assert out["messages"][-1].content == "You said: hi"


### PR DESCRIPTION
## Problem

The README's **FastAPI WebSocket Streaming** section documents:

```bash
pip install 'langgraph-stream-parser[fastapi]' uvicorn
uvicorn examples.fastapi_websocket:app --reload
```

Run verbatim on a clean install, it crashes immediately with `ModuleNotFoundError` — first on `dotenv` (`fastapi_websocket.py`), then on `deepagents` (`agent.py`). Neither is declared by the `[fastapi]` extra, and the example also needed an LLM API key — so the documented command never started the server.

Fixes #47.

## Fix

Make the example **self-contained and keyless** so the documented command works verbatim:

- `examples/agent.py` is now a minimal one-node LangGraph graph compiled with an in-memory checkpointer (the adapter requires one), echoing the user's message — no `deepagents`, no model, no API key. A docstring shows how to swap in your own (e.g. `deepagents`) agent.
- `python-dotenv` is imported **optionally** in `fastapi_websocket.py` (only useful for loading a `.env` once you wire in a model-backed agent).
- add `examples/__init__.py` so `examples.fastapi_websocket` is a proper package.

## Tests

`tests/test_example_fastapi.py`: imports the example with `deepagents` and `dotenv` **simulated-absent** (the clean-install condition) and drives one agent turn. Passes; ruff clean.

> Repo/examples + docs only — no package `src/` change, so **no new release is needed** (the wheel doesn't ship `examples/`). Merging fixes the README example on the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
