### PR TITLE
feat(host): apply_workspace/workspace_root — workspace source of truth (ADR 0005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.0.7] - 2026-07-03
+
+### Added
+- **`apply_workspace()` / `workspace_root()` — the single workspace source of truth
+  (ADR 0005).** Core resolved `workspace_root` (the value) but never *applied* it, so
+  each surface invented its own mechanism (cli `chdir` / vscode env-push / hermes
+  backend-arg / jupyter global-mutate / web hand-sync) and three drifted into a
+  workspace bug. `apply_workspace(root, *, chdir=False)` — called once after
+  `HostConfig.resolve()` — ensures the dir exists, records it as the process's active
+  workspace, and publishes it as `LANGSTAGE_WORKSPACE_ROOT` (plus the legacy
+  `DEEPAGENT_WORKSPACE_ROOT`); `workspace_root()` is the one accessor tools and
+  surfaces read instead of a private global. `chdir` is opt-in (single-process
+  surfaces only). Surfaces migrate to it incrementally; a bring-your-own graph's
+  tools opt in by reading `workspace_root()`. Both exported top-level.
+
 ## [1.0.6] - 2026-07-03
 
 ### Added

--- a/docs/adr/0005-apply-workspace-in-core.md
+++ b/docs/adr/0005-apply-workspace-in-core.md
@@ -1,0 +1,171 @@
+# ADR 0005 — Apply the resolved workspace in core (one source of truth)
+
+**Status:** Accepted — 2026-07-03
+**Decision owner:** Kedar Dabhadkar
+**Relates to:** ADR 0004 (this is its staged second half), backlog item 37
+
+## Decisions (resolved)
+
+1. **BYO boundary endorsed.** Core roots agents it builds; a bring-your-own graph's
+   tools opt in by reading `core.workspace_root()`. `check` warns when a BYO agent's
+   tools are unlikely to honor the workspace. (Open question 1.)
+2. **`chdir` kept as opt-in** (`chdir=True`) for the single-process surfaces (cli, the
+   vscode sidecar) only; servers (web, jupyter) never chdir. (Open question 2.)
+3. **Shipped as core 1.0.7** — additive, immediate, decoupled from the 1.1.0
+   deprecation sunset. (Open question 3.)
+
+## Context
+
+ADR 0004 established: config *resolution* is consolidated in core
+(`HostConfig.resolve()`) and does not drift, while the two things that were *not*
+consolidated — live preflight and workspace **application** — generate ~half the
+dogfood backlog. Preflight is now shared (`core.verify`, adopted by cli/web/jupyter).
+This ADR proposes the harder half: workspace application.
+
+**The distinction.** Core resolves `workspace_root` (the *value*) through the shared
+precedence chain, so every surface gets the value identically. But core **stops
+there** — no `chdir`, no wiring of the value into the agent's filesystem tools. The
+`host/workspace.py` `Workspace` helper (ensure + safe-join) exists for this and is
+used by **nobody**. So each surface invented its own "apply":
+
+| Surface | Mechanism to make the resolved root the agent's root | Bug it produced |
+|---|---|---|
+| cli | `os.chdir()` — process cwd only; never reaches the agent's tools | — |
+| vscode | write `os.environ["LANGSTAGE_WORKSPACE_ROOT"]` | #19 (`setdefault` dropped `--workspace`) |
+| hermes | `workspace=` → `FilesystemBackend(root_dir=...)`; the `chat` factory path **drops** it | factory-path gap (only `verify` forwarded it) |
+| jupyter | mutate module-global `config.WORKSPACE_ROOT` + rebuild backend | #45 (pinned root discarded), #36 (dead re-root / bad import) |
+| web | file-browser reads the dataclass value; agent tools read a mutable module global; hand-synced in `CoworkApp.__init__` | #44 (split-brain — tools ignored `--workspace`) |
+
+Five surfaces, five mechanisms, three shipped bugs. One missing abstraction, copied
+five ways and drifting.
+
+### The crux (why this is not a dive-in)
+
+There is **no single mechanism that uniformly re-roots an arbitrary bring-your-own
+graph's tools**, because core does not own those tools. A BYO compiled graph
+(`-a my_agent.py:graph`, supported by cli/vscode/jupyter/web) is already built with
+whatever tools the user wired; core cannot reach inside it and change where its
+tools resolve paths. Any honest design must split "agents core/the surface builds"
+(rootable) from "BYO graphs" (not rootable by core — opt-in only). The five current
+mechanisms all blur this, which is part of why they drift.
+
+Candidate mechanisms, and why none is a silver bullet:
+
+- **`chdir`** — universal for cwd-relative tools, but process-global (not per-request);
+  a blunt instrument a multi-workspace server couldn't use.
+- **Env var** — crosses process boundaries (vscode subprocess), but only tools that
+  *read* it honor it (the bundled deepagents tools do; BYO tools don't), and it's
+  process-global. It's the "lowest-priority hack" #44 called out.
+- **`FilesystemBackend(root_dir=...)` at build time** — explicit and thread-safe, but
+  only works for agents *we* build; can't touch a pre-built BYO graph.
+- **`RunnableConfig` `configurable.workspace_root`** — LangGraph-native, per-invocation,
+  but again only tools wired to read it honor it.
+
+## Decision (proposed)
+
+Make core own a **single active-workspace source of truth**, applied once at startup
+by each surface, and be explicit about the BYO boundary. Concretely:
+
+1. **`apply_workspace(root, *, chdir=False)`** — the one function every surface calls
+   after resolving config. It ensures the dir exists, publishes it as the single
+   source of truth (module state + the `LANGSTAGE_WORKSPACE_ROOT` env var, plus the
+   legacy `DEEPAGENT_WORKSPACE_ROOT` until the ADR-0004 sunset), optionally `chdir`s,
+   and returns the `Workspace`. This *replaces* the five bespoke mechanisms.
+2. **`workspace_root()`** — the one accessor tools and surfaces read, instead of each
+   maintaining a private global (web's `config.WORKSPACE_ROOT`, jupyter's, …).
+3. **For agents core/the surface builds** (the bundled deepagents agent — web default,
+   hermes, jupyter default), root the `FilesystemBackend` from `workspace_root()` at
+   build time (mechanism C). This is where most of the actual bugs live (web #44,
+   the hermes factory drop), and it's fully in core's control.
+4. **For BYO graphs**, core cannot re-root the user's tools. It publishes the value
+   through `workspace_root()` + the env var and **documents the contract**: a BYO tool
+   that should honor the workspace reads `core.workspace_root()`. `check`/`--verify`
+   can warn when a BYO agent's tools are unlikely to honor it. This limitation is
+   named, not papered over.
+5. **`chdir` is opt-in**, taken only by single-process, single-agent surfaces (cli,
+   the vscode sidecar). Servers (web, jupyter) do **not** chdir; they root the built
+   agent's backend and serve the file-browser from the same `workspace_root()`.
+
+### Explicit assumption (the one thing that could bite later)
+
+`apply_workspace` sets **process-global** state. That is correct today because every
+surface runs **one workspace per process** — including the servers: web/jupyter have
+a single workspace root for the whole app, and the task board runs copies of the
+*same* agent in the *same* workspace. If a future surface needs **per-request/per-agent
+workspaces**, that is a `RunnableConfig`-based extension (mechanism D), explicitly out
+of scope here. This assumption is stated so a future maintainer sees the boundary.
+
+## Proposed API (builds on the existing `Workspace`)
+
+```python
+# langstage_core/host/workspace.py  (extends today's Workspace: root/ensure/subpath/name)
+
+_ACTIVE: Workspace | None = None
+
+def apply_workspace(root, *, chdir=False):
+    """Make `root` the active resolved workspace: ensure it exists, publish it as
+    the single source of truth (module state + LANGSTAGE_WORKSPACE_ROOT env, plus
+    legacy DEEPAGENT_WORKSPACE_ROOT until sunset), optionally chdir. Returns the
+    Workspace. Call ONCE, after HostConfig.resolve(), before building the agent."""
+
+def workspace_root() -> Path:
+    """The active resolved workspace root — the ONE accessor tools/surfaces read
+    instead of a private global. Falls back to cwd if apply_workspace wasn't called."""
+```
+
+Exported top-level (`langstage_core`) alongside `Workspace`.
+
+## Per-surface migration (one PR each, staged; web last)
+
+- **cli**: `os.chdir(workspace_path)` → `apply_workspace(cfg.workspace_root, chdir=True)`.
+- **vscode**: the manual `os.environ[...] = ...` block → `apply_workspace(cfg.workspace_root)`.
+- **hermes**: pass `cfg.workspace_root` into the factory on the **`chat`** path (today only
+  `verify` forwards it); the factory roots `FilesystemBackend` from `workspace_root()`.
+- **jupyter**: the `config.WORKSPACE_ROOT` mutation + rebuild dance → `apply_workspace()`;
+  a re-root on a new `server_root_dir` calls `apply_workspace()` again.
+- **web** (highest risk): replace the hand-synced `_config.WORKSPACE_ROOT = …` + env
+  writes in `CoworkApp.__init__` with one `apply_workspace()` call; **both** the
+  file-browser (`FileManager`) and the agent tools derive from `workspace_root()` —
+  the split-brain (#44) is closed by construction (one source, not two hand-synced).
+
+Old env-var readers keep working throughout, because `apply_workspace` sets the same
+env vars — so migration is additive, surface-by-surface (ADR 0004 discipline).
+
+## Risks & mitigations
+
+- **Re-opening the web split-brain (#44).** Mitigation: a regression test that sets
+  `--workspace <tmp>`, runs a turn whose agent writes a file via its bash/fs tool, and
+  asserts the file lands under `<tmp>` **and** that the file-browser lists it — proving
+  one source feeds both. This test is the acceptance gate for the web PR.
+- **Order of operations.** `apply_workspace` must run *before* the agent is built and
+  the file-browser is constructed. Encode as the first step of each surface's startup.
+- **Process-global test pollution** (same shape as `_QUIET`): a conftest fixture resets
+  `_ACTIVE` + the env vars between tests.
+- **BYO tools silently unrooted.** Not a regression (they were never rooted), but name
+  it: document the `workspace_root()` contract and consider a `check` warning.
+
+## Verification
+
+A pm-dogfood-able cross-surface acceptance: for each surface, set `--workspace <tmp>`,
+drive one turn that writes a file via the agent's filesystem tool, and assert the file
+appears under `<tmp>` (not the launch cwd). This is the single behavior all five bugs
+were about; passing it on all five surfaces is "done."
+
+## Staging
+
+1. Ship `apply_workspace` / `workspace_root` in core (additive; a 1.0.x minor).
+2. Migrate cli, vscode, hermes, jupyter (each a thin PR + the acceptance test).
+3. Migrate web last, gated on the split-brain regression test.
+4. (Optional, later) a `RunnableConfig` path if per-request workspaces ever appear.
+
+## Open questions for the decision
+
+1. **Endorse the BYO boundary?** Core roots agents it builds; BYO graphs opt in via
+   `workspace_root()`. This is honest but means `-a my_agent.py` with hand-rolled tools
+   isn't auto-rooted. Acceptable, or do we want a `check` warning / a documented
+   `LANGSTAGE_TOOLS`-style helper that reads `workspace_root()` for BYO authors?
+2. **`chdir` for cli/vscode — keep it?** It's the bluntest mechanism but the most
+   universal for those single-process surfaces. Keep as an opt-in `chdir=True`, or drop
+   chdir entirely and rely on backend-rooting + the env var only?
+3. **Version:** ship the core API as **1.0.7** (additive, immediate) or fold into the
+   **1.1.0** that ADR 0004 earmarked for the deprecation sunset?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.6"
+version = "1.0.7"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/__init__.py
+++ b/src/langstage_core/__init__.py
@@ -33,7 +33,13 @@ from .extractors import (
     TodoExtractor,
     ToolExtractor,
 )
-from .host import HostConfig, Workspace, load_agent_spec
+from .host import (
+    HostConfig,
+    Workspace,
+    apply_workspace,
+    load_agent_spec,
+    workspace_root,
+)
 from .resume import create_resume_input, prepare_agent_input
 from .tasks import (
     InMemoryTaskStore,
@@ -58,6 +64,8 @@ __all__ = [
     "load_agent_spec",
     "HostConfig",
     "Workspace",
+    "apply_workspace",
+    "workspace_root",
     # Input helpers
     "prepare_agent_input",
     "create_resume_input",

--- a/src/langstage_core/host/__init__.py
+++ b/src/langstage_core/host/__init__.py
@@ -7,11 +7,13 @@ host (``langstage``, ``langstage-jupyter``, ``langstage-cli``,
 """
 from .config import HostConfig, load_toml_config
 from .loader import load_agent_spec
-from .workspace import Workspace
+from .workspace import Workspace, apply_workspace, workspace_root
 
 __all__ = [
     "load_agent_spec",
     "HostConfig",
     "load_toml_config",
     "Workspace",
+    "apply_workspace",
+    "workspace_root",
 ]

--- a/src/langstage_core/host/workspace.py
+++ b/src/langstage_core/host/workspace.py
@@ -1,8 +1,16 @@
-"""A small workspace-root wrapper shared by hosts.
+"""The shared workspace-root wrapper + the one place a host *applies* it.
 
-Not load-bearing — just removes the repeated ``mkdir`` / safe-join logic and
-gives a single place for the "agent's working directory" concept.
+``Workspace`` removes the repeated ``mkdir`` / safe-join logic. ``apply_workspace``
+/ ``workspace_root`` are the single source of truth for "the agent's working
+directory" (ADR 0005): a surface calls ``apply_workspace`` once after resolving
+config, and everything downstream — the agent's filesystem backend, a file
+browser, a BYO tool — reads ``workspace_root`` instead of maintaining a private
+global. This replaces the five bespoke "apply" mechanisms (cli ``chdir`` / vscode
+env-push / hermes backend-arg / jupyter global-mutate / web hand-sync) that each
+drifted into a workspace bug.
 """
+
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -31,12 +39,62 @@ class Workspace:
         candidate = self.root.joinpath(*parts).resolve()
         root_resolved = self.root.resolve()
         if root_resolved != candidate and root_resolved not in candidate.parents:
-            raise ValueError(
-                f"Path {candidate} escapes workspace root {root_resolved}"
-            )
+            raise ValueError(f"Path {candidate} escapes workspace root {root_resolved}")
         return candidate
 
     @property
     def name(self) -> str:
         """The workspace directory name (for display)."""
         return self.root.resolve().name
+
+
+# The active workspace for this process. Set by apply_workspace(); read by
+# workspace_root(). One per process — see ADR 0005 "explicit assumption".
+_ACTIVE: "Workspace | None" = None
+
+# The env vars apply_workspace publishes so out-of-process readers (the vscode
+# sidecar's subprocess) and legacy tools still see the resolved root. The legacy
+# name is written until the ADR 0004 deprecation sunset.
+_ENV_CANONICAL = "LANGSTAGE_WORKSPACE_ROOT"
+_ENV_LEGACY = "DEEPAGENT_WORKSPACE_ROOT"
+
+
+def apply_workspace(root, *, chdir: bool = False) -> "Workspace":
+    """Make ``root`` the active resolved workspace and publish it as the single
+    source of truth (ADR 0005).
+
+    Ensures the directory exists, records it as this process's active workspace,
+    and exports it as ``LANGSTAGE_WORKSPACE_ROOT`` (plus the legacy
+    ``DEEPAGENT_WORKSPACE_ROOT``) so out-of-process and legacy readers agree.
+    ``chdir=True`` also changes the process cwd — taken only by single-process,
+    single-agent surfaces (cli, the vscode sidecar); servers root their built
+    agent's backend from :func:`workspace_root` instead and never chdir.
+
+    Call ONCE, after ``HostConfig.resolve()`` and before building the agent /
+    file browser, so both derive from the same value.
+
+    Returns the :class:`Workspace`.
+    """
+    global _ACTIVE
+    ws = Workspace(root).ensure()
+    _ACTIVE = ws
+    resolved = str(ws.root.resolve())
+    os.environ[_ENV_CANONICAL] = resolved
+    os.environ[_ENV_LEGACY] = resolved
+    if chdir:
+        os.chdir(ws.root)
+    return ws
+
+
+def workspace_root() -> Path:
+    """The active resolved workspace root — the ONE accessor tools and surfaces
+    read instead of a private global (ADR 0005).
+
+    Prefers the in-process value set by :func:`apply_workspace`; falls back to the
+    ``LANGSTAGE_WORKSPACE_ROOT`` / ``DEEPAGENT_WORKSPACE_ROOT`` env (set by a parent
+    process), then to the current working directory.
+    """
+    if _ACTIVE is not None:
+        return _ACTIVE.root.resolve()
+    env = os.environ.get(_ENV_CANONICAL) or os.environ.get(_ENV_LEGACY)
+    return Path(env).resolve() if env else Path.cwd()

--- a/tests/test_workspace_apply.py
+++ b/tests/test_workspace_apply.py
@@ -1,0 +1,66 @@
+"""apply_workspace / workspace_root — the single workspace source of truth (ADR 0005).
+
+A surface calls apply_workspace() once after resolving config; everything downstream
+reads workspace_root() instead of a private global. These replace the five bespoke
+"apply" mechanisms that each drifted into a workspace bug.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from langstage_core import Workspace, apply_workspace, workspace_root
+from langstage_core.host import workspace as ws_mod
+
+
+@pytest.fixture(autouse=True)
+def _isolate_active_workspace(monkeypatch, tmp_path):
+    """apply_workspace sets PROCESS-global state (a module global + env + maybe cwd).
+    Snapshot and restore it around each test so invocations stay isolated."""
+    monkeypatch.chdir(tmp_path)  # a safe cwd; monkeypatch restores the real one
+    saved_active = ws_mod._ACTIVE
+    monkeypatch.setattr(ws_mod, "_ACTIVE", None)
+    monkeypatch.delenv("LANGSTAGE_WORKSPACE_ROOT", raising=False)
+    monkeypatch.delenv("DEEPAGENT_WORKSPACE_ROOT", raising=False)
+    yield
+    ws_mod._ACTIVE = saved_active
+
+
+def test_apply_workspace_publishes_the_source_of_truth(tmp_path):
+    target = tmp_path / "ws"
+    ws = apply_workspace(target)
+    assert isinstance(ws, Workspace)
+    # Created, active, and published to both env names — all pointing at the resolved dir.
+    assert target.is_dir()
+    assert workspace_root() == target.resolve()
+    assert os.environ["LANGSTAGE_WORKSPACE_ROOT"] == str(target.resolve())
+    assert os.environ["DEEPAGENT_WORKSPACE_ROOT"] == str(target.resolve())
+
+
+def test_apply_workspace_no_chdir_by_default(tmp_path):
+    before = Path.cwd()
+    apply_workspace(tmp_path / "ws")
+    assert Path.cwd() == before  # servers must not have their cwd moved
+
+
+def test_apply_workspace_chdir_opt_in(tmp_path):
+    target = tmp_path / "ws"
+    apply_workspace(target, chdir=True)
+    assert Path.cwd().resolve() == target.resolve()
+
+
+def test_workspace_root_falls_back_to_env_then_cwd(tmp_path, monkeypatch):
+    # No apply_workspace() this test -> fall back to the env a parent process set...
+    monkeypatch.setenv("LANGSTAGE_WORKSPACE_ROOT", str(tmp_path / "from_env"))
+    assert workspace_root() == (tmp_path / "from_env").resolve()
+    # ...and to cwd when nothing is set.
+    monkeypatch.delenv("LANGSTAGE_WORKSPACE_ROOT", raising=False)
+    assert workspace_root() == Path.cwd().resolve()
+
+
+def test_in_process_active_beats_stale_env(tmp_path, monkeypatch):
+    # A stale env from a previous run must not override the value applied here.
+    monkeypatch.setenv("LANGSTAGE_WORKSPACE_ROOT", str(tmp_path / "stale"))
+    apply_workspace(tmp_path / "current")
+    assert workspace_root() == (tmp_path / "current").resolve()

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "langstage-core"
-version = "1.0.6"
+version = "1.0.7"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Ships the second consolidation from the dogfooding synthesis (ADR 0005, accepted): core now *applies* the resolved workspace, not just resolves it.

### What
- **`apply_workspace(root, *, chdir=False)`** — called once after `HostConfig.resolve()`. Ensures the dir exists, records the process's active workspace, and publishes it as `LANGSTAGE_WORKSPACE_ROOT` (+ legacy `DEEPAGENT_WORKSPACE_ROOT`). `chdir` is opt-in (single-process surfaces only).
- **`workspace_root()`** — the one accessor tools and surfaces read instead of each keeping a private global. Prefers the in-process active value, falls back to env, then cwd.
- **ADR 0005** (accepted) with the resolved decisions.

### Why
Core resolved `workspace_root` but never applied it, so each surface invented its own mechanism (cli `chdir` / vscode env-push / hermes backend-arg / jupyter global-mutate / web hand-sync) — and three drifted into a workspace bug (#19, #45/#36, #44). This is the one source of truth they were each reinventing.

### Scope (honest boundary, per ADR 0005)
Core roots agents it builds; a **bring-your-own** graph's tools opt in by reading `workspace_root()` (core can't reach inside an arbitrary pre-built graph). Named, not papered over.

### Adoption
Additive — no surface changes until it opts in. Migration is one PR per surface (web last, gated on the #44 split-brain regression test). Old env readers keep working throughout since `apply_workspace` sets the same env vars.

### Tests
`tests/test_workspace_apply.py`: publishes to both env names + creates the dir + `workspace_root()` returns it; no chdir by default; `chdir=True` moves cwd; env/cwd fallback; in-process value beats a stale env. An autouse fixture isolates the process-global state. 128 passed, ruff + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)