### PR TITLE
feat(agui): iter_event_frames + SessionAdapter AG-UI mode (ADR 0002, web enabler)

### DIFF
--- a/docs/adr/0002-execute-event-layer-retirement.md
+++ b/docs/adr/0002-execute-event-layer-retirement.md
@@ -131,6 +131,13 @@ usable without dragging the web-server stack (see Open questions).
 - Renaming the core package — bundled with the major that removes `events.py`, decided then.
 - Touching the host layer — it is the keeper; this ADR does not change it.
 
-**Migration progress:** cli — **done** (0.5.17, text + tools + interrupts). Next by
-the cheapest-first sequence: jupyter, then vscode, then web. Both gates cleared, so
-no surface is gate-blocked; each still migrates one PR at a time, gated on parity.
+**Migration progress:** cli (0.5.17), jupyter (0.5.13), vscode (0.4.9) — **done**,
+each opt-in behind an `[agui]` extra with full text + tools + interrupts parity.
+**web** is the last surface. Both gates cleared; each surface migrated one PR at a
+time, gated on parity.
+
+**Shared-mapping note:** cli + jupyter consume the same `stream_graph_updates`
+chunk-dict format, so their AG-UI→chunk mappings are byte-identical copies — the
+concrete dedupe target (hoist into this module). vscode is a *different* wire
+(`event_to_dict` frames) so it has its own mapping; web (SessionAdapter) will
+likely differ again. Consolidate per format-family, not one universal mapping.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.15"
+version = "0.6.16"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/adapters/session.py
+++ b/src/langgraph_stream_parser/adapters/session.py
@@ -102,6 +102,7 @@ class SessionAdapter:
         graph: Any,
         stream_mode: str | list[str] = ("updates", "messages"),
         max_result_len: int = 500,
+        agui: bool = False,
         **parser_kwargs: Any,
     ):
         self._graph = graph
@@ -110,6 +111,12 @@ class SessionAdapter:
         self._max_result_len = max_result_len
         self._parser_kwargs = parser_kwargs
         self._sessions: dict[str, Session] = {}
+        # Experimental (ADR 0002): when set, turns stream through the in-process
+        # AG-UI adapter (``agui.iter_event_frames``) instead of StreamParser,
+        # emitting the SAME ``event_to_dict`` frames. The wrapped agent is built
+        # lazily and reused (its checkpointer keys per-session by thread_id).
+        self._agui = agui
+        self._agui_agent: Any = None
 
     # ── Session lifecycle ────────────────────────────────────────────
 
