### PR TITLE
docs: rewrite README for the 1.0 API (1.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## [1.0.1] - 2026-07-02
+
+### Fixed
+- **README documented the removed event-layer API.** The 1.0.0 README was only
+  name-renamed, so its body still showed `StreamParser`, `langstage_core.events`,
+  `event_to_dict`, `stream_graph_updates`, and the removed display adapters — every
+  example failed to import against the 1.0 wheel (caught by dogfooding the published
+  docs). Rewritten as a slim quickstart for the actual 1.0 surface (host + AG-UI
+  bridge + task engine + resume helpers), with a migration table. Docs-only.
+
+## [1.0.0] - 2026-07-02
+
+### Changed
+- **Renamed `langgraph-stream-parser` → `langstage-core`; retired the event layer
+  (ADR 0002 / 0003).** AG-UI is now the sole streaming wire across the LangStage
+  family. Removed `StreamParser`, `events.py`, `event_to_dict`, `compat.py`,
+  `handlers/`, the message/interrupt extractors, and the display adapters
+  (`CLIAdapter`/`PrintAdapter`/`FastAPIAdapter`/`JupyterDisplay`). `SessionAdapter`
+  is now AG-UI-only.
+- **Kept:** `load_agent_spec`, `HostConfig`, `Workspace`, `prepare_agent_input`,
+  `create_resume_input`, the `tasks` engine, `extractors` (`ToolExtractor` +
+  built-ins), and the two shared mappings `agui.iter_event_frames` /
+  `agui.iter_chunk_frames`.
+- A `langgraph-stream-parser` 1.0.0 compat shim re-exports `langstage_core` under
+  the old import name with a `DeprecationWarning`.
+
 ## [0.6.13] - 2026-06-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@
 
 # langstage-core
 
-Universal parser for LangGraph streaming outputs. Normalizes complex, variable output shapes from `graph.stream()` and `graph.astream()` into consistent, typed event objects.
+The shared core behind the **[LangStage](https://github.com/dkedar7/langstage) family**: a host layer for LangGraph agents (spec-loading + layered config), an in-process **AG-UI** bridge that streams any `CompiledGraph` to a frontend, an async task-delegation engine, and interrupt-aware input helpers. Write your agent once — any LangGraph `CompiledGraph` — and every LangStage surface runs it the same way.
+
+> **1.0 — renamed from `langgraph-stream-parser`.** The old `StreamParser` / `events` / `event_to_dict` event layer was retired in favor of the AG-UI wire (see [Migrating](#migrating-from-langgraph-stream-parser) and [ADR 0003](docs/adr/0003-deprecate-the-event-layer.md)). The old import name still works via a compat shim.
 
 ## Every stage for your LangGraph agent
 
-`langstage-core` is the shared core of the **[LangStage](https://github.com/dkedar7/langstage) family**: write your agent once — any LangGraph `CompiledGraph` — and run it on every stage with the same spec string (`module:attr` or `path/to/file.py:attr`), the same `langstage.toml` config file, and the same `LANGSTAGE_*` environment variables. (The pre-rename `deepagents.toml` / `DEEPAGENT_*` vocabulary still resolves as a deprecated fallback.)
+`langstage-core` is the shared core of the **LangStage family**: write your agent once — any LangGraph `CompiledGraph` — and run it on every stage with the same spec string (`module:attr` or `path/to/file.py:attr`), the same `langstage.toml` config file, and the same `LANGSTAGE_*` environment variables. (The pre-rename `deepagents.toml` / `DEEPAGENT_*` vocabulary still resolves as a deprecated fallback.)
 
 | Stage | Package | Try it |
 |---|---|---|
@@ -21,562 +23,121 @@ Universal parser for LangGraph streaming outputs. Normalizes complex, variable o
 
 📖 **Full documentation:** <https://dkedar7.github.io/langstage-docs/>
 
-No agent yet? Every stage has a keyless demo mode backed by this package's stub agent — no API key required:
-
-```bash
-export LANGSTAGE_AGENT_SPEC=langstage_core.demo.stub:graph  # or each CLI's --demo flag
-```
-
-And the resolved configuration (each value, its source, and the env var / `langstage.toml` key that sets it) is printable everywhere: `python -m langstage_core.host`, or each CLI's `--show-config`.
-
-## Serve any agent over AG-UI
-
-Any LangGraph agent can be served over the **[AG-UI protocol](https://github.com/ag-ui-protocol/ag-ui)** — the event-based wire format for streaming rich agent interactions (text, tool calls, reasoning, state, and human-in-the-loop interrupts) to frontends. The host layer resolves *which* agent; the official, MIT-licensed `ag-ui-langgraph` adapter owns the wire:
+## Installation
 
 ```bash
 pip install "langstage-core[agui]"
+```
+
+The `[agui]` extra pulls the AG-UI runtime (`ag-ui-langgraph[fastapi]` + `uvicorn`) — needed for the streaming bridge below and by every LangStage surface. The bare `pip install langstage-core` (only `langchain-core`) is enough if you just want the host/config/tasks layer without streaming.
+
+No agent of your own yet? The `[stub]` extra adds a keyless echo graph you can stream:
+
+```bash
+pip install "langstage-core[agui,stub]"
+```
+
+## Quick start
+
+Wrap any compiled graph with `build_agent`, then stream a turn. Two shared mappings cover the two frontend styles the family uses:
+
+```python
+import asyncio
+from langstage_core import load_agent_spec
+from langstage_core.agui import build_agent, iter_event_frames
+
+# any LangGraph CompiledGraph — here the keyless demo stub
+agent = build_agent(load_agent_spec("langstage_core.demo.stub:graph"))
+
+async def main():
+    async for frame in iter_event_frames(agent, "hello", thread_id="s1"):
+        if frame["type"] == "content":
+            print(frame["content"], end="")
+        elif frame["type"] == "complete":
+            print()
+
+asyncio.run(main())
+```
+
+- **`iter_event_frames`** yields rich, typed frames — `content`, `tool_start`, `tool_end`, `reasoning`, `interrupt`, `extraction`, `complete`, `error` — used by the web and VS Code surfaces.
+- **`iter_chunk_frames`** yields terminal-friendly chunk dicts — `{"status": "streaming", "chunk": "..."}` … `{"status": "complete"}` — used by the CLI and Jupyter surfaces.
+
+`build_agent` attaches an in-memory checkpointer if the graph has none, so multi-turn memory and interrupts work out of the box; pass a `thread_id` per turn to key per-conversation state.
+
+### Human-in-the-loop (interrupt → resume)
+
+When the graph calls `interrupt(...)`, you get an `interrupt` frame; resume by passing the decision back via `resume=`:
+
+```python
+async for frame in iter_event_frames(agent, "run it", thread_id="s1"):
+    if frame["type"] == "interrupt":
+        # frame["action_requests"], frame["allowed_decisions"]
+        ...
+
+# next turn resumes the same thread with the user's decision
+async for frame in iter_event_frames(agent, "", thread_id="s1",
+                                     resume={"decisions": [{"type": "approve"}]}):
+    ...
+```
+
+Decision types: `approve`, `reject`, `edit`, `respond` (deepagents 0.6+ / LangGraph 1.1+).
+
+## What's in the box
+
+Everything is re-exported from the top-level `langstage_core` package (except the AG-UI helpers under `langstage_core.agui`):
+
+| Area | API | What it does |
+|---|---|---|
+| **Host** | `load_agent_spec`, `HostConfig`, `Workspace` | Load a graph from a `module:attr` / `file.py:attr` spec; resolve layered config (defaults < `langstage.toml` < `LANGSTAGE_*` env < overrides). |
+| **AG-UI bridge** (`langstage_core.agui`) | `build_agent`, `iter_event_frames`, `iter_chunk_frames`, `build_app`, `serve`, `add_agui_endpoint` | Stream any `CompiledGraph` in-process (the `iter_*` mappings) or serve it as an AG-UI HTTP endpoint. |
+| **Session adapter** (`langstage_core.adapters`) | `SessionAdapter`, `Session` | A session-scoped driver over the AG-UI agent with a typed terminal `outcome` — the streaming engine behind the web app + task board. |
+| **Input helpers** | `prepare_agent_input`, `create_resume_input` | Build graph input from a message (+ optional context) or a resume decision. |
+| **Extractors** | `ToolExtractor` + built-ins (`ThinkToolExtractor`, `TodoExtractor`, `DisplayInlineExtractor`, `SkillManageExtractor`, `MemoryExtractor`, …) | Turn a tool's result into a structured `extraction` frame; pass `extractors=[...]` to the `iter_*` mappings. |
+| **Task engine** | `TaskRunner`, `TaskStore`, `InMemoryTaskStore`, `TASK_TOOLS`, `set_runner`, `get_runner` | Async delegate-and-walk-away worker pool + a persistence-agnostic store Protocol; `TASK_TOOLS` are the agent-facing delegation tools. |
+
+## Serve any agent over AG-UI
+
+Any LangGraph agent can be served over the **[AG-UI protocol](https://github.com/ag-ui-protocol/ag-ui)** — the event-based wire for streaming rich agent interactions (text, tool calls, reasoning, state, interrupts) to frontends (CopilotKit, React/Vue/Angular components, any AG-UI client). The host layer resolves *which* agent; the official MIT `ag-ui-langgraph` adapter owns the wire:
+
+```bash
 langstage-agui --agent my_agent.py:graph     # serve over AG-UI at http://localhost:8050
 langstage-agui --demo                          # keyless echo agent, no API key
 ```
 
 ```python
 from langstage_core.agui import build_app
-app = build_app(my_compiled_graph)   # an ASGI app; run with uvicorn
+app = build_app(my_compiled_graph)   # an ASGI (FastAPI) app; run with uvicorn
 ```
 
-This is the family's blessed path to the broad AG-UI frontend ecosystem (CopilotKit, React/Vue/Angular components, and any AG-UI client). See [`docs/adr/0001-adopt-ag-ui-for-the-wire.md`](docs/adr/0001-adopt-ag-ui-for-the-wire.md) for the rationale.
+See [ADR 0001](docs/adr/0001-adopt-ag-ui-for-the-wire.md) for the rationale.
 
-## Installation
+## Configuration
+
+The same resolution chain everywhere — defaults < `langstage.toml` < `LANGSTAGE_*` env < CLI/overrides (legacy `deepagents.toml` / `DEEPAGENT_*` still resolve as a deprecated fallback). Print the resolved value + source of every key:
 
 ```bash
-pip install langstage-core
+python -m langstage_core.host      # or each surface's --show-config
 ```
 
-The core depends only on `langchain-core`. The Quick Start below parses *your*
-compiled LangGraph `graph`, so you'll also have `langgraph` (and your agent's
-deps) installed. To try it end to end with **no API key and no agent of your
-own**, install the lightweight `stub` extra (just `langgraph`) for a bundled
-stub graph:
+## Migrating from langgraph-stream-parser
 
-```bash
-pip install "langstage-core[stub]"
-```
-```python
-from langstage_core.demo import create_stub_agent
-graph = create_stub_agent()   # a keyless echo agent you can stream
-```
+`langstage-core` **1.0** is the rename of `langgraph-stream-parser`. Importing the old name still works via a compat shim that re-exports `langstage_core` (with a `DeprecationWarning`), so `import langgraph_stream_parser` and its submodules keep resolving — but update to `import langstage_core` when convenient.
 
-## Quick Start
+The **event layer was removed** in 1.0. If you used it directly, migrate:
 
-```python
-from langstage_core import StreamParser
-from langstage_core.events import ContentEvent, ToolCallStartEvent, InterruptEvent
+| Removed (pre-1.0) | Use instead |
+|---|---|
+| `StreamParser`, `langstage_core.events`, `event_to_dict` | `langstage_core.agui.iter_event_frames` / `iter_chunk_frames` (frame dicts, same vocabulary) |
+| `stream_graph_updates`, `resume_graph_from_interrupt` | `iter_chunk_frames(agent, msg, thread_id, resume=...)` |
+| `adapters.CLIAdapter` / `PrintAdapter` / `FastAPIAdapter` / `JupyterDisplay` | `SessionAdapter` (in-process) or `build_app` / `serve` (HTTP), both AG-UI |
 
-parser = StreamParser()
-
-for event in parser.parse(graph.stream(input_data, stream_mode="updates")):
-    match event:
-        case ContentEvent(content=text):
-            print(text, end="")
-        case ToolCallStartEvent(name=name):
-            print(f"\nCalling {name}...")
-        case InterruptEvent(action_requests=actions):
-            # Handle human-in-the-loop
-            decision = get_user_decision(actions)
-            # Resume with create_resume_input()
-```
-
-## Features
-
-- **Typed Events**: All stream outputs normalized to dataclass events with full type hints
-- **Tool Lifecycle Tracking**: Automatic tracking of tool calls from start to completion
-- **Interrupt Handling**: Parse and resume from human-in-the-loop interrupts
-- **Extensible Extractors**: Register custom extractors for domain-specific tools
-- **Async Support**: Both sync and async parsing via `parse()` and `aparse()`
-- **Dependency-light**: only `langchain-core` at runtime; LangGraph/LangChain (and the demo agent's deps) are imported dynamically only when needed
-- **Backward Compatible**: Legacy dict-based API available for gradual migration
-
-## Event Types
-
-| Event | Description |
-|-------|-------------|
-| `ContentEvent` | Text content from AI messages. Includes `agent_name` when from a deep agent subagent. |
-| `ReasoningEvent` | Reasoning / thinking text — from langchain-core `reasoning` content blocks or `think_tool` reflections |
-| `ToolCallStartEvent` | Tool call initiated by AI |
-| `ToolCallEndEvent` | Tool call completed with result |
-| `ToolExtractedEvent` | Special content extracted from tool (e.g., todos, custom extractors) |
-| `DisplayEvent` | Rich inline content (dataframe, image, plotly, html, json) from `display_inline`-style tools |
-| `InterruptEvent` | Human-in-the-loop interrupt requiring decision |
-| `StateUpdateEvent` | Non-message state updates (opt-in) |
-| `UsageEvent` | Token usage metadata (input/output/total/cache_read/cache_creation tokens) |
-| `CustomEvent` | Custom data emitted via `get_stream_writer()` |
-| `ValuesEvent` | Full state snapshot from `stream_mode="values"` (one per super-step) |
-| `DebugEvent` | Debug, checkpoint, or task trace from v2 streaming |
-| `CompleteEvent` | Stream finished successfully |
-| `ErrorEvent` | Error during streaming |
-
-All events (except `CompleteEvent` and `ErrorEvent`) carry a `namespace` field that identifies which subgraph produced the event — `None` for the parent graph, or a tuple like `("researcher:abc123",)` for subgraphs.
-
-All events have a `to_dict()` method for JSON serialization. Use `event_to_dict(event)` for a convenient conversion function.
-
-## Usage Examples
-
-### Basic Parsing
-
-```python
-from langstage_core import StreamParser
-
-parser = StreamParser()
-
-for event in parser.parse(graph.stream({"messages": [...]}, stream_mode="updates")):
-    print(event)
-```
-
-### Pattern Matching (Python 3.10+)
-
-```python
-from langstage_core import StreamParser
-from langstage_core.events import *
-
-parser = StreamParser()
-
-for event in parser.parse(stream):
-    match event:
-        case ContentEvent(content=text, node=node):
-            print(f"[{node}] {text}", end="")
-
-        case ToolCallStartEvent(name=name, args=args):
-            print(f"\n⏳ Calling {name}...")
-
-        case ToolCallEndEvent(name=name, status="success"):
-            print(f"✅ {name} completed")
-
-        case ToolCallEndEvent(name=name, status="error", error_message=err):
-            print(f"❌ {name} failed: {err}")
-
-        case InterruptEvent() as interrupt:
-            if interrupt.needs_approval:
-                handle_approval(interrupt.action_requests)
-
-        case CompleteEvent():
-            print("\n✓ Done")
-
-        case ErrorEvent(error=err):
-            print(f"⚠️ Error: {err}")
-```
-
-### Handling Interrupts
-
-```python
-from langstage_core import StreamParser
-from langstage_core.events import InterruptEvent
-
-parser = StreamParser()
-config = {"configurable": {"thread_id": "my-thread"}}
-
-for event in parser.parse(graph.stream(input_data, config=config)):
-    if isinstance(event, InterruptEvent):
-        # Show user the pending actions
-        for action in event.action_requests:
-            print(f"Tool: {action['tool']}")
-            print(f"Args: {action['args']}")
-
-        # Check allowed decisions
-        print(f"Allowed: {event.allowed_decisions}")
-
-        # Get user decision and resume
-        decision = "approve" if input("Approve? (y/n): ") == "y" else "reject"
-        resume_input = event.create_resume(decision)
-
-        for resume_event in parser.parse(graph.stream(resume_input, config=config)):
-            handle_event(resume_event)
-        break
-```
-
-Supported decision types (deepagents 0.6+ / LangGraph 1.1+): `"approve"`, `"reject"`, `"edit"`, `"respond"`.
-
-```python
-# Edit args before approval — emits the modern ``edited_action`` shape
-resume = event.create_resume(
-    "edit",
-    args_modifier=lambda args: {**args, "safe": True},
-)
-
-# Reply with text in place of running the tool
-resume = event.create_resume("respond", response="Please rephrase that.")
-
-# For older LangGraph runtimes that expect ``{"type": "edit", "args": ...}``:
-resume = event.create_resume("edit", args_modifier=fn, use_edited_action=False)
-```
-
-### Custom Tool Extractors
-
-```python
-from langstage_core import StreamParser, ToolExtractor
-from langstage_core.events import ToolExtractedEvent
-
-class CanvasExtractor:
-    tool_name = "add_to_canvas"
-    extracted_type = "canvas_item"
-
-    def extract(self, content):
-        if isinstance(content, dict):
-            return content
-        return {"type": "text", "data": str(content)}
-
-parser = StreamParser()
-parser.register_extractor(CanvasExtractor())
-
-for event in parser.parse(stream):
-    if isinstance(event, ToolExtractedEvent) and event.extracted_type == "canvas_item":
-        add_to_canvas_ui(event.data)
-```
-
-### Async Support
-
-```python
-from langstage_core import StreamParser
-
-parser = StreamParser()
-
-async def stream_agent():
-    async for event in parser.aparse(graph.astream(input_data)):
-        handle_event(event)
-```
-
-### Dual Stream Mode (Token-Level Streaming)
-
-For real-time token streaming alongside full tool lifecycle, use dual mode:
-
-```python
-parser = StreamParser(stream_mode=["updates", "messages"])
-
-stream = graph.stream(
-    input_data, config=config,
-    stream_mode=["updates", "messages"],
-)
-
-for event in parser.parse(stream):
-    match event:
-        case ContentEvent(content=text):
-            # Token-by-token from "messages" mode
-            print(text, end="", flush=True)
-        case ToolCallStartEvent(name=name):
-            # Complete tool calls from "updates" mode
-            print(f"\nCalling {name}...")
-```
-
-The parser automatically deduplicates: `ContentEvent` comes from `"messages"` (token-level), while tool calls, interrupts, and state updates come from `"updates"`.
-
-You can also use `stream_mode="auto"` to auto-detect the format from the first chunk.
-
-### Subgraph & Deep Agent Support
-
-When streaming with `subgraphs=True`, events carry a `namespace` identifying which subgraph produced them:
-
-```python
-parser = StreamParser(stream_mode=["updates", "messages"])
-
-stream = graph.stream(
-    input_data, config=config,
-    stream_mode=["updates", "messages"],
-    subgraphs=True,
-)
-
-for event in parser.parse(stream):
-    if isinstance(event, ContentEvent):
-        if event.namespace:
-            print(f"[subagent] {event.content}", end="")
-        else:
-            print(event.content, end="")
-```
-
-For [LangChain deep agents](https://docs.langchain.com/oss/python/deepagents/subagents), `ContentEvent.agent_name` is extracted from `lc_agent_name` metadata, and `ContentEvent.is_subagent` is set to `True` when deepagents (>= 0.6) tags the run with `ls_agent_type="subagent"`. Match on either signal:
-
-```python
-case ContentEvent(content=text, agent_name=name, is_subagent=True):
-    label = f"[{name or 'subagent'}] "
-    print(f"{label}{text}", end="")
-case ContentEvent(content=text):
-    print(text, end="")
-```
-
-### Custom Stream Mode
-
-Handle custom data from `get_stream_writer()`:
-
-```python
-parser = StreamParser(stream_mode=["updates", "messages", "custom"])
-
-for event in parser.parse(stream):
-    match event:
-        case CustomEvent(data=data):
-            print(f"Progress: {data}")
-```
-
-### Reasoning & Thinking
-
-Reasoning content arrives as a distinct `ReasoningEvent` so UIs can render it differently from the final answer (greyed out, collapsed, etc.). Two sources, same event type:
-
-```python
-for event in parser.parse(stream):
-    match event:
-        case ReasoningEvent(content=text, source="content_block"):
-            # From langchain-core reasoning blocks (Anthropic thinking,
-            # OpenAI reasoning summaries). Streamed token-by-token.
-            print(f"\033[90m{text}\033[0m", end="")  # grey
-        case ReasoningEvent(content=text, source="think_tool"):
-            # From the built-in think_tool ThinkToolExtractor.
-            print(f"💭 {text}")
-        case ContentEvent(content=text):
-            print(text, end="")
-```
-
-### Rich Inline Display
-
-For agents that need to show DataFrames, charts, images, or HTML in the transcript, use a `display_inline`-style tool. The parser recognizes the convention and emits a typed `DisplayEvent` — no stringified dict hacks.
-
-**Tool side** — return a JSON string with `display_type`, `data`, `title`, `status`:
-
-```python
-def show_dataframe(df_name: str) -> str:
-    import json
-    df = load(df_name)
-    return json.dumps({
-        "type": "display_inline",
-        "display_type": "dataframe",
-        "title": df_name,
-        "data": df.to_html(),       # or fig.to_json() for plotly,
-        "status": "success",         # base64 PNG for matplotlib, etc.
-    })
-```
-
-Configure your LangGraph tool registration with `name="display_inline"` (or register a custom `DisplayInlineExtractor` for a different name).
-
-**Consumer side** — match on `DisplayEvent`:
-
-```python
-for event in parser.parse(stream):
-    match event:
-        case DisplayEvent(display_type="dataframe", data=html, title=title):
-            ui.show_html(f"<h3>{title}</h3>{html}")
-        case DisplayEvent(display_type="plotly", data=plotly_json):
-            ui.show_plotly(json.loads(plotly_json))
-        case DisplayEvent(display_type=kind, data=data):
-            ui.show_generic(kind, data)
-```
-
-The `display_type` field is consumer-defined — any string the tool and UI agree on. Common values: `"dataframe"`, `"image"`, `"plotly"`, `"html"`, `"json"`.
-
-### Configuration Options
-
-```python
-parser = StreamParser(
-    # Stream format to expect (default: "updates")
-    stream_mode="updates",  # or "messages", "custom", "values", "auto", or a list
-
-    # Track tool call lifecycle (start -> end)
-    track_tool_lifecycle=True,
-
-    # Skip these tools entirely (no events emitted)
-    skip_tools=["internal_tool"],
-
-    # Include StateUpdateEvent for non-message state keys
-    include_state_updates=False,
-)
-```
-
-## Legacy Dict-Based API
-
-For backward compatibility or simpler use cases:
-
-```python
-from langstage_core import stream_graph_updates, resume_graph_from_interrupt
-
-for update in stream_graph_updates(agent, input_data, config=config):
-    if update.get("status") == "interrupt":
-        interrupt = update["interrupt"]
-        # Handle interrupt...
-    elif "chunk" in update:
-        print(update["chunk"], end="")
-    elif "tool_calls" in update:
-        print(f"Calling tools: {update['tool_calls']}")
-    elif update.get("status") == "complete":
-        break
-
-# Resume from interrupt
-for update in resume_graph_from_interrupt(agent, decisions=[{"type": "approve"}], config=config):
-    handle_update(update)
-```
-
-## Display Adapters
-
-Pre-built adapters for rendering stream events in different environments:
-
-### CLIAdapter - Styled Terminal Output
-
-```python
-from langstage_core.adapters import CLIAdapter
-
-adapter = CLIAdapter()
-adapter.run(
-    graph=agent,
-    input_data={"messages": [("user", "Hello")]},
-    config={"configurable": {"thread_id": "my-thread"}}
-)
-```
-
-Features:
-- ANSI color formatting
-- Spinner animation during tool execution
-- Interactive arrow-key interrupt handling
-
-### PrintAdapter - Plain Text Output
-
-```python
-from langstage_core.adapters import PrintAdapter
-
-adapter = PrintAdapter()
-adapter.run(graph=agent, input_data=input_data, config=config)
-```
-
-Universal output that works in any Python environment without dependencies.
-
-### FastAPIAdapter - WebSocket / SSE Streaming
-
-Stream events to a web client over WebSocket or Server-Sent Events. The adapter is stateless — conversation state lives in LangGraph's checkpointer, keyed by `session_id` (used as `thread_id`).
-
-```python
-from fastapi import FastAPI, WebSocket
-from langstage_core.adapters import FastAPIAdapter
-
-app = FastAPI()
-adapter = FastAPIAdapter(graph=agent)  # agent must be compiled with a checkpointer
-
-@app.websocket("/chat/{session_id}")
-async def chat(ws: WebSocket, session_id: str):
-    await adapter.handle_websocket(ws, session_id)
-```
-
-Reconnecting with the same `session_id` resumes the conversation — LangGraph's checkpointer rehydrates history automatically.
-
-**WebSocket message protocol (client ↔ server)**
-
-Client → Server:
-
-```jsonc
-{"type": "message", "content": "Hello"}
-{"type": "decision", "decisions": [{"type": "approve"}]}
-{"type": "decision", "decisions": [{"type": "edit", "args": {...}}]}
-{"type": "cancel"}
-```
-
-Server → Client: every event's `to_dict()` output (e.g. `{"type": "content", ...}`, `{"type": "tool_start", ...}`, `{"type": "interrupt", ...}`, `{"type": "complete"}`), plus protocol-level messages:
-
-```jsonc
-{"type": "ack", "ref": "message|decision|cancel"}
-{"type": "error", "error": "..."}
-```
-
-**Server-Sent Events**
-
-```python
-from fastapi.responses import StreamingResponse
-from langstage_core import prepare_agent_input
-
-@app.post("/chat/{session_id}")
-async def chat(session_id: str, body: dict):
-    input_data = prepare_agent_input(message=body["message"])
-    return StreamingResponse(
-        adapter.sse_stream(session_id, input_data),
-        media_type="text/event-stream",
-    )
-
-@app.post("/chat/{session_id}/resume")
-async def resume(session_id: str, body: dict):
-    return StreamingResponse(
-        adapter.resume(session_id, body["decisions"]),
-        media_type="text/event-stream",
-    )
-```
-
-Requires: `pip install langstage-core[fastapi]`
-
-### JupyterDisplay - Rich Notebook Display
-
-```python
-from langstage_core.adapters.jupyter import JupyterDisplay
-
-display = JupyterDisplay()
-display.run(graph=agent, input_data=input_data, config=config)
-```
-
-Requires: `pip install langstage-core[jupyter]`
-
-### Adapter Options
-
-All adapters support:
-
-```python
-adapter = CLIAdapter(
-    show_tool_args=True,           # Show tool arguments
-    max_content_preview=200,       # Max chars for extracted content
-    reflection_types={"thinking"}, # Custom reflection type names
-    todo_types={"tasks"},          # Custom todo type names
-)
-```
-
-### Custom Adapters
-
-Extend `BaseAdapter` for custom rendering:
-
-```python
-from langstage_core.adapters import BaseAdapter
-
-class MyAdapter(BaseAdapter):
-    def render(self):
-        # Implement your rendering logic
-        pass
-
-    def prompt_interrupt(self, event):
-        # Handle interrupt prompts
-        return [{"type": "approve"}]
-```
-
-## Built-in Extractors
-
-The package includes extractors for common LangGraph tools:
-
-- **ThinkToolExtractor**: Extracts reflections from `think_tool`
-- **TodoExtractor**: Extracts todo lists from `write_todos`
-- **DisplayInlineExtractor**: Extracts inline display artifacts from `display_inline`
-
-## Examples
-
-### FastAPI WebSocket Streaming
-
-See [examples/fastapi_websocket.py](examples/fastapi_websocket.py) for a complete example using `FastAPIAdapter` to stream LangGraph events to a web client.
-
-```bash
-# Install dependencies
-pip install 'langstage-core[fastapi]' uvicorn
-
-# Run the example
-uvicorn examples.fastapi_websocket:app --reload
-
-# Open http://localhost:8000 in your browser
-```
+Kept and unchanged: `load_agent_spec`, `HostConfig`, `prepare_agent_input`, `create_resume_input`, the `tasks` engine, and the `extractors` (`ToolExtractor` + built-ins). Full detail: [ADR 0003](docs/adr/0003-deprecate-the-event-layer.md).
 
 ## Development
 
 ```bash
-# Install with dev dependencies
 pip install -e ".[dev]"
-
-# Run tests
 pytest
-
-# Run tests with coverage
 pytest --cov=langstage_core
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.0"
+version = "1.0.1"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Dogfooding the published docs against the 1.0.0 wheel found the **README still documented the removed event-layer API** — `StreamParser`, `langstage_core.events`, `event_to_dict`, `stream_graph_updates`, and the removed display adapters. Every code example on the flagship package's front page raised `ImportError` against the shipped 1.0.0 (it was only name-renamed during the rename, never rewritten).

Rewritten as a **slim quickstart for the actual 1.0 surface**:
- `build_agent` + `iter_event_frames` / `iter_chunk_frames` quickstart (verified verbatim in a clean room), plus the interrupt→resume flow.
- A "what's in the box" cheatsheet: host (`load_agent_spec`/`HostConfig`), AG-UI bridge, `SessionAdapter`, input helpers, extractors, task engine.
- The AG-UI serve path, config resolution, and a **migration table** from the removed API.
- Backfills the skipped **1.0.0** changelog entry.

Doc-only **1.0.1** so the PyPI project page stops teaching a deleted API. Surfaces pin `langstage-core[agui]>=1.0`, so 1.0.1 satisfies them with no re-release.

Closes the headline gap from the AG-UI-migration dogfood (backlog opp #6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)