### PR TITLE
feat(agui): add iter_chunk_frames (chunk-dict family) — ADR 0002 dedupe

### DIFF
--- a/docs/adr/0002-execute-event-layer-retirement.md
+++ b/docs/adr/0002-execute-event-layer-retirement.md
@@ -131,13 +131,23 @@ usable without dragging the web-server stack (see Open questions).
 - Renaming the core package — bundled with the major that removes `events.py`, decided then.
 - Touching the host layer — it is the keeper; this ADR does not change it.
 
-**Migration progress:** cli (0.5.17), jupyter (0.5.13), vscode (0.4.9) — **done**,
-each opt-in behind an `[agui]` extra with full text + tools + interrupts parity.
-**web** is the last surface. Both gates cleared; each surface migrated one PR at a
-time, gated on parity.
+**Migration progress: ALL FOUR SURFACES DONE** — cli (0.5.17), jupyter (0.5.13),
+vscode (0.4.9), web (langstage 0.12.3, on core 0.6.16). Each ships an opt-in
+`[agui]` path with full text + tools + interrupts parity (frame/chunk shape AND
+terminal outcome), default path untouched. Both gates cleared; each surface
+migrated one PR at a time, gated on parity.
 
-**Shared-mapping note:** cli + jupyter consume the same `stream_graph_updates`
-chunk-dict format, so their AG-UI→chunk mappings are byte-identical copies — the
-concrete dedupe target (hoist into this module). vscode is a *different* wire
-(`event_to_dict` frames) so it has its own mapping; web (SessionAdapter) will
-likely differ again. Consolidate per format-family, not one universal mapping.
+**Shared-mapping note (two format-families).**
+- *chunk-dict* (`stream_graph_updates` shape): **cli + jupyter** — byte-identical
+  copies in `langstage_cli.agui_stream` / `langstage_jupyter.agui_stream`.
+- *`event_to_dict` frames*: **vscode + web** — web uses the core's
+  `agui.iter_event_frames` (0.6.16); the vscode sidecar still has its own copy.
+
+**Remaining work (post-migration):**
+1. **Dedupe:** point the vscode sidecar at `agui.iter_event_frames` (delete its
+   copy); consider a core `agui` helper for the chunk-dict family (cli + jupyter).
+2. **Deprecate the event layer (Decision 3):** now that every first-party surface
+   has an AG-UI path, mark `StreamParser` / `events.py` / extractors deprecated,
+   then remove at the next major — *keeping* `extractors/` (hermes extends it).
+3. **Rename** the core to a `langstage-core`-style identity, bundled with that major.
+4. Flip each surface's default to AG-UI once the opt-in paths have soaked.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.16"
+version = "0.6.17"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/agui/__init__.py
+++ b/src/langgraph_stream_parser/agui/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     "serve",
     "ensure_available",
     "iter_event_frames",
+    "iter_chunk_frames",
     "DEFAULT_AGENT_NAME",
 ]
 
