### PR TITLE
feat(agui): extractors= on iter_event_frames (ADR 0003 Stage 1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.17"
+version = "0.6.18"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/agui/__init__.py
+++ b/src/langgraph_stream_parser/agui/__init__.py
@@ -232,6 +232,7 @@ async def iter_event_frames(
     *,
     resume: Any = None,
     max_result_len: int = 500,
+    extractors: Any = (),
 ):
     """Drive an ``ag-ui-langgraph`` agent in-process and yield ``event_to_dict``-
     shaped frames — the SAME wire vocabulary ``StreamParser`` + ``event_to_dict``
@@ -245,6 +246,12 @@ async def iter_event_frames(
     ``agent`` is an already-built ``LangGraphAgent`` (see :func:`build_agent`).
     ``resume`` (a decision answering an interrupt) rides
     ``forwarded_props.command.resume`` -> LangGraph ``Command(resume=...)``.
+
+    ``extractors`` is an optional iterable of :class:`~langgraph_stream_parser.extractors.base.ToolExtractor`
+    (``tool_name`` / ``extracted_type`` / ``extract(content)``). After each tool
+    result, the matching extractor (by tool name) runs; a non-None return emits an
+    ``extraction`` frame identical to ``event_to_dict(ToolExtractedEvent)`` — the
+    AG-UI home for domain callouts (e.g. hermes' skill/memory events).
     """
     try:
         from ag_ui.core.types import RunAgentInput, UserMessage
@@ -254,6 +261,7 @@ async def iter_event_frames(
     import uuid
 
     allowed_decisions = ["reject", "edit", "respond", "approve"]
+    by_tool = {e.tool_name: e for e in extractors}
     forwarded_props = {"command": {"resume": resume}} if resume is not None else {}
     run_input = RunAgentInput(
         thread_id=thread_id,
@@ -296,15 +304,26 @@ async def iter_event_frames(
             result = str(getattr(ev, "content", ""))
             if len(result) > max_result_len:
                 result = result[:max_result_len] + "…(truncated)"
+            name = tool_names.get(ev.tool_call_id, "tool")
             yield {
                 "type": "tool_end",
                 "id": ev.tool_call_id,
-                "name": tool_names.get(ev.tool_call_id, "tool"),
+                "name": name,
                 "result": result,
                 "status": "success",
                 "error_message": None,
                 "duration_ms": None,
             }
+            extractor = by_tool.get(name)
+            if extractor is not None:
+                data = extractor.extract(getattr(ev, "content", ""))
+                if data is not None:
+                    yield {
+                        "type": "extraction",
+                        "tool_name": name,
+                        "extracted_type": extractor.extracted_type,
+                        "data": data,
+                    }
         elif t == "CustomEvent" and getattr(ev, "name", None) == "on_interrupt":
             payload = getattr(ev, "value", None)
             if isinstance(payload, str):

--- a/tests/test_agui_frames.py
+++ b/tests/test_agui_frames.py
@@ -35,3 +35,57 @@ async def test_iter_event_frames_shape():
     content = [f for f in frames if f.get("type") == "content"]
     assert content and all(set(f) == {"type", "content", "role", "node"} for f in content)
     assert "event wire" in "".join(f["content"] for f in content)
+
+
+async def test_iter_event_frames_runs_extractors():
+    """extractors= runs a matching extractor over each tool result and emits an
+    `extraction` frame (ADR 0003 Stage 1, productionized)."""
+    from typing import Iterator, List
+
+    from langchain_core.language_models.chat_models import BaseChatModel
+    from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, ToolMessage
+    from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+    from langchain_core.tools import tool
+    from langgraph.prebuilt import create_react_agent
+
+    @tool
+    def note(text: str) -> str:
+        """Write a note."""
+        return '{"saved": true}'
+
+    class M(BaseChatModel):
+        @property
+        def _llm_type(self):
+            return "m"
+
+        def bind_tools(self, tools, **k):
+            return self
+
+        def _stream(self, messages: List[BaseMessage], stop=None, run_manager=None, **k) -> Iterator[ChatGenerationChunk]:
+            if any(isinstance(m, ToolMessage) for m in messages):
+                yield ChatGenerationChunk(message=AIMessageChunk(content="ok"))
+            else:
+                yield ChatGenerationChunk(message=AIMessageChunk(content="", tool_call_chunks=[
+                    {"name": "note", "args": '{"text": "hi"}', "id": "c1", "index": 0}]))
+
+        def _generate(self, messages, stop=None, run_manager=None, **k) -> ChatResult:
+            cs = list(self._stream(messages)); msg = cs[0].message
+            for c in cs[1:]:
+                msg = msg + c.message
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(
+                content=msg.content, tool_calls=getattr(msg, "tool_calls", [])))])
+
+    class NoteExtractor:
+        tool_name = "note"
+        extracted_type = "note_saved"
+
+        def extract(self, content):
+            import json
+            d = json.loads(content) if isinstance(content, str) else content
+            return {"ok": bool(d.get("saved"))} if isinstance(d, dict) else None
+
+    agent = build_agent(create_react_agent(M(), [note]))
+    frames = await _collect(iter_event_frames(agent, "note hi", "tE", extractors=[NoteExtractor()]))
+    extraction = [f for f in frames if f["type"] == "extraction"]
+    assert extraction and extraction[0]["extracted_type"] == "note_saved"
+    assert extraction[0]["data"] == {"ok": True}


### PR DESCRIPTION
Productionizes the validated extractor→AG-UI bridge: `iter_event_frames(..., extractors=[...])` runs each matching extractor over its tool result and emits an `extraction` frame identical to `event_to_dict(ToolExtractedEvent)`. Unblocks hermes' migration + the event-layer retirement. Test added; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)