### PR TITLE
feat(agui): state= param on iter_*_frames (seed richer graph input)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langgraph-stream-parser"
-version = "0.6.18"
+version = "0.6.19"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langgraph_stream_parser/agui/__init__.py
+++ b/src/langgraph_stream_parser/agui/__init__.py
@@ -233,6 +233,7 @@ async def iter_event_frames(
     resume: Any = None,
     max_result_len: int = 500,
     extractors: Any = (),
+    state: Any = None,
 ):
     """Drive an ``ag-ui-langgraph`` agent in-process and yield ``event_to_dict``-
     shaped frames — the SAME wire vocabulary ``StreamParser`` + ``event_to_dict``
@@ -266,7 +267,7 @@ async def iter_event_frames(
     run_input = RunAgentInput(
         thread_id=thread_id,
         run_id=str(uuid.uuid4()),
-        state={},
+        state=dict(state or {}),
         messages=[UserMessage(id=str(uuid.uuid4()), role="user", content=message)],
         tools=[],
         context=[],
@@ -355,6 +356,7 @@ async def iter_chunk_frames(
     thread_id: str,
     *,
     resume: Any = None,
+    state: Any = None,
 ):
     """Drive an ``ag-ui-langgraph`` agent in-process and yield ``stream_graph_updates``
     chunk-dict frames (``{"status": "streaming", "chunk"/"tool_calls"/"tool_result": ...}``,
@@ -362,7 +364,8 @@ async def iter_chunk_frames(
 
     The chunk-dict counterpart of :func:`iter_event_frames`: the retirement path
     for surfaces on the ``stream_graph_updates`` wire (the cli and Jupyter render
-    loops). ``resume`` rides ``forwarded_props.command.resume``.
+    loops). ``resume`` rides ``forwarded_props.command.resume``; ``state`` seeds the
+    graph input (for agents whose input carries more than ``messages``).
     """
     try:
         from ag_ui.core.types import RunAgentInput, UserMessage
@@ -375,7 +378,7 @@ async def iter_chunk_frames(
     run_input = RunAgentInput(
         thread_id=thread_id,
         run_id=str(uuid.uuid4()),
-        state={},
+        state=dict(state or {}),
         messages=[UserMessage(id=str(uuid.uuid4()), role="user", content=message)],
         tools=[],
         context=[],

--- a/tests/test_agui_frames.py
+++ b/tests/test_agui_frames.py
@@ -89,3 +89,26 @@ async def test_iter_event_frames_runs_extractors():
     extraction = [f for f in frames if f["type"] == "extraction"]
     assert extraction and extraction[0]["extracted_type"] == "note_saved"
     assert extraction[0]["data"] == {"ok": True}
+
+
+async def test_iter_event_frames_state_passthrough():
+    """state= seeds the graph input so agents with a richer contract than
+    `messages` (e.g. hermes' iteration_budget) get their extra keys."""
+    from langgraph.checkpoint.memory import InMemorySaver
+    from langchain_core.messages import AIMessage
+    from langgraph.graph import END, START, StateGraph
+    from typing import Any as _Any
+    from typing_extensions import TypedDict
+
+    class S(TypedDict):
+        messages: _Any
+        budget: int
+
+    def node(st):
+        return {"messages": [AIMessage(content=f"budget={st.get('budget')}")]}
+
+    b = StateGraph(S); b.add_node("n", node); b.add_edge(START, "n"); b.add_edge("n", END)
+    agent = build_agent(b.compile(checkpointer=InMemorySaver()))
+    frames = await _collect(iter_event_frames(agent, "hi", "tS", state={"budget": 7}))
+    text = "".join(f["content"] for f in frames if f.get("type") == "content")
+    assert "budget=7" in text, frames


### PR DESCRIPTION
Lets surfaces pass extra graph-input keys via RunAgentInput.state (which the adapter forwards). Needed for hermes' AG-UI migration (its agent takes iteration_budget_remaining/model_override/session_id, not just messages). Test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)