### PR TITLE
fix(agui): emit the advertised reasoning frame (gh #71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.0.8] - 2026-07-04
+
+### Fixed
+- **`iter_event_frames` / `iter_chunk_frames` now emit the advertised `reasoning`
+  frame (gh #71).** The mappers had no branch for the `Reasoning*` / `Thinking*`
+  AG-UI events that `ag-ui-langgraph` emits for reasoning-capable models (Anthropic
+  extended thinking, OpenAI o-series, DeepSeek R1, Qwen, xAI, …), so the model's
+  chain-of-thought was silently dropped and no `reasoning` frame was ever produced —
+  contradicting the README. `ReasoningMessageContentEvent` /
+  `ThinkingTextMessageContentEvent` now map to `{"type": "reasoning", "content": …}`
+  (event wire) / `{"status": "streaming", "reasoning": …}` (chunk wire), kept
+  separate from the `content` answer so renderers can show or collapse the thinking.
+
 ## [1.0.7] - 2026-07-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.7"
+version = "1.0.8"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/agui/__init__.py
+++ b/src/langstage_core/agui/__init__.py
@@ -307,6 +307,16 @@ async def iter_event_frames(
         elif t == "TextMessageContentEvent":
             streamed_text = True
             yield {"type": "content", "content": ev.delta, "role": "assistant", "node": current_node}
+        elif t in ("ReasoningMessageContentEvent", "ThinkingTextMessageContentEvent"):
+            # Reasoning-model chain-of-thought (Anthropic extended thinking, o-series,
+            # DeepSeek R1, Qwen, xAI, ...). Surface it as the advertised `reasoning`
+            # frame so renderers can show/collapse the thinking separately from the
+            # answer, instead of dropping it. Does NOT set streamed_text — reasoning
+            # isn't the answer, so a reasoning-only turn still falls back to the final
+            # snapshot for the reply. (gh #71)
+            delta = getattr(ev, "delta", "")
+            if delta:
+                yield {"type": "reasoning", "content": delta, "node": current_node}
         elif t == "ToolCallStartEvent":
             tool_names[ev.tool_call_id] = ev.tool_call_name
             tool_args[ev.tool_call_id] = ""
@@ -446,6 +456,13 @@ async def iter_chunk_frames(
         elif t == "TextMessageContentEvent":
             streamed_text = True
             yield {"status": "streaming", "chunk": ev.delta, "node": current_node}
+        elif t in ("ReasoningMessageContentEvent", "ThinkingTextMessageContentEvent"):
+            # Reasoning-model chain-of-thought on the chunk wire — a distinct
+            # `reasoning` key (parallel to `chunk`) so renderers can style/collapse
+            # it, rather than dropping it. Not the answer, so no streamed_text. (gh #71)
+            delta = getattr(ev, "delta", "")
+            if delta:
+                yield {"status": "streaming", "reasoning": delta, "node": current_node}
         elif t == "ToolCallStartEvent":
             tool_buf[ev.tool_call_id] = {"name": ev.tool_call_name, "args": ""}
         elif t == "ToolCallArgsEvent":

--- a/tests/test_agui_frames.py
+++ b/tests/test_agui_frames.py
@@ -172,3 +172,44 @@ async def test_iter_event_frames_state_passthrough():
     frames = await _collect(iter_event_frames(agent, "hi", "tS", state={"budget": 7}))
     text = "".join(f["content"] for f in frames if f.get("type") == "content")
     assert "budget=7" in text, frames
+
+
+# The mappers dispatch on type(ev).__name__, so the fakes just need the AG-UI class
+# names + a `.delta` — name the classes exactly what ag-ui-langgraph emits.
+class ReasoningMessageContentEvent:
+    def __init__(self, delta):
+        self.delta = delta
+
+
+class TextMessageContentEvent:
+    def __init__(self, delta):
+        self.delta = delta
+
+
+class _FakeReasoningAgent:
+    """An agent whose run() emits the exact event sequence ag-ui-langgraph produces
+    for a reasoning model: reasoning deltas, then the answer text."""
+
+    async def run(self, run_input):
+        for d in ("Let me think... ", "2+2=4. "):
+            yield ReasoningMessageContentEvent(d)
+        yield TextMessageContentEvent("The answer is 4.")
+
+
+async def test_iter_event_frames_emits_reasoning():
+    # gh #71: reasoning-model chain-of-thought must surface as a `reasoning` frame,
+    # not be dropped — and stay separate from the `content` answer.
+    frames = await _collect(iter_event_frames(_FakeReasoningAgent(), "think", "tr"))
+    reasoning = [f for f in frames if f.get("type") == "reasoning"]
+    assert reasoning, frames
+    assert "".join(f["content"] for f in reasoning) == "Let me think... 2+2=4. "
+    content = [f for f in frames if f.get("type") == "content"]
+    assert "".join(f["content"] for f in content) == "The answer is 4."
+
+
+async def test_iter_chunk_frames_emits_reasoning():
+    frames = await _collect(iter_chunk_frames(_FakeReasoningAgent(), "think", "tr"))
+    reasoning = [f["reasoning"] for f in frames if "reasoning" in f]
+    assert "".join(reasoning) == "Let me think... 2+2=4. "
+    chunks = [f["chunk"] for f in frames if "chunk" in f]
+    assert "".join(chunks) == "The answer is 4."

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "langstage-core"
-version = "1.0.7"
+version = "1.0.8"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Closes #71.

The README advertises that `iter_event_frames` yields a **`reasoning`** frame, but the mappers had **no branch** for any `Reasoning*` / `Thinking*` AG-UI event. `ag-ui-langgraph` faithfully emits `ReasoningMessageContentEvent` for reasoning-capable models (Anthropic extended thinking, OpenAI o-series, DeepSeek R1, Qwen, xAI, Bedrock…), but every one fell through and was discarded — the model's chain-of-thought never reached the frontend.

Now `ReasoningMessageContentEvent` / `ThinkingTextMessageContentEvent` map to:
- event wire: `{"type": "reasoning", "content": delta, "node": …}`
- chunk wire: `{"status": "streaming", "reasoning": delta, "node": …}`

kept **separate** from the `content` answer (and not counted as `streamed_text`, so a reasoning-only turn still falls back to the final snapshot for the reply).

`tests/test_agui_frames.py`: a fake agent emitting the exact reasoning-model event sequence produces `reasoning` frames on both wires, distinct from the answer `content`/`chunk`. 130 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)