### PR TITLE
feat(agui): shared live-preflight primitive verify() + ADR 0004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.0.6] - 2026-07-03
+
+### Added
+- **`langstage_core.agui.verify` / `averify` — a shared live-preflight primitive
+  (ADR 0004).** Runs ONE real turn through the AG-UI adapter (`iter_event_frames`)
+  and returns a structured `VerifyResult` (`ok` / `saw_complete` / `saw_error` /
+  `error_message` / `content_chars`). `ok` is True only if the turn *completed
+  with no error* — a missing API key, broken tool, or bad state schema fails here,
+  where a static "imports fine / loads / key is set" check gives a false green.
+  Accepts a compiled graph or an already-built `LangGraphAgent`; `verify()` is the
+  sync wrapper, `averify()` the coroutine. This is the primitive each surface's
+  `doctor`/`check`/`selfcheck`/`health` was reinventing (vscode `--selfcheck` and
+  hermes `verify` drive a real turn; cli/web/jupyter assert static state and gave
+  the false-green class in the backlog). Surfaces adopt it incrementally.
+
 ## [1.0.5] - 2026-07-03
 
 ### Fixed

--- a/docs/adr/0004-consolidate-preflight-and-workspace-into-core.md
+++ b/docs/adr/0004-consolidate-preflight-and-workspace-into-core.md
@@ -1,0 +1,94 @@
+# ADR 0004 — Consolidate live preflight and workspace application into the core
+
+**Status:** Accepted — 2026-07-03
+**Decision owner:** Kedar Dabhadkar
+
+## Context
+
+Five days of dogfooding across the six LangStage packages closed ~36 issues.
+Sorting them by root cause rather than by repo, ~40% are one meta-bug: **a
+surface reports a config / health / version state it never actually applied or
+verified** — a clean `doctor` for a missing extra (hermes #41), `[ok] loads` for
+a non-graph (web #39), a green `--selfcheck` for a path that errors
+(vscode #28, historically), a labextension version that doesn't match the wheel
+(jupyter #38 *then* #48), and a recurring family of "workspace root silently
+dropped" (vscode #19, jupyter #45/#36, web #44, the hermes factory path).
+
+A read-only audit of all six packages found *why* these recur. Core already ships
+one genuinely shared abstraction — `HostConfig.resolve()` (`defaults < TOML < env
+< overrides`), which every surface subclasses. **Two things that should also be
+shared are not**, and every recurring bug lives in exactly those two seams:
+
+| Surface | Config resolution | Workspace **application** | Live preflight (runs a real turn?) |
+|---|---|---|---|
+| **core** | **owns** `HostConfig.resolve()` | resolves the *value*; never applies it (`Workspace` helper unused) | **none** — parts exist (`build_agent` + `iter_event_frames`), uncomposed |
+| cli | delegates (`CodeConfig`) | `os.chdir` only — never reaches the agent's tools | ✗ static `--show-config` |
+| vscode | delegates fully | push value → `os.environ` | ✓ `--selfcheck` drives a real turn |
+| jupyter | delegates (`LabConfig`) | mutate module-global + rebuild backend | ✗ health = `agent is not None` |
+| web | delegates (`AppConfig`) | dataclass (browser) **+** module-global (tools), hand-synced | ✗ `check` asserts `callable(astream)`, never invokes |
+| hermes | **forks** `resolve()` (2nd TOML) | factory path drops it; only `verify` forwards | ✓ `verify`; `doctor` static → #41 |
+
+Read the columns, not the rows. The **config** column is uniform — and the lone
+fork (hermes) is the only surface that had a config-resolution bug (#24). The
+**workspace-application** and **preflight** columns are a zoo: five surfaces apply
+workspace root five different ways, and the "run a real turn" preflight was
+independently reinvented twice (vscode, hermes) and is static or absent the other
+four times. This is a natural experiment: the abstraction we consolidated doesn't
+drift; the two we copied per-surface generate ~half the backlog.
+
+## Decision
+
+Finish the consolidation. Two additive core capabilities, adopted by surfaces
+incrementally (same "additive now, migrate surface-by-surface" discipline as
+ADR 0001).
+
+1. **Shared live preflight — `langstage_core.agui.verify` / `averify`.**
+   Build the agent, stream **one real turn** through `iter_event_frames`, return a
+   structured `VerifyResult` (`ok` iff a `complete` frame arrived with no `error`
+   frame and no raised exception). vscode `--selfcheck` and hermes `verify` are the
+   reference behaviour; this is the primitive they were each hand-rolling. Every
+   surface's `doctor` / `check` / `selfcheck` / `health` delegates to it, so
+   "healthy" means the same thing everywhere: *the agent actually completed a
+   turn.* This kills the false-green class (#41, #39, #28). **Shipped in 1.0.6.**
+
+2. **Workspace *application* in core — not just resolution.** Core resolves
+   `workspace_root` today but stops there; each surface invents how to make it the
+   agent's actual root (`chdir` / env-push / backend-arg / global-mutate). Core
+   should own a single "apply the resolved workspace" path — root the agent's
+   `FilesystemBackend`/tools *and* the surface from one source (the unused
+   `host/workspace.py` `Workspace` is the seed) — so file-browser and agent tools
+   can never disagree (#44) and a pinned root can't be silently re-rooted (#45).
+   *Staged — higher blast radius; each surface migrates in its own PR.*
+
+Two supporting guardrails, tracked alongside:
+
+3. **Version-parity CI gate (jupyter):** assert the built labextension version
+   equals the wheel version, so the `skip-if-exists` drift (#38, #48) can't recur
+   silently. A pre-merge clean-room first-run smoke (install the wheel with no
+   extras, run one turn via the new `verify`) generalises this across the family.
+
+4. **Deprecation sunset:** every package carries `deepagent-*` scripts + alias
+   trees, `DEEPAGENT_*` env, legacy `.toml` fallbacks, and no-op `[agui]`/`[demo]`
+   extras — all "kept for one transition window," **none with a removal version.**
+   Pick a family-wide target (proposed: the next core minor, **1.1.0**, with
+   surfaces dropping their aliases in the release that pins `langstage-core>=1.1`)
+   and collect the removals into one deliberate pass.
+
+## Consequences
+
+- **New core API:** `langstage_core.agui.verify(agent_or_graph) -> VerifyResult`,
+  its `averify` coroutine, and the `VerifyResult` dataclass — behind the existing
+  `[agui]` extra (it drives the AG-UI adapter). No change to any surface until it
+  opts in; adoption is one thin PR per surface (replace the bespoke check body with
+  a `verify()` call plus any surface-specific extras, e.g. hermes' side-effect
+  assertions).
+- **"Healthy" becomes a single definition** across the family, removing the
+  false-green failure mode by construction rather than by per-surface patching.
+- **Workspace application (2)** is the higher-value, higher-risk half; it is
+  deliberately staged behind (1) so the low-risk win lands first and the tools-vs-
+  browser rewiring gets its own reviewed PR per surface.
+- **The dogfood matures** from "here are N bugs" to also flagging consolidation
+  candidates: any fix that had to ship to ≥2 repos, any health check that asserts
+  static state instead of running a turn, any recurrence, and any deprecation with
+  no removal date. The synthesis that produced this ADR becomes the closing stage's
+  standing checklist.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.5"
+version = "1.0.6"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/agui/__init__.py
+++ b/src/langstage_core/agui/__init__.py
@@ -37,6 +37,9 @@ __all__ = [
     "ensure_available",
     "iter_event_frames",
     "iter_chunk_frames",
+    "verify",
+    "averify",
+    "VerifyResult",
     "DEFAULT_AGENT_NAME",
 ]
 
@@ -487,3 +490,8 @@ async def iter_chunk_frames(
             yield {"status": "error", "error": getattr(ev, "message", "unknown error")}
 
     yield {"status": "complete"}
+
+
+# Imported at the bottom so verify.py can reference build_agent / iter_event_frames
+# as already-defined names (avoids a circular import). See ADR 0004.
+from .verify import VerifyResult, averify, verify  # noqa: E402,F401

--- a/src/langstage_core/agui/verify.py
+++ b/src/langstage_core/agui/verify.py
@@ -1,0 +1,121 @@
+"""Live preflight — run ONE real turn and report whether the agent actually works.
+
+Every surface grew its own health check (vscode ``--selfcheck``, hermes ``verify``,
+web ``langstage check``, cli ``--show-config``, jupyter ``/health``) and they
+disagree on the one thing that matters: whether a configured agent can complete a
+turn. The two that drive a real turn (vscode, hermes) can't give a false green;
+the ones that assert static facts — "imports fine", "loads", "key is set" — do,
+and that gap is the single largest class in the family's issue backlog (a clean
+``doctor`` for a missing extra, ``[ok] loads`` for a non-graph, a green selfcheck
+for a path that errors).
+
+This is the shared primitive those checks were each reinventing: build the agent,
+stream one turn through :func:`iter_event_frames`, and return a structured verdict.
+A missing API key, a broken tool, or a bad state schema fails HERE — because it
+runs the real path — instead of passing preflight and failing at first chat. See
+ADR 0004.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+from . import _is_langgraph_agent, build_agent, iter_event_frames
+
+# A tiny, model-agnostic probe. It only needs the turn to *complete*; the content
+# is incidental (the keyless demo stub echoes it, a real model answers it).
+DEFAULT_VERIFY_MESSAGE = "Reply with the single word: OK."
+
+
+@dataclass
+class VerifyResult:
+    """The verdict of one preflight turn.
+
+    ``ok`` is True iff the turn reached a ``complete`` frame with no ``error``
+    frame and no raised exception. Truthy in a boolean context, so
+    ``if verify(graph): ...`` reads naturally.
+    """
+
+    ok: bool
+    reason: str
+    saw_complete: bool = False
+    saw_error: bool = False
+    error_message: str | None = None
+    content_chars: int = 0
+    frames: int = 0
+
+    def __bool__(self) -> bool:
+        return self.ok
+
+
+async def averify(
+    agent_or_graph: Any,
+    *,
+    message: str = DEFAULT_VERIFY_MESSAGE,
+    thread_id: str = "verify",
+    timeout: float = 60.0,
+    state: Any = None,
+) -> VerifyResult:
+    """Drive one real turn through the AG-UI adapter and return a structured verdict.
+
+    Args:
+        agent_or_graph: A compiled LangGraph graph OR an already-built
+            ``LangGraphAgent`` (see :func:`build_agent`) — both accepted so a
+            surface can verify whatever it already holds.
+        message: The probe message. Defaults to a trivial model-agnostic prompt.
+        thread_id: Checkpoint thread for the probe turn (kept off real threads).
+        timeout: Seconds to wait for the turn to finish before failing.
+        state: Optional extra graph input (e.g. an agent with a richer contract
+            than ``messages``), forwarded to :func:`iter_event_frames`.
+
+    Returns:
+        A :class:`VerifyResult`. ``ok`` is True only if the turn *completed with
+        no error* — a missing key / broken tool / bad schema yields ``ok=False``
+        with a human-readable ``reason``, never an exception to the caller.
+    """
+    agent = (
+        agent_or_graph
+        if _is_langgraph_agent(agent_or_graph)
+        else build_agent(agent_or_graph)
+    )
+
+    result = VerifyResult(ok=False, reason="turn produced no completion frame")
+
+    async def _run() -> None:
+        async for frame in iter_event_frames(agent, message, thread_id, state=state):
+            result.frames += 1
+            kind = frame.get("type")
+            if kind == "content":
+                result.content_chars += len(frame.get("content") or "")
+            elif kind == "error":
+                result.saw_error = True
+                result.error_message = frame.get("error")
+            elif kind == "complete":
+                result.saw_complete = True
+
+    try:
+        await asyncio.wait_for(_run(), timeout=timeout)
+    except asyncio.TimeoutError:
+        result.reason = f"timed out after {timeout:g}s"
+        return result
+    except Exception as exc:  # noqa: BLE001 - any failure IS a failed preflight
+        result.reason = f"{type(exc).__name__}: {exc}"
+        return result
+
+    result.ok = result.saw_complete and not result.saw_error
+    if result.ok:
+        result.reason = "one turn completed cleanly"
+    elif result.saw_error:
+        result.reason = f"agent errored: {result.error_message}"
+    return result
+
+
+def verify(agent_or_graph: Any, **kwargs: Any) -> VerifyResult:
+    """Synchronous wrapper around :func:`averify`.
+
+    For a sync caller (a CLI ``doctor``/``check``/``selfcheck``). Async callers
+    already inside an event loop should await :func:`averify` instead.
+    """
+    return asyncio.run(averify(agent_or_graph, **kwargs))

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,0 +1,66 @@
+"""The shared live-preflight primitive (ADR 0004).
+
+``verify`` / ``averify`` run ONE real turn through the AG-UI adapter and report
+whether the agent actually completed — the thing each surface's health check was
+reinventing. A turn that errors (or a non-runnable object) must fail here, not
+pass a static check and blow up at first chat.
+Skipped unless the agui extra is installed (dev pulls it, so CI runs it).
+"""
+
+import pytest
+
+pytest.importorskip("ag_ui_langgraph")
+pytest.importorskip("fastapi")
+
+from langstage_core import load_agent_spec
+from langstage_core.agui import VerifyResult, averify, build_agent, verify
+
+# asyncio_mode = "auto" (pyproject) runs the async tests as coroutines; the sync
+# wrapper test stays sync, so no module-level asyncio mark here.
+
+
+def _erroring_graph():
+    """A compiled graph whose only node raises — the AG-UI adapter surfaces this
+    as a RunError frame, so a real turn fails while a static load would pass."""
+    from langgraph.graph import END, START, MessagesState, StateGraph
+
+    def boom(state):
+        raise RuntimeError("tool exploded")
+
+    b = StateGraph(MessagesState)
+    b.add_node("boom", boom)
+    b.add_edge(START, "boom")
+    b.add_edge("boom", END)
+    return b.compile()
+
+
+async def test_averify_demo_stub_passes():
+    # The keyless echo stub completes a turn and emits content -> ok.
+    r = await averify(load_agent_spec("langstage_core.demo.stub:graph"))
+    assert isinstance(r, VerifyResult)
+    assert r.ok and bool(r) is True
+    assert r.saw_complete and not r.saw_error
+    assert r.content_chars > 0
+    assert r.reason == "one turn completed cleanly"
+
+
+async def test_averify_accepts_a_prebuilt_agent():
+    # Passing an already-built LangGraphAgent must work too (not just a graph).
+    agent = build_agent(load_agent_spec("langstage_core.demo.stub:graph"))
+    r = await averify(agent)
+    assert r.ok
+
+
+async def test_averify_erroring_agent_fails_not_raises():
+    # A turn that errors is a FAILED preflight returned as data, never an
+    # exception to the caller — and never a false green.
+    r = await averify(_erroring_graph())
+    assert r.ok is False and bool(r) is False
+    # Either a RunError frame or a surfaced exception — both are non-ok with a reason.
+    assert r.reason and (r.saw_error or "Error" in r.reason)
+
+
+def test_verify_sync_wrapper_runs_a_turn():
+    # The sync convenience a CLI doctor/check/selfcheck would call.
+    r = verify(load_agent_spec("langstage_core.demo.stub:graph"))
+    assert r.ok and r.saw_complete

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "langstage-core"
-version = "1.0.0"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Ships the first of the two consolidations from the dogfooding synthesis (ADR 0004): a shared **live-preflight** primitive so every surface's health check means the same thing — *the agent actually completed a turn.*

### What
- `langstage_core.agui.verify(agent_or_graph) -> VerifyResult` (+ `averify` coroutine, `VerifyResult` dataclass). Drives ONE real turn through `iter_event_frames`; `ok` is True only if a `complete` frame arrived with no `error` frame and no raised exception. Accepts a compiled graph or an already-built `LangGraphAgent`.
- **ADR 0004** — the six-surface evidence matrix and the staged plan (shared preflight now; workspace *application* into core next; the version-parity CI gate; the deprecation sunset).

### Why
~40% of the last five days' closed issues are one meta-bug: a surface reports a state it never verified. The two surfaces that drive a real turn (vscode `--selfcheck`, hermes `verify`) can't give a false green; the four that assert static state (`doctor`/`check`/`--show-config`/`health`) did — #41 (clean doctor for a missing extra), #39 (`[ok] loads` for a non-graph), #28. This primitive is what they were each hand-rolling.

### Adoption
Additive — no surface changes until it opts in. Each surface later replaces its bespoke check body with a `verify()` call plus any surface-specific extras (e.g. hermes' side-effect assertions). Tracked in the backlog.

### Tests
`tests/test_verify.py`: demo stub passes (real turn, content, clean completion), a prebuilt agent is accepted, an **erroring** graph fails as *data* (not an exception) and never a false green, and the sync wrapper runs a turn. 123 passed, ruff + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)