### PR TITLE
Fix langstage-agui --show-config ignoring --agent (gh #60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.0.2] - 2026-07-02
+
+### Fixed
+- **`langstage-agui --show-config` ignored `--agent` (gh #60).** The `--show-config`
+  branch resolved `HostConfig` with only the host/port overrides — the `--agent`
+  spec was applied later, after the early return — so `--show-config --agent X`
+  reported `agent_spec = None` while `serve()` honored the flag (advertised ≠
+  honored). The `--agent`/`--host`/`--port` overrides are now resolved once, before
+  the branch, so the shown config matches the real run. Regression-tested.
+
 ## [1.0.1] - 2026-07-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.1"
+version = "1.0.2"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/agui/__main__.py
+++ b/src/langstage_core/agui/__main__.py
@@ -67,34 +67,36 @@ def main(argv: list[str] | None = None) -> int:
 
     from ..host import HostConfig
 
-    # CLI --host/--port are overrides on the resolved config so --show-config and
-    # the actual bind always agree (and env / langstage.toml host/port work).
-    host_port = {}
+    if args.demo and args.agent:
+        print("error: --demo and --agent are mutually exclusive", file=sys.stderr)
+        return 2
+
+    # CLI flags are overrides on the resolved config so --show-config and the actual
+    # bind always agree (and env / langstage.toml host/port/agent work). --agent must
+    # be applied HERE, before the --show-config branch — otherwise --show-config
+    # resolved without it and reported agent_spec = None while serving used the flag
+    # (advertised != honored). (gh #60)
+    overrides: dict = {}
     if args.host is not None:
-        host_port["host"] = args.host
+        overrides["host"] = args.host
     if args.port is not None:
-        host_port["port"] = args.port
+        overrides["port"] = args.port
+    if not args.demo:
+        overrides["agent_spec"] = args.agent
+
+    cfg = HostConfig.resolve(overrides=overrides)
 
     if args.show_config:
         # The AG-UI server consumes only agent_spec/host/port. Drop the inherited
         # workspace_root/debug/title rows so --show-config doesn't advertise env
         # vars that have no effect on this surface (same omit_keys treatment the
         # stdio sidecar and JupyterLab launcher already use). (gh #39)
-        print(
-            HostConfig.resolve(overrides=host_port).describe(
-                omit_keys=["workspace_root", "debug", "title"]
-            )
-        )
+        described = cfg.describe(omit_keys=["workspace_root", "debug", "title"])
+        if args.demo:
+            described += f"\n  demo: agent_spec resolves to {DEMO_SPEC}"
+        print(described)
         return 0
 
-    if args.demo and args.agent:
-        print("error: --demo and --agent are mutually exclusive", file=sys.stderr)
-        return 2
-
-    overrides = dict(host_port)
-    if not args.demo:
-        overrides["agent_spec"] = args.agent
-    cfg = HostConfig.resolve(overrides=overrides)
     spec: str | None = DEMO_SPEC if args.demo else cfg.agent_spec
 
     if not spec:

--- a/tests/test_agui_cli.py
+++ b/tests/test_agui_cli.py
@@ -26,6 +26,18 @@ def test_show_config_reflects_port_override(capsys):
     assert "[override]" in out
 
 
+def test_show_config_reflects_agent_override(capsys):
+    # gh #60: --show-config resolved without the --agent override and reported
+    # agent_spec = None while serve() honored the flag (advertised != honored).
+    # --agent is now applied before the --show-config branch, so the shown config
+    # matches the real run.
+    rc = main(["--show-config", "--agent", "my_agent.py:graph"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "my_agent.py:graph" in out
+    assert "[override]" in out
+
+
 def test_show_config_default_host_port_present(capsys):
     rc = main(["--show-config"])
     assert rc == 0


### PR DESCRIPTION
Closes #60.

`langstage-agui --show-config --agent my_agent.py:graph` reported `agent_spec = None`, while actually serving with the same flag honored it — the shown config disagreed with the real run. Root cause: the `--show-config` branch resolved `HostConfig` with only the host/port overrides; `--agent` was added to the overrides *after* the branch's early return.

Fix: resolve the `--agent`/`--host`/`--port` overrides once, before the `--show-config` branch, so both paths use the same config. `--show-config --demo` now also notes the demo spec. Regression test added.

`1.0.1 → 1.0.2`. Docs/CLI-only; the streaming/host API is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)