@@ -170,6 +177,13 @@ class SessionAdapter:
         """
         session = self.get_or_create(session_id)
         session.cancel_current()
+        if self._agui:
+            # Reuse prepare_agent_input's context-combining, then hand the raw
+            # text to the AG-UI producer (which builds its own RunAgentInput).
+            combined = prepare_agent_input(message=content, context_parts=context_parts)
+            text = combined["messages"][0]["content"]
+            session.current_task = asyncio.create_task(self._produce_agui(session, message=text))
+            return session
         input_data = prepare_agent_input(message=content, context_parts=context_parts)
         session.current_task = asyncio.create_task(self._produce(session, input_data))
         return session
@@ -182,6 +196,11 @@ class SessionAdapter:
         """Resume a session from an interrupt with HITL decisions."""
         session = self.get_or_create(session_id)
         session.cancel_current()
+        if self._agui:
+            session.current_task = asyncio.create_task(
+                self._produce_agui(session, resume={"decisions": decisions})
+            )
+            return session
         input_data = create_resume_input(decisions=decisions)
         session.current_task = asyncio.create_task(self._produce(session, input_data))
         return session
@@ -238,6 +257,60 @@ class SessionAdapter:
                 elif isinstance(event, CompleteEvent):
                     # A Complete that follows an interrupt means "paused",
                     # not "finished" — distinguish the two for consumers.
+                    if pending_interrupt is not None:
+                        session.outcome = "interrupted"
+                        session.interrupt = pending_interrupt
+                    else:
+                        session.outcome = "complete"
+                    return
+        except asyncio.CancelledError:
+            session.outcome = "cancelled"
+            session.push({"type": "cancelled"})
+            raise
+        except Exception as exc:  # noqa: BLE001 — surfaced to the client, not swallowed
+            session.outcome = "error"
+            session.error = f"{type(exc).__name__}: {exc}"
+            session.push({"type": "error", "error": f"{type(exc).__name__}: {exc}"})
+
+    async def _produce_agui(
+        self,
+        session: Session,
+        *,
+        message: str = "",
+        resume: Any = None,
+    ) -> None:
+        """AG-UI variant of :meth:`_produce` (experimental, ADR 0002).
+
+        Sources the same ``event_to_dict`` frames from the in-process AG-UI
+        adapter instead of StreamParser, and records the identical terminal
+        outcome so headless consumers (the task runner) behave unchanged.
+        """
+        from ..agui import build_agent, iter_event_frames
+
+        session.outcome = None
+        session.interrupt = None
+        session.error = None
+        pending_interrupt: dict[str, Any] | None = None
+        if self._agui_agent is None:
+            self._agui_agent = build_agent(self._graph)
+        thread_id = session.config.get("configurable", {}).get("thread_id", session.id)
+        try:
+            async for data in iter_event_frames(
+                self._agui_agent,
+                message,
+                thread_id,
+                resume=resume,
+                max_result_len=self._max_result_len,
+            ):
+                session.push(data)
+                kind = data.get("type")
+                if kind == "interrupt":
+                    pending_interrupt = data
+                elif kind == "error":
+                    session.outcome = "error"
+                    session.error = data.get("error")
+                    return
+                elif kind == "complete":
                     if pending_interrupt is not None:
                         session.outcome = "interrupted"
                         session.interrupt = pending_interrupt

--- a/src/langgraph_stream_parser/agui/__init__.py
+++ b/src/langgraph_stream_parser/agui/__init__.py
@@ -35,6 +35,7 @@ __all__ = [
     "build_app",
     "serve",
     "ensure_available",
+    "iter_event_frames",
     "DEFAULT_AGENT_NAME",
 ]
 
@@ -221,3 +222,108 @@ def serve(
     except ImportError as e:  # pragma: no cover
         raise RuntimeError(_IMPORT_HINT) from e
     uvicorn.run(app, host=host, port=port)
+
+
+async def iter_event_frames(
+    agent: Any,
+    message: str,
+    thread_id: str,
+    *,
+    resume: Any = None,
+    max_result_len: int = 500,
+):
+    """Drive an ``ag-ui-langgraph`` agent in-process and yield ``event_to_dict``-
+    shaped frames — the SAME wire vocabulary ``StreamParser`` + ``event_to_dict``
+    emit (``content`` / ``tool_start`` / ``tool_end`` / ``interrupt`` /
+    ``complete`` / ``error``), sourced from AG-UI events instead.
+
+    This is the retirement path for surfaces on the ``event_to_dict`` wire (the
+    vscode sidecar and the web ``SessionAdapter``): swap ``StreamParser`` for the
+    in-process AG-UI adapter without changing what the client renders.
+
+    ``agent`` is an already-built ``LangGraphAgent`` (see :func:`build_agent`).
+    ``resume`` (a decision answering an interrupt) rides
+    ``forwarded_props.command.resume`` -> LangGraph ``Command(resume=...)``.
+    """
+    try:
+        from ag_ui.core.types import RunAgentInput, UserMessage
+    except ImportError as e:  # pragma: no cover - only without the extra
+        raise RuntimeError(_IMPORT_HINT) from e
+    import json
+    import uuid
+
+    allowed_decisions = ["reject", "edit", "respond", "approve"]
+    forwarded_props = {"command": {"resume": resume}} if resume is not None else {}
+    run_input = RunAgentInput(
+        thread_id=thread_id,
+        run_id=str(uuid.uuid4()),
+        state={},
+        messages=[UserMessage(id=str(uuid.uuid4()), role="user", content=message)],
+        tools=[],
+        context=[],
+        forwarded_props=forwarded_props,
+    )
+
+    streamed_text = False
+    tool_args: dict[str, str] = {}
+    tool_names: dict[str, str] = {}
+
+    async for ev in agent.run(run_input):
+        t = type(ev).__name__
+        if t == "TextMessageContentEvent":
+            streamed_text = True
+            yield {"type": "content", "content": ev.delta, "role": "assistant", "node": "agent"}
+        elif t == "ToolCallStartEvent":
+            tool_names[ev.tool_call_id] = ev.tool_call_name
+            tool_args[ev.tool_call_id] = ""
+        elif t == "ToolCallArgsEvent":
+            tool_args[ev.tool_call_id] = tool_args.get(ev.tool_call_id, "") + ev.delta
+        elif t == "ToolCallEndEvent":
+            raw = tool_args.pop(ev.tool_call_id, "")
+            try:
+                args = json.loads(raw) if raw else {}
+            except json.JSONDecodeError:
+                args = {"_raw": raw}
+            yield {
+                "type": "tool_start",
+                "id": ev.tool_call_id,
+                "name": tool_names.get(ev.tool_call_id, "tool"),
+                "args": args,
+                "node": "agent",
+            }
+        elif t == "ToolCallResultEvent":
+            result = str(getattr(ev, "content", ""))
+            if len(result) > max_result_len:
+                result = result[:max_result_len] + "…(truncated)"
+            yield {
+                "type": "tool_end",
+                "id": ev.tool_call_id,
+                "name": tool_names.get(ev.tool_call_id, "tool"),
+                "result": result,
+                "status": "success",
+                "error_message": None,
+                "duration_ms": None,
+            }
+        elif t == "CustomEvent" and getattr(ev, "name", None) == "on_interrupt":
+            payload = getattr(ev, "value", None)
+            if isinstance(payload, str):
+                try:
+                    payload = json.loads(payload)
+                except json.JSONDecodeError:
+                    payload = {}
+            payload = payload or {}
+            yield {
+                "type": "interrupt",
+                "action_requests": payload.get("action_requests", []),
+                "review_configs": payload.get("review_configs", []),
+                "allowed_decisions": payload.get("allowed_decisions", allowed_decisions),
+            }
+        elif t == "MessagesSnapshotEvent" and not streamed_text:
+            for m in ev.messages:
+                if getattr(m, "role", None) == "assistant" and getattr(m, "content", None):
+                    yield {"type": "content", "content": m.content, "role": "assistant", "node": "agent"}
+        elif t == "RunErrorEvent":
+            yield {"type": "error", "error": getattr(ev, "message", "unknown error")}
+            return
+
+    yield {"type": "complete"}

--- a/tests/test_session_agui.py
+++ b/tests/test_session_agui.py
@@ -1,0 +1,114 @@
+"""SessionAdapter's experimental AG-UI mode (ADR 0002, web surface).
+
+Verifies that streaming through the in-process AG-UI adapter emits the SAME
+``event_to_dict`` frames + terminal ``session.outcome`` as the StreamParser path.
+Skipped unless the agui extra is installed (the dev extra pulls it, so CI runs it).
+"""
+import asyncio
+from typing import Iterator, List
+
+import pytest
+
+pytest.importorskip("ag_ui_langgraph")
+pytest.importorskip("fastapi")
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.types import interrupt
+
+from langgraph_stream_parser import load_agent_spec
+from langgraph_stream_parser.adapters import SessionAdapter
+
+pytestmark = pytest.mark.asyncio
+
+
+def _drain(queue: asyncio.Queue) -> List[dict]:
+    out = []
+    while not queue.empty():
+        out.append(queue.get_nowait())
+    return out
+
+
+async def test_text_and_outcome_on_demo_stub():
+    adapter = SessionAdapter(graph=load_agent_spec("langgraph_stream_parser.demo.stub:graph"), agui=True)
+    session = adapter.submit_message(None, "hello web")
+    await session.current_task
+    frames = _drain(session.event_queue)
+    assert frames[-1]["type"] == "complete"
+    assert session.outcome == "complete"
+    assert "hello web" in "".join(f["content"] for f in frames if f["type"] == "content")
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Get the weather."""
+    return "Sunny, 72F"
+
+
+class _FakeToolModel(BaseChatModel):
+    @property
+    def _llm_type(self) -> str:
+        return "fake"
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+    def _stream(self, messages: List[BaseMessage], stop=None, run_manager=None, **kwargs) -> Iterator[ChatGenerationChunk]:
+        if any(isinstance(m, ToolMessage) for m in messages):
+            yield ChatGenerationChunk(message=AIMessageChunk(content="Sunny."))
+        else:
+            yield ChatGenerationChunk(message=AIMessageChunk(
+                content="", tool_call_chunks=[{"name": "get_weather", "args": "", "id": "c1", "index": 0}]))
+            for seg in ('{"city": ', '"PDX"}'):
+                yield ChatGenerationChunk(message=AIMessageChunk(
+                    content="", tool_call_chunks=[{"name": None, "args": seg, "id": None, "index": 0}]))
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> ChatResult:
+        chunks = list(self._stream(messages))
+        msg = chunks[0].message
+        for c in chunks[1:]:
+            msg = msg + c.message
+        return ChatResult(generations=[ChatGeneration(
+            message=AIMessage(content=msg.content, tool_calls=getattr(msg, "tool_calls", [])))])
+
+
+async def test_tool_frames():
+    from langgraph.prebuilt import create_react_agent
+
+    adapter = SessionAdapter(graph=create_react_agent(_FakeToolModel(), [get_weather]), agui=True)
+    session = adapter.submit_message(None, "weather?")
+    await session.current_task
+    frames = _drain(session.event_queue)
+    starts = [f for f in frames if f["type"] == "tool_start"]
+    ends = [f for f in frames if f["type"] == "tool_end"]
+    assert starts and starts[0]["name"] == "get_weather" and starts[0]["args"] == {"city": "PDX"}
+    assert ends and ends[0]["result"] == "Sunny, 72F"
+
+
+async def test_interrupt_then_resume_sets_outcomes():
+    def gate(state):
+        d = interrupt({"action_requests": [{"tool": "approve", "args": {"x": 1}}]})
+        return {"messages": [AIMessage(content=f"ok {d}")]}
+
+    b = StateGraph(MessagesState)
+    b.add_node("gate", gate)
+    b.add_edge(START, "gate")
+    b.add_edge("gate", END)
+    adapter = SessionAdapter(graph=b.compile(checkpointer=InMemorySaver()), agui=True)
+
+    session = adapter.submit_message("s1", "go")
+    await session.current_task
+    frames = _drain(session.event_queue)
+    assert any(f["type"] == "interrupt" for f in frames)
+    assert session.outcome == "interrupted"
+    assert session.interrupt and session.interrupt["action_requests"][0]["tool"] == "approve"
+
+    session = adapter.submit_decisions("s1", [{"type": "accept"}])
+    await session.current_task
+    resumed = _drain(session.event_queue)
+    assert session.outcome == "complete"
+    assert "ok" in "".join(f["content"] for f in resumed if f["type"] == "content")


### PR DESCRIPTION
Enables the **web** surface (the last one) to stream through the in-process AG-UI adapter.

## Additions
1. **`agui.iter_event_frames`** — the shared AG-UI → `event_to_dict` mapping (`content`/`tool_start`/`tool_end`/`interrupt`/`complete`/`error`), the same wire StreamParser + event_to_dict emit. This is the retirement path for the `event_to_dict`-format surfaces (**vscode + web**). `resume` rides `forwarded_props.command.resume`.
2. **`SessionAdapter(agui=True)`** — `submit_message`/`submit_decisions` route to a new `_produce_agui` that sources frames from `iter_event_frames` instead of StreamParser, pushing the **same serialized frames** and recording the **identical terminal outcome** (`complete`/`interrupted`/`error`/`cancelled` + `session.interrupt`) so headless consumers (the task runner) are unchanged.

## Tests
`tests/test_session_agui.py`: text+outcome, tool frames, interrupt→resume outcome transitions. Full suite **652 passed**. Default (non-agui) path untouched; requires the `[agui]` extra.

Follow-up: cowork-dash opts in via config → `SessionAdapter(agui=True)`. Also a cheap dedupe later: vscode's sidecar copy can delegate to `iter_event_frames`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)