@@ -327,3 +328,75 @@ async def iter_event_frames(
             return
 
     yield {"type": "complete"}
+
+
+async def iter_chunk_frames(
+    agent: Any,
+    message: str,
+    thread_id: str,
+    *,
+    resume: Any = None,
+):
+    """Drive an ``ag-ui-langgraph`` agent in-process and yield ``stream_graph_updates``
+    chunk-dict frames (``{"status": "streaming", "chunk"/"tool_calls"/"tool_result": ...}``,
+    ``{"status": "interrupt", ...}``, ``{"status": "complete"}``, ``{"status": "error"}``).
+
+    The chunk-dict counterpart of :func:`iter_event_frames`: the retirement path
+    for surfaces on the ``stream_graph_updates`` wire (the cli and Jupyter render
+    loops). ``resume`` rides ``forwarded_props.command.resume``.
+    """
+    try:
+        from ag_ui.core.types import RunAgentInput, UserMessage
+    except ImportError as e:  # pragma: no cover - only without the extra
+        raise RuntimeError(_IMPORT_HINT) from e
+    import json
+    import uuid
+
+    forwarded_props = {"command": {"resume": resume}} if resume is not None else {}
+    run_input = RunAgentInput(
+        thread_id=thread_id,
+        run_id=str(uuid.uuid4()),
+        state={},
+        messages=[UserMessage(id=str(uuid.uuid4()), role="user", content=message)],
+        tools=[],
+        context=[],
+        forwarded_props=forwarded_props,
+    )
+
+    streamed_text = False
+    tool_buf: dict[str, dict[str, str]] = {}
+
+    async for ev in agent.run(run_input):
+        t = type(ev).__name__
+        if t == "TextMessageContentEvent":
+            streamed_text = True
+            yield {"status": "streaming", "chunk": ev.delta, "node": "agent"}
+        elif t == "ToolCallStartEvent":
+            tool_buf[ev.tool_call_id] = {"name": ev.tool_call_name, "args": ""}
+        elif t == "ToolCallArgsEvent":
+            tool_buf.setdefault(ev.tool_call_id, {"name": "tool", "args": ""})["args"] += ev.delta
+        elif t == "ToolCallEndEvent":
+            tc = tool_buf.pop(ev.tool_call_id, {"name": "tool", "args": ""})
+            try:
+                args = json.loads(tc["args"]) if tc["args"] else {}
+            except json.JSONDecodeError:
+                args = {"_raw": tc["args"]}
+            yield {"status": "streaming", "tool_calls": [{"name": tc["name"], "args": args}]}
+        elif t == "ToolCallResultEvent":
+            yield {"status": "streaming", "tool_result": getattr(ev, "content", "")}
+        elif t == "CustomEvent" and getattr(ev, "name", None) == "on_interrupt":
+            payload = getattr(ev, "value", None)
+            if isinstance(payload, str):
+                try:
+                    payload = json.loads(payload)
+                except json.JSONDecodeError:
+                    payload = {"action_requests": []}
+            yield {"status": "interrupt", "interrupt": payload or {"action_requests": []}}
+        elif t == "MessagesSnapshotEvent" and not streamed_text:
+            for m in ev.messages:
+                if getattr(m, "role", None) == "assistant" and getattr(m, "content", None):
+                    yield {"status": "streaming", "chunk": m.content, "node": "agent"}
+        elif t == "RunErrorEvent":
+            yield {"status": "error", "error": getattr(ev, "message", "unknown error")}
+
+    yield {"status": "complete"}

--- a/tests/test_agui_frames.py
+++ b/tests/test_agui_frames.py
@@ -1,0 +1,37 @@
+"""The two shared AG-UI mapping helpers in the agui module (ADR 0002 dedupe).
+
+``iter_event_frames`` -> event_to_dict wire (vscode + web).
+``iter_chunk_frames`` -> stream_graph_updates chunk-dict wire (cli + jupyter).
+Skipped unless the agui extra is installed (dev pulls it, so CI runs it).
+"""
+import pytest
+
+pytest.importorskip("ag_ui_langgraph")
+pytest.importorskip("fastapi")
+
+from langgraph_stream_parser import load_agent_spec
+from langgraph_stream_parser.agui import build_agent, iter_chunk_frames, iter_event_frames
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _collect(aiter):
+    return [frame async for frame in aiter]
+
+
+async def test_iter_chunk_frames_shape():
+    agent = build_agent(load_agent_spec("langgraph_stream_parser.demo.stub:graph"))
+    frames = await _collect(iter_chunk_frames(agent, "chunk wire", "t1"))
+    assert frames[-1] == {"status": "complete"}
+    content = [f for f in frames if f.get("status") == "streaming" and "chunk" in f]
+    assert content and all(set(f) == {"status", "chunk", "node"} for f in content)
+    assert "chunk wire" in "".join(f["chunk"] for f in content)
+
+
+async def test_iter_event_frames_shape():
+    agent = build_agent(load_agent_spec("langgraph_stream_parser.demo.stub:graph"))
+    frames = await _collect(iter_event_frames(agent, "event wire", "t2"))
+    assert frames[-1] == {"type": "complete"}
+    content = [f for f in frames if f.get("type") == "content"]
+    assert content and all(set(f) == {"type", "content", "role", "node"} for f in content)
+    assert "event wire" in "".join(f["content"] for f in content)


### PR DESCRIPTION
Adds the second shared AG-UI mapping to the core, the counterpart of `iter_event_frames`: AG-UI events → `stream_graph_updates` chunk-dict frames. Single source of truth for the **chunk-dict** surfaces (cli + jupyter), whose byte-identical local copies will delegate to it.

- `iter_event_frames` → `event_to_dict` wire (vscode + web) [0.6.16]
- `iter_chunk_frames` → chunk-dict wire (cli + jupyter) [this]

Test: `tests/test_agui_frames.py` asserts both mapping shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)