### PR TITLE
Harden config: don't crash on malformed TOML; warn on legacy deepagents.toml (gh #42, #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [1.0.3] - 2026-07-02
+
+### Fixed
+- **A malformed config file crashed every entrypoint (gh #42).** Config resolves at
+  import time on several surfaces, so a raw `TOMLDecodeError` (or an unreadable
+  file) from a broken `langstage.toml` killed `--version` / `--help` / `--demo`,
+  the `deepagent-*` aliases, the server extension, and even `import langstage_jupyter`
+  — not just the command that needed the config. `_read_toml` now skips a bad file
+  with a visible one-line notice and falls back to environment + defaults.
+
+### Added
+- **Legacy `deepagents.toml` now emits a deprecation notice (gh #25).** The legacy
+  `DEEPAGENT_*` env vars already warned on use, but a legacy `deepagents.toml`
+  (project) or `~/.deepagents/config.toml` (global) resolved silently. It now raises
+  a once-per-file `DeprecationWarning` + a visible stderr notice (same
+  `LANGSTAGE_SUPPRESS_LEGACY_NOTICE=1` opt-out and pytest suppression as the env
+  notice), closing the advertised-parity gap.
+
 ## [1.0.2] - 2026-07-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.2"
+version = "1.0.3"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/host/config.py
+++ b/src/langstage_core/host/config.py
@@ -107,6 +107,41 @@ def _print_legacy_env_notice(legacy: str, canonical: str) -> None:
     )
 
 
+_warned_legacy_toml: set[str] = set()
+
+
+def _warn_legacy_toml(path: Path, canonical_name: str) -> None:
+    """Visible deprecation notice when a legacy-named TOML file is resolved
+    (project ``deepagents.toml`` or global ``~/.deepagents/config.toml``).
+
+    The legacy ``DEEPAGENT_*`` *env vars* already warn on use, but the legacy
+    *TOML* files resolved silently — so a user who moved their env to
+    ``LANGSTAGE_*`` but kept a ``deepagents.toml`` got no nudge (the same
+    advertised-parity gap the env notice closes). Same once-per-file dedupe,
+    ``LANGSTAGE_SUPPRESS_LEGACY_NOTICE`` opt-out, and pytest suppression as
+    ``_warn_legacy_env``. (gh #25)
+    """
+    key = str(path)
+    if key in _warned_legacy_toml:
+        return
+    _warned_legacy_toml.add(key)
+    if _env_bool(os.getenv("LANGSTAGE_SUPPRESS_LEGACY_NOTICE")):
+        return
+    warnings.warn(
+        f"{path} is deprecated; rename it to {canonical_name}.",
+        DeprecationWarning,
+        stacklevel=4,
+    )
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        return
+    print(
+        f"note: config file {path} uses the legacy name; rename it to "
+        f"{canonical_name}. (Legacy deepagents.toml support will be removed in a "
+        "future release; set LANGSTAGE_SUPPRESS_LEGACY_NOTICE=1 to silence.)",
+        file=sys.stderr,
+    )
+
+
 def _env_bool(value: str | None, default: bool = False) -> bool:
     """Parse an env-var string into a bool."""
     if value is None or value == "":
@@ -160,7 +195,20 @@ def _read_toml(path: Path) -> dict:
     # Windows, and `tomllib.load()` (binary) chokes on it with a cryptic
     # "Invalid statement (at line 1, column 1)" — which, because jupyter's
     # config resolves at import time, bricked the whole extension. (gh #-dogfood)
-    return _tomllib.loads(path.read_text(encoding="utf-8-sig"))
+    try:
+        return _tomllib.loads(path.read_text(encoding="utf-8-sig"))
+    except Exception as exc:  # noqa: BLE001 — a broken config must not brick every entrypoint
+        # Several surfaces resolve config at import time, so a raw TOMLDecodeError
+        # (or an unreadable file) here would kill --version / --help / --demo,
+        # `import langstage_jupyter`, and the server extension — not just the command
+        # that needs the config. Skip the bad file with a visible one-line notice and
+        # fall back to env + defaults. ASCII-only (cp1252-safe). (gh #42)
+        print(
+            f"note: ignoring malformed config {path} "
+            f"({type(exc).__name__}: {exc}); using environment + defaults instead.",
+            file=sys.stderr,
+        )
+        return {}
 
 
 def load_toml_config(start: Path | None = None) -> tuple[dict, list[Path]]:
@@ -182,10 +230,14 @@ def load_toml_config(start: Path | None = None) -> tuple[dict, list[Path]]:
     if gpath.is_file():
         merged = _deep_merge(merged, _read_toml(gpath))
         sources.append(gpath)
+        if gpath == LEGACY_GLOBAL_TOML:
+            _warn_legacy_toml(gpath, str(GLOBAL_TOML))
     ppath = _find_project_toml(start)
     if ppath is not None:
         merged = _deep_merge(merged, _read_toml(ppath))
         sources.append(ppath)
+        if ppath.name == LEGACY_PROJECT_TOML:
+            _warn_legacy_toml(ppath, PROJECT_TOML)
     return merged, sources
 
 

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -216,6 +216,51 @@ class TestLangstageVocabulary:
         cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
         assert cfg.port == 8123
 
+    def test_malformed_toml_does_not_crash(self, isolated_global, tmp_path, capsys):
+        # gh #42: a broken langstage.toml must NOT crash resolve(). Config resolves
+        # at import time on several surfaces, so a raw TOMLDecodeError bricked
+        # --version / --help / --demo and even `import langstage_jupyter`. The bad
+        # file is skipped (with a visible notice); env + defaults still resolve.
+        (tmp_path / "langstage.toml").write_text("this is not = [valid toml\n")
+        cfg = HostConfig.resolve(env={"LANGSTAGE_PORT": "7777"}, toml_start=tmp_path)
+        assert cfg.port == 7777  # env layer still applies; the bad TOML was ignored
+        err = capsys.readouterr().err
+        assert "ignoring malformed config" in err and "langstage.toml" in err
+        err.encode("cp1252")  # ASCII-only — must not crash a cp1252 console
+
+    def test_legacy_toml_warns(self, isolated_global, tmp_path):
+        # gh #25: legacy DEEPAGENT_* env warns, but a legacy deepagents.toml used to
+        # resolve silently. It now raises a DeprecationWarning too.
+        import langstage_core.host.config as config_mod
+
+        p = tmp_path / "deepagents.toml"
+        p.write_text("[server]\nport = 1234\n")
+        config_mod._warned_legacy_toml.discard(str(p))
+        with pytest.warns(DeprecationWarning, match="deepagents.toml"):
+            HostConfig.resolve(env={}, toml_start=tmp_path)
+
+    def test_legacy_toml_prints_visible_notice(self, isolated_global, tmp_path, monkeypatch, capsys):
+        import langstage_core.host.config as config_mod
+
+        p = tmp_path / "deepagents.toml"
+        p.write_text("[server]\nport = 1234\n")
+        config_mod._warned_legacy_toml.discard(str(p))
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("LANGSTAGE_SUPPRESS_LEGACY_NOTICE", raising=False)
+        HostConfig.resolve(env={}, toml_start=tmp_path)
+        err = capsys.readouterr().err
+        assert "deepagents.toml" in err and "legacy name" in err and "langstage.toml" in err
+        err.encode("cp1252")
+
+    def test_legacy_toml_notice_silent_under_pytest(self, isolated_global, tmp_path, capsys):
+        import langstage_core.host.config as config_mod
+
+        p = tmp_path / "deepagents.toml"
+        p.write_text("[server]\nport = 1234\n")
+        config_mod._warned_legacy_toml.discard(str(p))
+        HostConfig.resolve(env={}, toml_start=tmp_path)  # PYTEST_CURRENT_TEST set
+        assert "legacy name" not in capsys.readouterr().err
+
     def test_nearest_toml_wins_across_dirs(self, isolated_global, tmp_path):
         # langstage.toml in the parent must NOT beat deepagents.toml in cwd.
         (tmp_path / "langstage.toml").write_text("[server]\nport = 1000\n")


### PR DESCRIPTION
Two cross-family config fixes in the shared host layer — both affect every surface.

**gh #42 (langstage-jupyter) — a malformed `langstage.toml` crashed every entrypoint.** Config resolves at import time on several surfaces, so a raw `TOMLDecodeError` from `_read_toml` killed `--version` / `--help` / `--demo`, the `deepagent-*` aliases, the server extension, and even `import langstage_jupyter`. Now `_read_toml` skips a bad file with a visible one-line notice and falls back to env + defaults. **Verified: `import langstage_jupyter` with a broken `langstage.toml` now succeeds** (was a hard crash).

**gh #25 (langstage-vscode) — legacy `deepagents.toml` resolved silently.** The legacy `DEEPAGENT_*` env vars already warned on use, but the legacy TOML files did not. Added `_warn_legacy_toml` (once-per-file `DeprecationWarning` + stderr notice, same `LANGSTAGE_SUPPRESS_LEGACY_NOTICE=1` opt-out and pytest suppression as the env notice), wired into `load_toml_config`.

4 regression tests added; host-config suite green. `1.0.2 → 1.0.3`. Surfaces pin `>=1.0`, so they inherit both fixes on next install.

Fixes dkedar7/langstage-jupyter#42 and dkedar7/langstage-vscode#25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)