### PR TITLE
docs: refresh README header image to the LangStage name

### DIFF
--- a/assets/header.svg
+++ b/assets/header.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="340" viewBox="0 0 1280 340" role="img" aria-label="langgraph-stream-parser — typed events and adapters for LangGraph streaming output">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="340" viewBox="0 0 1280 340" role="img" aria-label="langstage-core — typed frames and adapters for LangGraph streaming output">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#0B1221"/>
@@ -22,22 +22,22 @@
   <g transform="translate(72,64)">
     <rect width="92" height="34" rx="17" fill="#1A1535" stroke="url(#accent)" stroke-width="1.5"/>
     <circle cx="22" cy="17" r="5" fill="url(#accent)"/>
-    <text x="38" y="23" font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="15" fill="#C9BEFF">v0.2</text>
+    <text x="38" y="23" font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="15" fill="#C9BEFF">v1.0</text>
   </g>
 
-  <text x="70" y="176" font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="50" font-weight="700" fill="#F2F6FC" letter-spacing="-1">langgraph<tspan fill="url(#accent)">-stream-parser</tspan></text>
+  <text x="70" y="176" font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="50" font-weight="700" fill="#F2F6FC" letter-spacing="-1">langstage<tspan fill="url(#accent)">-core</tspan></text>
 
-  <text x="72" y="220" font-family="'Segoe UI',Helvetica,Arial,sans-serif" font-size="22" fill="#A6AECB">Typed events &#38; adapters for LangGraph streaming output.</text>
-  <text x="72" y="250" font-family="'Segoe UI',Helvetica,Arial,sans-serif" font-size="22" fill="#A6AECB">The shared runtime behind the deep-agent surfaces.</text>
+  <text x="72" y="220" font-family="'Segoe UI',Helvetica,Arial,sans-serif" font-size="22" fill="#A6AECB">Typed frames &#38; adapters for LangGraph streaming output.</text>
+  <text x="72" y="250" font-family="'Segoe UI',Helvetica,Arial,sans-serif" font-size="22" fill="#A6AECB">The shared runtime behind every LangStage surface.</text>
 
   <g font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="13" fill="#7C7FA6">
-    <text x="72" y="298">StreamParser</text>
+    <text x="72" y="298">build_agent</text>
     <text x="196" y="298" fill="#45487A">&#8226;</text>
-    <text x="216" y="298">extractors</text>
-    <text x="312" y="298" fill="#45487A">&#8226;</text>
-    <text x="332" y="298">adapters</text>
-    <text x="420" y="298" fill="#45487A">&#8226;</text>
-    <text x="440" y="298">host &#183; demo</text>
+    <text x="216" y="298">verify</text>
+    <text x="288" y="298" fill="#45487A">&#8226;</text>
+    <text x="308" y="298">extractors</text>
+    <text x="404" y="298" fill="#45487A">&#8226;</text>
+    <text x="424" y="298">host &#183; demo</text>
   </g>
 
   <!-- ===== right: stream -> typed events ===== -->
@@ -50,37 +50,37 @@
     <line x1="150" y1="20" x2="196" y2="20" stroke="url(#accent)" stroke-width="2"/>
     <path d="M196 20 l-9 -5 v10 z" fill="#34D6C8"/>
 
-    <!-- parser node -->
-    <rect x="196" y="2" width="118" height="36" rx="10" fill="#1A1535" stroke="url(#accent)" stroke-width="1.5"/>
+    <!-- bridge node -->
+    <rect x="196" y="2" width="128" height="36" rx="10" fill="#1A1535" stroke="url(#accent)" stroke-width="1.5"/>
     <circle cx="216" cy="20" r="5" fill="url(#accent)"/>
-    <text x="230" y="25" font-family="'SF Mono','Consolas',monospace" font-size="12" fill="#C9BEFF">parse()</text>
+    <text x="230" y="25" font-family="'SF Mono','Consolas',monospace" font-size="12" fill="#C9BEFF">iter_frames</text>
 
-    <!-- typed event chips -->
+    <!-- typed frame chips -->
     <g font-family="'SF Mono','Consolas',monospace" font-size="12">
       <g transform="translate(40,72)">
-        <rect width="130" height="26" rx="6" fill="#10243A" stroke="#2F9BFF" stroke-width="1"/>
+        <rect width="110" height="26" rx="6" fill="#10243A" stroke="#2F9BFF" stroke-width="1"/>
         <circle cx="15" cy="13" r="4" fill="#2F9BFF"/>
-        <text x="28" y="17" fill="#8FC4FF">ContentEvent</text>
+        <text x="28" y="17" fill="#8FC4FF">content</text>
       </g>
-      <g transform="translate(190,72)">
-        <rect width="150" height="26" rx="6" fill="#0C2A22" stroke="#34D6C8" stroke-width="1"/>
+      <g transform="translate(170,72)">
+        <rect width="130" height="26" rx="6" fill="#0C2A22" stroke="#34D6C8" stroke-width="1"/>
         <circle cx="15" cy="13" r="4" fill="#34D6C8"/>
-        <text x="28" y="17" fill="#7FE3D6">ToolCallStart</text>
+        <text x="28" y="17" fill="#7FE3D6">tool_start</text>
       </g>
       <g transform="translate(40,108)">
-        <rect width="150" height="26" rx="6" fill="#0C2A22" stroke="#34D6C8" stroke-width="1"/>
+        <rect width="120" height="26" rx="6" fill="#0C2A22" stroke="#34D6C8" stroke-width="1"/>
         <circle cx="15" cy="13" r="4" fill="#34D6C8"/>
-        <text x="28" y="17" fill="#7FE3D6">ToolCallEnd</text>
+        <text x="28" y="17" fill="#7FE3D6">tool_end</text>
       </g>
-      <g transform="translate(210,108)">
-        <rect width="130" height="26" rx="6" fill="#241A33" stroke="#7C5CFF" stroke-width="1"/>
+      <g transform="translate(180,108)">
+        <rect width="120" height="26" rx="6" fill="#241A33" stroke="#7C5CFF" stroke-width="1"/>
         <circle cx="15" cy="13" r="4" fill="#7C5CFF"/>
-        <text x="28" y="17" fill="#C9BEFF">Interrupt</text>
+        <text x="28" y="17" fill="#C9BEFF">interrupt</text>
       </g>
       <g transform="translate(40,144)">
         <rect width="180" height="26" rx="6" fill="#10243A" stroke="#2F9BFF" stroke-width="1"/>
         <circle cx="15" cy="13" r="4" fill="#2F9BFF"/>
-        <text x="28" y="17" fill="#8FC4FF">Reasoning &#183; Display &#8230;</text>
+        <text x="28" y="17" fill="#8FC4FF">reasoning &#183; extraction &#8230;</text>
       </g>
     </g>
   </g>


### PR DESCRIPTION
The README header still showed an old name. Updated the SVG header (family style, correct name/API). Found by fresh-user dogfood.