### PR TITLE
Stop history replay for snapshot agents; best-effort tool-error status (gh #67, #55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [1.0.5] - 2026-07-03
+
+### Fixed
+- **Non-token-streamed agents re-rendered the entire conversation history every turn
+  (gh #67).** `iter_event_frames` / `iter_chunk_frames` emit content from the final
+  `MessagesSnapshotEvent` for agents that don't token-stream — but that snapshot is
+  the *full* thread (prior turns come from the checkpointer), so every turn re-emitted
+  turns 1..n. Now the snapshot is sliced to the messages after the last user message,
+  so only the current turn's replies are emitted. (Regression from the 1.0.4 snapshot
+  node-mapping.)
+
+### Known limitation
+- **A failed tool call can still render as `status="success"` (gh #55).** The AG-UI
+  `ToolCallResultEvent` carries no status field and its `raw_event` is empty, so the
+  `ToolMessage`'s error status is dropped before the mapping sees it. `iter_event_frames`
+  now flags a `tool_end` as an error when a preceding `on_tool_error` RawEvent named the
+  same tool (best-effort, covers raised-and-handled errors), but a tool that *returns* a
+  `status="error"` message without raising is still shown as success — that needs the
+  status carried on the AG-UI event upstream (tracked in ag-ui-langgraph).
+
 ## [1.0.4] - 2026-07-02
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.4"
+version = "1.0.5"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/agui/__init__.py
+++ b/src/langstage_core/agui/__init__.py
@@ -282,6 +282,11 @@ async def iter_event_frames(
     # letting renderers separate one node's output from the next (gh #43).
     current_node = "agent"
     step_nodes: list[str] = []
+    # Tool names that raised (from on_tool_error RawEvents). The AG-UI
+    # ToolCallResultEvent drops the ToolMessage status, so a failed tool otherwise
+    # renders as "success"; on_tool_error fires before the result, so we flag it by
+    # name and correct the tool_end frame. (gh #55)
+    errored_tools: dict[str, int] = {}
 
     async for ev in agent.run(run_input):
         t = type(ev).__name__
@@ -290,6 +295,12 @@ async def iter_event_frames(
             if step:
                 current_node = step
                 step_nodes.append(step)
+        elif t == "RawEvent":
+            raw = getattr(ev, "event", None) or {}
+            if raw.get("event") == "on_tool_error":
+                nm = raw.get("name")
+                if nm:
+                    errored_tools[nm] = errored_tools.get(nm, 0) + 1
         elif t == "TextMessageContentEvent":
             streamed_text = True
             yield {"type": "content", "content": ev.delta, "role": "assistant", "node": current_node}
@@ -316,13 +327,16 @@ async def iter_event_frames(
             if len(result) > max_result_len:
                 result = result[:max_result_len] + "…(truncated)"
             name = tool_names.get(ev.tool_call_id, "tool")
+            is_error = errored_tools.get(name, 0) > 0
+            if is_error:
+                errored_tools[name] -= 1
             yield {
                 "type": "tool_end",
                 "id": ev.tool_call_id,
                 "name": name,
                 "result": result,
-                "status": "success",
-                "error_message": None,
+                "status": "error" if is_error else "success",
+                "error_message": result if is_error else None,
                 "duration_ms": None,
             }
             extractor = by_tool.get(name)
@@ -350,11 +364,18 @@ async def iter_event_frames(
                 "allowed_decisions": payload.get("allowed_decisions", allowed_decisions),
             }
         elif t == "MessagesSnapshotEvent" and not streamed_text:
-            # Non-streaming graphs deliver content in one final snapshot; map the
-            # trailing assistant messages back to the steps that produced them so a
-            # multi-node graph renders one block per node, not a run-on (gh #43).
+            # Non-streaming graphs deliver content in one final snapshot. The snapshot
+            # is the FULL thread (prior turns come from the checkpointer), so slice to
+            # what follows the last user message — otherwise the agent re-emits its
+            # entire history every turn (gh #67). Then map the trailing assistant
+            # messages back to the steps that produced them (gh #43).
+            msgs = list(ev.messages)
+            last_user = max(
+                (i for i, m in enumerate(msgs) if getattr(m, "role", None) in ("user", "human")),
+                default=-1,
+            )
             assistant = [
-                m for m in ev.messages
+                m for m in msgs[last_user + 1:]
                 if getattr(m, "role", None) == "assistant" and getattr(m, "content", None)
             ]
             offset = max(0, len(assistant) - len(step_nodes))
@@ -444,11 +465,17 @@ async def iter_chunk_frames(
                     payload = {"action_requests": []}
             yield {"status": "interrupt", "interrupt": payload or {"action_requests": []}}
         elif t == "MessagesSnapshotEvent" and not streamed_text:
-            # Non-streaming graphs deliver content in one final snapshot; map the
-            # trailing assistant messages back to the steps that produced them so a
-            # multi-node graph renders one block per node, not a run-on (gh #43).
+            # Non-streaming graphs deliver content in one final snapshot. The snapshot
+            # is the FULL thread, so slice to what follows the last user message —
+            # otherwise the agent re-emits its whole history every turn (gh #67). Then
+            # map the trailing assistant messages back to their steps (gh #43).
+            msgs = list(ev.messages)
+            last_user = max(
+                (i for i, m in enumerate(msgs) if getattr(m, "role", None) in ("user", "human")),
+                default=-1,
+            )
             assistant = [
-                m for m in ev.messages
+                m for m in msgs[last_user + 1:]
                 if getattr(m, "role", None) == "assistant" and getattr(m, "content", None)
             ]
             offset = max(0, len(assistant) - len(step_nodes))

--- a/tests/test_agui_frames.py
+++ b/tests/test_agui_frames.py
@@ -68,6 +68,35 @@ async def test_event_frames_carry_real_node_names():
     assert by_text.get("from second.") == "second"
 
 
+def _echo_graph():
+    """A non-token (snapshot-delivered) agent that echoes the last user message."""
+    from langchain_core.messages import AIMessage
+    from langgraph.checkpoint.memory import InMemorySaver
+    from langgraph.graph import END, START, MessagesState, StateGraph
+
+    b = StateGraph(MessagesState)
+    b.add_node("echo", lambda s: {"messages": [AIMessage(content=f"reply to: {s['messages'][-1].content}")]})
+    b.add_edge(START, "echo")
+    b.add_edge("echo", END)
+    return b.compile(checkpointer=InMemorySaver())
+
+
+async def test_snapshot_agent_does_not_replay_history():
+    # gh #67: a non-token agent delivers content via the final snapshot, which is the
+    # FULL thread. Turn 2 must emit only turn 2's reply, not re-render turn 1.
+    agent = build_agent(_echo_graph())
+
+    # chunk-frames turn
+    t1 = [f["chunk"] for f in await _collect(iter_chunk_frames(agent, "ONE", "t67")) if "chunk" in f]
+    t2 = [f["chunk"] for f in await _collect(iter_chunk_frames(agent, "TWO", "t67")) if "chunk" in f]
+    assert any("TWO" in c for c in t2)
+    assert not any("ONE" in c for c in t2), f"replayed history: {t2}"
+    # event-frames turn (separate thread)
+    e1 = [f["content"] for f in await _collect(iter_event_frames(agent, "ONE", "t67e")) if f.get("type") == "content"]
+    e2 = [f["content"] for f in await _collect(iter_event_frames(agent, "TWO", "t67e")) if f.get("type") == "content"]
+    assert any("TWO" in c for c in e2) and not any("ONE" in c for c in e2), f"replayed history: {e2}"
+
+
 async def test_iter_event_frames_runs_extractors():
     """extractors= runs a matching extractor over each tool result and emits an
     `extraction` frame (ADR 0003 Stage 1, productionized)."""


### PR DESCRIPTION
**gh #67 (regression from 1.0.4) — fixed.** For a non-token-streamed agent, `iter_event_frames`/`iter_chunk_frames` emit content from the final `MessagesSnapshotEvent`, but that snapshot is the *full* thread (prior turns come from the checkpointer) — so every turn re-emitted turns 1..n. Now the snapshot is sliced to the messages after the last user message. **Verified**: a two-turn echo agent emits only the current turn's reply (regression test added).

**gh #55 — best-effort + upstream escalation.** The AG-UI `ToolCallResultEvent` carries **no status field** and its `raw_event` is empty, so a `ToolMessage`'s error status is dropped before the mapping sees it (confirmed by probing the event + snapshot types). `iter_event_frames` now flags `tool_end` as an error when a preceding `on_tool_error` RawEvent named the same tool (best-effort, covers raised-and-handled errors; never false-positives on a successful tool). A tool that *returns* `status="error"` without raising is still shown as success — that requires the status to be carried on the AG-UI event, which is an **upstream `ag-ui-langgraph` gap** (filing separately). Documented as a known limitation.

`1.0.4 → 1.0.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)