### PR TITLE
AG-UI frames carry the real langgraph node, not a fixed 'agent' (gh #43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.0.4] - 2026-07-02
+
+### Fixed
+- **AG-UI frames now carry the real langgraph node instead of a fixed `"agent"`
+  (gh #43, langstage-cli).** `iter_event_frames` / `iter_chunk_frames` hardcoded
+  `node="agent"` on every content/tool frame, so a multi-node graph's output was
+  indistinguishable — the CLI (which starts a new marker on a node change) rendered
+  two nodes' messages as one unreadable run-on. The node now tracks
+  `StepStartedEvent.step_name`, and the non-streaming `MessagesSnapshotEvent` path
+  maps trailing assistant messages back to their steps. Single-node graphs (node
+  `"agent"`) are unchanged; renderers can now separate per-node output.
+
 ## [1.0.3] - 2026-07-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.3"
+version = "1.0.4"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/agui/__init__.py
+++ b/src/langstage_core/agui/__init__.py
@@ -277,12 +277,22 @@ async def iter_event_frames(
     streamed_text = False
     tool_args: dict[str, str] = {}
     tool_names: dict[str, str] = {}
+    # The langgraph node currently executing, from StepStartedEvent — so a
+    # multi-node graph's frames carry the real node instead of a fixed "agent",
+    # letting renderers separate one node's output from the next (gh #43).
+    current_node = "agent"
+    step_nodes: list[str] = []
 
     async for ev in agent.run(run_input):
         t = type(ev).__name__
-        if t == "TextMessageContentEvent":
+        if t == "StepStartedEvent":
+            step = getattr(ev, "step_name", None)
+            if step:
+                current_node = step
+                step_nodes.append(step)
+        elif t == "TextMessageContentEvent":
             streamed_text = True
-            yield {"type": "content", "content": ev.delta, "role": "assistant", "node": "agent"}
+            yield {"type": "content", "content": ev.delta, "role": "assistant", "node": current_node}
         elif t == "ToolCallStartEvent":
             tool_names[ev.tool_call_id] = ev.tool_call_name
             tool_args[ev.tool_call_id] = ""
@@ -299,7 +309,7 @@ async def iter_event_frames(
                 "id": ev.tool_call_id,
                 "name": tool_names.get(ev.tool_call_id, "tool"),
                 "args": args,
-                "node": "agent",
+                "node": current_node,
             }
         elif t == "ToolCallResultEvent":
             result = str(getattr(ev, "content", ""))
@@ -340,9 +350,18 @@ async def iter_event_frames(
                 "allowed_decisions": payload.get("allowed_decisions", allowed_decisions),
             }
         elif t == "MessagesSnapshotEvent" and not streamed_text:
-            for m in ev.messages:
-                if getattr(m, "role", None) == "assistant" and getattr(m, "content", None):
-                    yield {"type": "content", "content": m.content, "role": "assistant", "node": "agent"}
+            # Non-streaming graphs deliver content in one final snapshot; map the
+            # trailing assistant messages back to the steps that produced them so a
+            # multi-node graph renders one block per node, not a run-on (gh #43).
+            assistant = [
+                m for m in ev.messages
+                if getattr(m, "role", None) == "assistant" and getattr(m, "content", None)
+            ]
+            offset = max(0, len(assistant) - len(step_nodes))
+            for i, m in enumerate(assistant):
+                idx = i - offset
+                node = step_nodes[idx] if 0 <= idx < len(step_nodes) else current_node
+                yield {"type": "content", "content": m.content, "role": "assistant", "node": node}
         elif t == "RunErrorEvent":
             yield {"type": "error", "error": getattr(ev, "message", "unknown error")}
             return
@@ -387,12 +406,22 @@ async def iter_chunk_frames(
 
     streamed_text = False
     tool_buf: dict[str, dict[str, str]] = {}
+    # The langgraph node currently executing (from StepStartedEvent) so a multi-node
+    # graph's chunks carry the real node instead of a fixed "agent" — renderers use
+    # it to separate one node's output from the next (gh #43).
+    current_node = "agent"
+    step_nodes: list[str] = []
 
     async for ev in agent.run(run_input):
         t = type(ev).__name__
-        if t == "TextMessageContentEvent":
+        if t == "StepStartedEvent":
+            step = getattr(ev, "step_name", None)
+            if step:
+                current_node = step
+                step_nodes.append(step)
+        elif t == "TextMessageContentEvent":
             streamed_text = True
-            yield {"status": "streaming", "chunk": ev.delta, "node": "agent"}
+            yield {"status": "streaming", "chunk": ev.delta, "node": current_node}
         elif t == "ToolCallStartEvent":
             tool_buf[ev.tool_call_id] = {"name": ev.tool_call_name, "args": ""}
         elif t == "ToolCallArgsEvent":
@@ -415,9 +444,18 @@ async def iter_chunk_frames(
                     payload = {"action_requests": []}
             yield {"status": "interrupt", "interrupt": payload or {"action_requests": []}}
         elif t == "MessagesSnapshotEvent" and not streamed_text:
-            for m in ev.messages:
-                if getattr(m, "role", None) == "assistant" and getattr(m, "content", None):
-                    yield {"status": "streaming", "chunk": m.content, "node": "agent"}
+            # Non-streaming graphs deliver content in one final snapshot; map the
+            # trailing assistant messages back to the steps that produced them so a
+            # multi-node graph renders one block per node, not a run-on (gh #43).
+            assistant = [
+                m for m in ev.messages
+                if getattr(m, "role", None) == "assistant" and getattr(m, "content", None)
+            ]
+            offset = max(0, len(assistant) - len(step_nodes))
+            for i, m in enumerate(assistant):
+                idx = i - offset
+                node = step_nodes[idx] if 0 <= idx < len(step_nodes) else current_node
+                yield {"status": "streaming", "chunk": m.content, "node": node}
         elif t == "RunErrorEvent":
             yield {"status": "error", "error": getattr(ev, "message", "unknown error")}
 

--- a/tests/test_agui_frames.py
+++ b/tests/test_agui_frames.py
@@ -37,6 +37,37 @@ async def test_iter_event_frames_shape():
     assert "event wire" in "".join(f["content"] for f in content)
 
 
+def _two_node_graph():
+    """A graph with two distinct content-emitting nodes ("first", "second")."""
+    from langchain_core.messages import AIMessage
+    from langgraph.graph import END, START, MessagesState, StateGraph
+
+    b = StateGraph(MessagesState)
+    b.add_node("first", lambda s: {"messages": [AIMessage(content="from first.")]})
+    b.add_node("second", lambda s: {"messages": [AIMessage(content="from second.")]})
+    b.add_edge(START, "first")
+    b.add_edge("first", "second")
+    b.add_edge("second", END)
+    return b.compile()
+
+
+async def test_chunk_frames_carry_real_node_names():
+    # gh #43: a multi-node graph's chunks used to all report node="agent", so the
+    # CLI (which separates output on a node change) rendered them as one run-on. The
+    # node now comes from the langgraph step, so distinct nodes are distinguishable.
+    frames = await _collect(iter_chunk_frames(build_agent(_two_node_graph()), "hi", "tn1"))
+    by_text = {f["chunk"]: f["node"] for f in frames if "chunk" in f}
+    assert by_text.get("from first.") == "first"
+    assert by_text.get("from second.") == "second"
+
+
+async def test_event_frames_carry_real_node_names():
+    frames = await _collect(iter_event_frames(build_agent(_two_node_graph()), "hi", "tn2"))
+    by_text = {f["content"]: f["node"] for f in frames if f.get("type") == "content"}
+    assert by_text.get("from first.") == "first"
+    assert by_text.get("from second.") == "second"
+
+
 async def test_iter_event_frames_runs_extractors():
     """extractors= runs a matching extractor over each tool result and emits an
     `extraction` frame (ADR 0003 Stage 1, productionized)."""


### PR DESCRIPTION
Root-cause fix for langstage-cli **#43** (multi-node graphs render as an unreadable run-on).

`iter_event_frames` / `iter_chunk_frames` hardcoded `node="agent"` on every content/tool frame, so a graph with multiple content-emitting nodes was indistinguishable downstream — the CLI (which starts a fresh `⏺` marker on a node change) concatenated two nodes' messages onto one line. The AG-UI stream *does* carry the node via `StepStartedEvent.step_name`; the core just ignored it.

Now the mappings track the current node from `StepStartedEvent`, and the non-streaming `MessagesSnapshotEvent` path maps trailing assistant messages back to their steps. Single-node graphs (node `"agent"`) are unchanged.

**Verified**: a two-node graph now reports `node="first"` / `node="second"` (was both `"agent"`), and `langstage-cli` renders each on its own line with its own marker. 2 regression tests added; agui suite green.

`1.0.3 → 1.0.4`. Pairs with the langstage-cli #43/#47 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)