### PR TITLE
fix: relative-workspace doubling (#66) + rewrite broken examples on the 1.0 API (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [1.0.9] - 2026-07-05
+
+### Fixed
+- **A relative workspace no longer doubles the agent's working directory (gh #66).**
+  `apply_workspace()` stored the root *as given* (e.g. `./ws`), and `workspace_root()`
+  re-`.resolve()`d it against the current cwd on every call — so a surface that then
+  chdir'd *into* the workspace (the cli, or the web app's `_enter_workspace`) made every
+  subsequent `workspace_root()` re-resolve `./ws` against the new cwd and double it to
+  `ws/ws`, splitting the agent's working directory from the file browser root. The root
+  is now resolved to absolute **once**, at apply time, so `workspace_root()` is idempotent
+  across a later chdir. Absolute and default (`.`) workspaces were unaffected.
+
+### Docs
+- **The two shipped `examples/` run again on a clean 1.0 install (gh #75).** Both still
+  imported symbols removed in the 1.0 rename (`FastAPIAdapter`, `JupyterDisplay`,
+  `StreamParser`) and crashed on the first line. `fastapi_websocket.py` now drives
+  `agui.iter_event_frames` over the WebSocket (the same typed frames the web UI renders;
+  the HTML client is unchanged), and `jupyter_example.ipynb` was rewritten around
+  `agui.iter_chunk_frames`. Both run keyless. Also dropped the stale `FastAPIAdapter`
+  cross-reference in `SessionAdapter`'s docstring.
+
 ## [1.0.8] - 2026-07-04
 
 ### Fixed

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,1 +1,1 @@
-"""Runnable examples for langgraph-stream-parser."""
+"""Runnable examples for langstage-core."""

--- a/examples/agent.py
+++ b/examples/agent.py
@@ -1,10 +1,10 @@
 """A minimal, self-contained agent for the FastAPI streaming example.
 
 Keyless and dependency-light, so the WebSocket example runs with just the
-documented install — `pip install 'langgraph-stream-parser[fastapi]' uvicorn` —
-with no API key and no extra packages. It echoes the user's message back through
-a one-node LangGraph graph compiled with a checkpointer (the adapter requires one
-for threaded per-session state).
+documented install — `pip install "langstage-core[agui]" uvicorn` — with no API
+key and no extra packages. It echoes the user's message back through a one-node
+LangGraph graph compiled with a checkpointer (iter_event_frames needs one for
+threaded per-session state).
 
 Swap in your own compiled LangGraph agent for real use — e.g. a `deepagents`
 agent with real tools and a model::
@@ -14,7 +14,7 @@ agent with real tools and a model::
     from langgraph.checkpoint.memory import InMemorySaver
     agent = create_deep_agent(name="Example", checkpointer=InMemorySaver())
 
-The adapter takes any ``CompiledGraph``.
+build_agent() / iter_event_frames() take any ``CompiledGraph``.
 """
 
 from langchain_core.messages import AIMessage
@@ -32,5 +32,5 @@ _builder.add_node("respond", respond)
 _builder.add_edge(START, "respond")
 _builder.add_edge("respond", END)
 
-# The FastAPIAdapter requires a checkpointer (threaded state per session).
+# iter_event_frames needs a checkpointer for threaded state per session.
 agent = _builder.compile(checkpointer=InMemorySaver())

--- a/examples/fastapi_websocket.py
+++ b/examples/fastapi_websocket.py
@@ -1,13 +1,17 @@
 """
-FastAPI WebSocket Example using FastAPIAdapter.
+FastAPI WebSocket example — stream a LangGraph agent over a WebSocket on the AG-UI path.
 
-Demonstrates the built-in ``FastAPIAdapter`` streaming LangGraph events
-over a WebSocket with interrupt handling. The adapter is stateless —
-conversation state lives in LangGraph's checkpointer keyed by
-``session_id`` (used as ``thread_id``).
+Drives ``langstage_core.agui.iter_event_frames`` (the same typed frames the LangStage
+web UI and the VS Code sidecar render) straight over a WebSocket. Conversation state
+lives in the agent's checkpointer keyed by ``session_id`` (used as ``thread_id``), so
+reconnecting with the same id resumes the conversation.
+
+The frame vocabulary the HTML client below consumes — ``content`` / ``tool_start`` /
+``tool_end`` / ``interrupt`` / ``complete`` / ``error`` — is exactly what
+``iter_event_frames`` yields, so the client is unchanged from the pre-1.0 adapter.
 
 Requirements:
-    pip install 'langgraph-stream-parser[fastapi]' uvicorn langgraph
+    pip install "langstage-core[agui]" uvicorn langgraph
 
 Run:
     uvicorn examples.fastapi_websocket:app --reload
@@ -16,10 +20,10 @@ Then open http://localhost:8000 in your browser.
 """
 import uuid
 
-from fastapi import FastAPI, WebSocket
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 
-from langgraph_stream_parser.adapters import FastAPIAdapter
+from langstage_core.agui import build_agent, iter_event_frames
 
 # python-dotenv is optional — only needed if you load API keys from a .env (e.g.
 # when you swap in a model-backed agent). Don't make the example crash without it.
@@ -30,18 +34,44 @@ try:
 except ImportError:
     pass
 
-from .agent import agent
+from .agent import agent as _graph
 
 
 app = FastAPI()
-adapter = FastAPIAdapter(graph=agent)
+# iter_event_frames drives an already-built AG-UI LangGraphAgent; build_agent wraps
+# any CompiledGraph into one. Build it once and reuse across every session.
+agent = build_agent(_graph, name="Example")
 
 
 @app.websocket("/ws/chat/{session_id}")
 async def websocket_chat(websocket: WebSocket, session_id: str):
-    """WebSocket endpoint. Reconnecting with the same session_id resumes
-    the conversation (state lives in the checkpointer)."""
-    await adapter.handle_websocket(websocket, session_id)
+    """WebSocket endpoint. Reconnecting with the same session_id resumes the
+    conversation (state lives in the checkpointer, keyed by session_id)."""
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_json()
+            kind = data.get("type")
+            if kind == "message":
+                await websocket.send_json({"type": "ack", "ref": "message"})
+                frames = iter_event_frames(
+                    agent, data.get("content", ""), thread_id=session_id
+                )
+            elif kind == "decision":
+                # Answer an interrupt: the decisions list rides
+                # forwarded_props.command.resume -> LangGraph Command(resume=...).
+                frames = iter_event_frames(
+                    agent, "", thread_id=session_id, resume=data.get("decisions", [])
+                )
+            else:
+                await websocket.send_json(
+                    {"type": "error", "error": f"unknown message type: {kind!r}"}
+                )
+                continue
+            async for frame in frames:
+                await websocket.send_json(frame)
+    except WebSocketDisconnect:
+        return
 
 
 @app.get("/")
@@ -54,14 +84,14 @@ async def get_client():
 # The protocol: client sends
 #   {"type": "message", "content": "..."}
 #   {"type": "decision", "decisions": [{"type": "approve"}, ...]}
-# Server sends: event_to_dict(event) for each StreamEvent, plus
-#   {"type": "ack", "ref": "..."} and {"type": "error", "error": "..."}
+# Server sends: each iter_event_frames() frame (content/tool_start/tool_end/
+#   interrupt/complete/error), plus {"type": "ack", "ref": "..."}
 
 HTML_CLIENT = """
 <!DOCTYPE html>
 <html>
 <head>
-    <title>LangGraph Stream Parser - WebSocket Demo</title>
+    <title>LangStage - WebSocket Demo</title>
     <style>
         * { box-sizing: border-box; }
         body {
@@ -105,7 +135,7 @@ HTML_CLIENT = """
     </style>
 </head>
 <body>
-    <h1>LangGraph Stream Parser Demo</h1>
+    <h1>LangStage Demo</h1>
     <p class="session">Session: <code>{{SESSION_ID}}</code></p>
 
     <div id="chat"></div>

--- a/examples/jupyter_example.ipynb
+++ b/examples/jupyter_example.ipynb
@@ -2,833 +2,145 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "intro-markdown",
+   "id": "cell-0",
    "metadata": {},
    "source": [
-    "# LangGraph Stream Parser - Jupyter Display Demo\n",
+    "# langstage-core in Jupyter — streaming a LangGraph agent with `iter_chunk_frames`\n",
     "\n",
-    "This notebook demonstrates the value of `JupyterDisplay` for visualizing LangGraph agent streams.\n",
+    "`langstage_core.agui.iter_chunk_frames` is the Jupyter/CLI mapping: it drives any\n",
+    "`CompiledGraph` in-process and yields small `stream_graph_updates` chunk dicts you\n",
+    "render however you like. The frame vocabulary is:\n",
     "\n",
-    "## The Problem\n",
+    "- `{\"status\": \"streaming\", \"chunk\": \"...\", \"node\": \"...\"}` — a token delta of the answer\n",
+    "- `{\"status\": \"streaming\", \"reasoning\": \"...\"}` — a reasoning-model chain-of-thought delta\n",
+    "- `{\"status\": \"streaming\", \"tool_calls\": [...]}` / `{\"status\": \"streaming\", \"tool_result\": {...}}`\n",
+    "- `{\"status\": \"interrupt\", ...}` — a human-in-the-loop approval request\n",
+    "- `{\"status\": \"complete\"}` / `{\"status\": \"error\", ...}`\n",
     "\n",
-    "When streaming from a LangGraph agent, the raw output is:\n",
-    "- **Verbose** - Nested dictionaries with metadata you don't care about\n",
-    "- **Hard to follow** - Tool calls, messages, and interrupts all mixed together\n",
-    "- **Not real-time friendly** - Output floods the cell instead of updating in place\n",
-    "- **Interrupts break the flow** - Human-in-the-loop requires manual resumption\n",
-    "\n",
-    "## The Solution\n",
-    "\n",
-    "`JupyterDisplay` provides:\n",
-    "- **Clean panels** - Content, tools, and interrupts in organized boxes\n",
-    "- **Live updates** - Updates in place instead of flooding output\n",
-    "- **Tool lifecycle** - See tools transition from running → success/error with timing\n",
-    "- **Prominent interrupts** - Human-in-the-loop requests are impossible to miss\n",
-    "- **Interactive interrupt handling** - Automatic prompts and agent resumption with `run()`"
+    "> Requirements: `pip install \"langstage-core[agui]\" langgraph`. The example agent is\n",
+    "> keyless (a one-node echo graph), so this notebook runs with no API key. Swap in a\n",
+    "> model-backed agent (see the last cell) to see `tool_calls` / `interrupt` frames."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "setup-markdown",
+   "id": "cell-1",
    "metadata": {},
    "source": [
-    "## Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "setup-cell",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import os\n",
-    "from dotenv import load_dotenv\n",
-    "load_dotenv()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "import-agent",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from agent import agent"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "before-markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## Before: Raw Streaming Output\n",
+    "## Setup\n",
     "\n",
-    "This is what you get with vanilla `graph.stream()` - a flood of nested dictionaries:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "raw-stream",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'PatchToolCallsMiddleware.before_agent': {'messages': Overwrite(value=[HumanMessage(content='What files are in the current directory?', additional_kwargs={}, response_metadata={}, id='6032e894-e8e5-4882-a123-fffee0730ae6')])}}\n",
-      "---\n",
-      "{'SummarizationMiddleware.before_model': None}\n",
-      "---{'model': {'messages': [AIMessage(content=[{'text': \"I'll list the files in the current directory for you.\", 'type': 'text'}, {'id': 'toolu_019ifLxGo51EssTxhscxURuB', 'input': {'path': '/'}, 'name': 'ls', 'type': 'tool_use'}], additional_kwargs={}, response_metadata={'id': 'msg_01UyW3e5Meaz2oTUSkY2bn5g', 'model': 'claude-sonnet-4-5-20250929', 'stop_reason': 'tool_use', 'stop_sequence': None, 'usage': {'cache_creation': {'ephemeral_1h_input_tokens': 0, 'ephemeral_5m_input_tokens': 6258}, 'cache_creation_input_tokens': 6258, 'cache_read_input_tokens': 0, 'input_tokens': 3, 'output_tokens': 64, 'server_tool_use': None, 'service_tier': 'standard'}, 'model_name': 'claude-sonnet-4-5-20250929', 'model_provider': 'anthropic'}, name='Example', id='lc_run--019c1c59-d004-7562-9425-77ec401ad486-0', tool_calls=[{'name': 'ls', 'args': {'path': '/'}, 'id': 'toolu_019ifLxGo51EssTxhscxURuB', 'type': 'tool_call'}], invalid_tool_calls=[], usage_metadata={'input_tokens': 6261, 'output_tokens': 64, 'total_tokens': 6325, 'input_token_details': {'cache_read': 0, 'cache_creation': 6258, 'ephemeral_5m_input_tokens': 6258, 'ephemeral_1h_input_tokens': 0}})]}}\n",
-      "---\n",
-      "{'HumanInTheLoopMiddleware.after_model': None}\n",
-      "---\n",
-      "{'TodoListMiddleware.after_model': None}\n",
-      "---\n",
-      "{'tools': {'messages': [ToolMessage(content=\"['/.ipynb_checkpoints/', '/__pycache__/', '/agent.py', '/jupyter_display.py', '/jupyter_example.ipynb']\", name='ls', id='110bbbba-21a5-47df-829c-46d664cb1de9', tool_call_id='toolu_019ifLxGo51EssTxhscxURuB')]}}\n",
-      "---\n",
-      "{'SummarizationMiddleware.before_model': None}\n",
-      "---{'model': {'messages': [AIMessage(content='The current directory contains:\\n\\n1. **`.ipynb_checkpoints/`** - A directory (likely created by Jupyter for notebook checkpoints)\\n2. **`__pycache__/`** - A directory containing Python bytecode cache files\\n3. **`agent.py`** - A Python script file\\n4. **`jupyter_display.py`** - A Python script file\\n5. **`jupyter_example.ipynb`** - A Jupyter notebook file\\n\\nWould you like me to explore any of these files or directories in more detail?', additional_kwargs={}, response_metadata={'id': 'msg_01SiroiqDEXtr8KDgDY5UVAq', 'model': 'claude-sonnet-4-5-20250929', 'stop_reason': 'end_turn', 'stop_sequence': None, 'usage': {'cache_creation': {'ephemeral_1h_input_tokens': 0, 'ephemeral_5m_input_tokens': 108}, 'cache_creation_input_tokens': 108, 'cache_read_input_tokens': 6258, 'input_tokens': 6, 'output_tokens': 125, 'server_tool_use': None, 'service_tier': 'standard'}, 'model_name': 'claude-sonnet-4-5-20250929', 'model_provider': 'anthropic'}, name='Example', id='lc_run--019c1c59-d8f2-7592-86bd-7bde46888dbc-0', tool_calls=[], invalid_tool_calls=[], usage_metadata={'input_tokens': 6372, 'output_tokens': 125, 'total_tokens': 6497, 'input_token_details': {'cache_read': 6258, 'cache_creation': 108, 'ephemeral_5m_input_tokens': 108, 'ephemeral_1h_input_tokens': 0}})]}}\n",
-      "---\n",
-      "{'HumanInTheLoopMiddleware.after_model': None}\n",
-      "---\n",
-      "{'TodoListMiddleware.after_model': None}\n",
-      "---"
-     ]
-    }
-   ],
-   "source": [
-    "# Raw streaming - hard to follow!\n",
-    "for chunk in agent.stream(\n",
-    "    dict(messages=[\"What files are in the current directory?\"]), \n",
-    "    config=dict(configurable=dict(thread_id=\"raw-demo\")),\n",
-    "    stream_mode=\"updates\"\n",
-    "):\n",
-    "    print(chunk)\n",
-    "    print(\"---\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "after-markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## After: JupyterDisplay\n",
-    "\n",
-    "Same stream, but with clean, live-updating panels:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "jupyter-display-import",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from langgraph_stream_parser.adapters.jupyter import JupyterDisplay"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "jupyter-display-demo",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">OK</span> <span style=\"color: #008080; text-decoration-color: #008080\">ls</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">path</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">/</span> 36ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[32mOK\u001b[0m \u001b[36mls\u001b[0m \u001b[2;33mpath\u001b[0m\u001b[2m=\u001b[0m\u001b[2;35m/\u001b[0m 36ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #000080; text-decoration-color: #000080\">╭───────────────────────────────── assistant ──────────────────────────────────╮</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> I'll list the files in the current directory for you.The current directory   <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> contains:                                                                    <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> 1. **/.ipynb_checkpoints/** - Directory for Jupyter notebook checkpoints     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> 2. **/__pycache__/** - Directory for Python bytecode cache                   <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> 3. **/agent.py** - A Python file                                             <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> 4. **/jupyter_display.py** - A Python file                                   <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> 5. **/jupyter_example.ipynb** - A Jupyter notebook file                      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> Would you like me to explore any of these files or directories in more       <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> detail?                                                                      <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">╰──────────────────────────────────────────────────────────────────────────────╯</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[34m╭─\u001b[0m\u001b[34m────────────────────────────────\u001b[0m\u001b[34m \u001b[0m\u001b[34massistant\u001b[0m\u001b[34m \u001b[0m\u001b[34m─────────────────────────────────\u001b[0m\u001b[34m─╮\u001b[0m\n",
-       "\u001b[34m│\u001b[0m I'll list the files in the current directory for you.The current directory   \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m contains:                                                                    \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                                                              \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m 1. **/.ipynb_checkpoints/** - Directory for Jupyter notebook checkpoints     \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m 2. **/__pycache__/** - Directory for Python bytecode cache                   \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m 3. **/agent.py** - A Python file                                             \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m 4. **/jupyter_display.py** - A Python file                                   \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m 5. **/jupyter_example.ipynb** - A Jupyter notebook file                      \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                                                              \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m Would you like me to explore any of these files or directories in more       \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m detail?                                                                      \u001b[34m│\u001b[0m\n",
-       "\u001b[34m╰──────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">done</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2mdone\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "display = JupyterDisplay()\n",
-    "\n",
-    "display.run(\n",
-    "    graph=agent,\n",
-    "    input_data=dict(messages=[\"What files are in the current directory?\"]),\n",
-    "    config=dict(configurable=dict(thread_id=\"display-demo\")),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "execution_count": null,
-   "id": "a1de72b7-506b-452e-b56b-ac0ddcf6696b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "---\n",
-    "## Interrupt Handling\n",
-    "\n",
-    "When the agent needs approval (like for `bash` commands), you get a prominent red panel and an input prompt. Type your decision and the agent continues automatically:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "ksskyqt27y",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">OK</span> <span style=\"color: #008080; text-decoration-color: #008080\">think_tool</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">reflection</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">The</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> user wants me to:</span>\n",
-       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf; font-weight: bold\">1</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">. L</span><span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">...</span> 14ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[32mOK\u001b[0m \u001b[36mthink_tool\u001b[0m \u001b[2;33mreflection\u001b[0m\u001b[2m=\u001b[0m\u001b[2;35mThe\u001b[0m\u001b[2m user wants me to:\u001b[0m\n",
-       "\u001b[1;2;36m1\u001b[0m\u001b[2m. L\u001b[0m\u001b[2;33m...\u001b[0m 14ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080\">reflection:</span> <span style=\"font-style: italic\">The user wants me to:</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold; font-style: italic\">1</span><span style=\"font-style: italic\">. List files in the current folder</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold; font-style: italic\">2</span><span style=\"font-style: italic\">. Identify the third file</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold; font-style: italic\">3</span><span style=\"font-style: italic\">. Show its contents</span>\n",
-       "\n",
-       "<span style=\"font-style: italic\">They specifically requested I use:</span>\n",
-       "<span style=\"font-style: italic\">- think_tool </span><span style=\"font-weight: bold; font-style: italic\">(</span><span style=\"font-style: italic\">which I'm using now</span><span style=\"font-weight: bold; font-style: italic\">)</span>\n",
-       "<span style=\"font-style: italic\">- write_todos </span><span style=\"font-weight: bold; font-style: italic\">(</span><span style=\"font-style: italic\">to plan </span><span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">...</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[35mreflection:\u001b[0m \u001b[3mThe user wants me to:\u001b[0m\n",
-       "\u001b[1;3;36m1\u001b[0m\u001b[3m. List files in the current folder\u001b[0m\n",
-       "\u001b[1;3;36m2\u001b[0m\u001b[3m. Identify the third file\u001b[0m\n",
-       "\u001b[1;3;36m3\u001b[0m\u001b[3m. Show its contents\u001b[0m\n",
-       "\n",
-       "\u001b[3mThey specifically requested I use:\u001b[0m\n",
-       "\u001b[3m- think_tool \u001b[0m\u001b[1;3m(\u001b[0m\u001b[3mwhich I'm using now\u001b[0m\u001b[1;3m)\u001b[0m\n",
-       "\u001b[3m- write_todos \u001b[0m\u001b[1;3m(\u001b[0m\u001b[3mto plan \u001b[0m\u001b[3;33m...\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #000080; text-decoration-color: #000080\">╭───────────────────────────────── assistant ──────────────────────────────────╮</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> I'll help you find out what's in the third file of this folder. Let me start <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> by thinking through this task and creating a plan.                           <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">╰──────────────────────────────────────────────────────────────────────────────╯</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[34m╭─\u001b[0m\u001b[34m────────────────────────────────\u001b[0m\u001b[34m \u001b[0m\u001b[34massistant\u001b[0m\u001b[34m \u001b[0m\u001b[34m─────────────────────────────────\u001b[0m\u001b[34m─╮\u001b[0m\n",
-       "\u001b[34m│\u001b[0m I'll help you find out what's in the third file of this folder. Let me start \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m by thinking through this task and creating a plan.                           \u001b[34m│\u001b[0m\n",
-       "\u001b[34m╰──────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">OK</span> <span style=\"color: #008080; text-decoration-color: #008080\">write_todos</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">todos</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">[{</span><span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">'content'</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">: 'Use bash ls c</span><span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">...</span> 18ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[32mOK\u001b[0m \u001b[36mwrite_todos\u001b[0m \u001b[2;33mtodos\u001b[0m\u001b[2m=\u001b[0m\u001b[1;2m[\u001b[0m\u001b[1;2m{\u001b[0m\u001b[2;32m'content'\u001b[0m\u001b[2m: 'Use bash ls c\u001b[0m\u001b[2;33m...\u001b[0m 18ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080\">todos:</span> \n",
-       "  <span style=\"color: #808000; text-decoration-color: #808000\">▶</span> Use bash ls command to list files in the current folder\n",
-       "  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">○</span> Identify the third file from the list\n",
-       "  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">○</span> Read and display the contents of the third file\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[35mtodos:\u001b[0m \n",
-       "  \u001b[33m▶\u001b[0m Use bash ls command to list files in the current folder\n",
-       "  \u001b[2m○\u001b[0m Identify the third file from the list\n",
-       "  \u001b[2m○\u001b[0m Read and display the contents of the third file\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">...</span> <span style=\"color: #008080; text-decoration-color: #008080\">bash</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">command</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">ls</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> </span><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf; font-weight: bold\">-1</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[33m...\u001b[0m \u001b[36mbash\u001b[0m \u001b[2;33mcommand\u001b[0m\u001b[2m=\u001b[0m\u001b[2;35mls\u001b[0m\u001b[2m \u001b[0m\u001b[1;2;36m-1\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #000080; text-decoration-color: #000080\">╭───────────────────────────────── assistant ──────────────────────────────────╮</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> Now let me list the files in the current folder using bash:                  <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">╰──────────────────────────────────────────────────────────────────────────────╯</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[34m╭─\u001b[0m\u001b[34m────────────────────────────────\u001b[0m\u001b[34m \u001b[0m\u001b[34massistant\u001b[0m\u001b[34m \u001b[0m\u001b[34m─────────────────────────────────\u001b[0m\u001b[34m─╮\u001b[0m\n",
-       "\u001b[34m│\u001b[0m Now let me list the files in the current folder using bash:                  \u001b[34m│\u001b[0m\n",
-       "\u001b[34m╰──────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">OK</span> <span style=\"color: #008080; text-decoration-color: #008080\">bash</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">command</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">ls</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> </span><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf; font-weight: bold\">-1</span> 32ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[32mOK\u001b[0m \u001b[36mbash\u001b[0m \u001b[2;33mcommand\u001b[0m\u001b[2m=\u001b[0m\u001b[2;35mls\u001b[0m\u001b[2m \u001b[0m\u001b[1;2;36m-1\u001b[0m 32ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #000080; text-decoration-color: #000080\">╭───────────────────────────────── assistant ──────────────────────────────────╮</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> Now let me list the files in the current folder using bash:                  <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">╰──────────────────────────────────────────────────────────────────────────────╯</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[34m╭─\u001b[0m\u001b[34m────────────────────────────────\u001b[0m\u001b[34m \u001b[0m\u001b[34massistant\u001b[0m\u001b[34m \u001b[0m\u001b[34m─────────────────────────────────\u001b[0m\u001b[34m─╮\u001b[0m\n",
-       "\u001b[34m│\u001b[0m Now let me list the files in the current folder using bash:                  \u001b[34m│\u001b[0m\n",
-       "\u001b[34m╰──────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">OK</span> <span style=\"color: #008080; text-decoration-color: #008080\">write_todos</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">todos</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">[{</span><span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">'content'</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">: 'Use bash ls c</span><span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">...</span> 24ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[32mOK\u001b[0m \u001b[36mwrite_todos\u001b[0m \u001b[2;33mtodos\u001b[0m\u001b[2m=\u001b[0m\u001b[1;2m[\u001b[0m\u001b[1;2m{\u001b[0m\u001b[2;32m'content'\u001b[0m\u001b[2m: 'Use bash ls c\u001b[0m\u001b[2;33m...\u001b[0m 24ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080\">todos:</span> \n",
-       "  <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> Use bash ls command to list files in the current folder\n",
-       "  <span style=\"color: #808000; text-decoration-color: #808000\">▶</span> Identify the third file from the list\n",
-       "  <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">○</span> Read and display the contents of the third file\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[35mtodos:\u001b[0m \n",
-       "  \u001b[32m✓\u001b[0m Use bash ls command to list files in the current folder\n",
-       "  \u001b[33m▶\u001b[0m Identify the third file from the list\n",
-       "  \u001b[2m○\u001b[0m Read and display the contents of the third file\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">OK</span> <span style=\"color: #008080; text-decoration-color: #008080\">think_tool</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">reflection</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">Looking</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> at the ls output, </span><span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">...</span> 29ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[32mOK\u001b[0m \u001b[36mthink_tool\u001b[0m \u001b[2;33mreflection\u001b[0m\u001b[2m=\u001b[0m\u001b[2;35mLooking\u001b[0m\u001b[2m at the ls output, \u001b[0m\u001b[2;33m...\u001b[0m 29ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080\">reflection:</span> <span style=\"font-style: italic\">Looking at the ls output, I can see there are </span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold; font-style: italic\">4</span><span style=\"font-style: italic\"> items listed:</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold; font-style: italic\">1</span><span style=\"font-style: italic\">. __pycache__ </span><span style=\"font-weight: bold; font-style: italic\">(</span><span style=\"font-style: italic\">directory, shown in color code</span><span style=\"font-weight: bold; font-style: italic\">)</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold; font-style: italic\">2</span><span style=\"font-style: italic\">. agent.py</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold; font-style: italic\">3</span><span style=\"font-style: italic\">. jupyter_display.py</span>\n",
-       "<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold; font-style: italic\">4</span><span style=\"font-style: italic\">. jupyter_example.ipynb</span>\n",
-       "\n",
-       "<span style=\"font-style: italic\">The third file in the list is </span><span style=\"color: #808000; text-decoration-color: #808000; font-style: italic\">...</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[35mreflection:\u001b[0m \u001b[3mLooking at the ls output, I can see there are \u001b[0m\u001b[1;3;36m4\u001b[0m\u001b[3m items listed:\u001b[0m\n",
-       "\u001b[1;3;36m1\u001b[0m\u001b[3m. __pycache__ \u001b[0m\u001b[1;3m(\u001b[0m\u001b[3mdirectory, shown in color code\u001b[0m\u001b[1;3m)\u001b[0m\n",
-       "\u001b[1;3;36m2\u001b[0m\u001b[3m. agent.py\u001b[0m\n",
-       "\u001b[1;3;36m3\u001b[0m\u001b[3m. jupyter_display.py\u001b[0m\n",
-       "\u001b[1;3;36m4\u001b[0m\u001b[3m. jupyter_example.ipynb\u001b[0m\n",
-       "\n",
-       "\u001b[3mThe third file in the list is \u001b[0m\u001b[3;33m...\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">OK</span> <span style=\"color: #008080; text-decoration-color: #008080\">write_todos</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">todos</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">[{</span><span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">'content'</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">: 'Use bash ls c</span><span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">...</span> 26ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[32mOK\u001b[0m \u001b[36mwrite_todos\u001b[0m \u001b[2;33mtodos\u001b[0m\u001b[2m=\u001b[0m\u001b[1;2m[\u001b[0m\u001b[1;2m{\u001b[0m\u001b[2;32m'content'\u001b[0m\u001b[2m: 'Use bash ls c\u001b[0m\u001b[2;33m...\u001b[0m 26ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080\">todos:</span> \n",
-       "  <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> Use bash ls command to list files in the current folder\n",
-       "  <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> Identify the third file from the list\n",
-       "  <span style=\"color: #808000; text-decoration-color: #808000\">▶</span> Read and display the contents of the third file\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[35mtodos:\u001b[0m \n",
-       "  \u001b[32m✓\u001b[0m Use bash ls command to list files in the current folder\n",
-       "  \u001b[32m✓\u001b[0m Identify the third file from the list\n",
-       "  \u001b[33m▶\u001b[0m Read and display the contents of the third file\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">OK</span> <span style=\"color: #008080; text-decoration-color: #008080\">read_file</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">file_path</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">/</span><span style=\"color: #ff7fff; text-decoration-color: #ff7fff\">jupyter_display.py</span> 26ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[32mOK\u001b[0m \u001b[36mread_file\u001b[0m \u001b[2;33mfile_path\u001b[0m\u001b[2m=\u001b[0m\u001b[2;35m/\u001b[0m\u001b[2;95mjupyter_display.py\u001b[0m 26ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">OK</span> <span style=\"color: #008080; text-decoration-color: #008080\">read_file</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">file_path</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">/</span><span style=\"color: #ff7fff; text-decoration-color: #ff7fff\">jupyter_display.py</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">, offset</span><span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">...</span> 20ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[32mOK\u001b[0m \u001b[36mread_file\u001b[0m \u001b[2;33mfile_path\u001b[0m\u001b[2m=\u001b[0m\u001b[2;35m/\u001b[0m\u001b[2;95mjupyter_display.py\u001b[0m\u001b[2m, offset\u001b[0m\u001b[2;33m...\u001b[0m 20ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">OK</span> <span style=\"color: #008080; text-decoration-color: #008080\">read_file</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">file_path</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">/</span><span style=\"color: #ff7fff; text-decoration-color: #ff7fff\">jupyter_display.py</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">, offset</span><span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">...</span> 16ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[32mOK\u001b[0m \u001b[36mread_file\u001b[0m \u001b[2;33mfile_path\u001b[0m\u001b[2m=\u001b[0m\u001b[2;35m/\u001b[0m\u001b[2;95mjupyter_display.py\u001b[0m\u001b[2m, offset\u001b[0m\u001b[2;33m...\u001b[0m 16ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #808000; text-decoration-color: #808000\">...</span> <span style=\"color: #008080; text-decoration-color: #008080\">bash</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">command</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">wc</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> -l </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">/</span><span style=\"color: #ff7fff; text-decoration-color: #ff7fff\">jupyter_display.py</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[33m...\u001b[0m \u001b[36mbash\u001b[0m \u001b[2;33mcommand\u001b[0m\u001b[2m=\u001b[0m\u001b[2;35mwc\u001b[0m\u001b[2m -l \u001b[0m\u001b[2;35m/\u001b[0m\u001b[2;95mjupyter_display.py\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800000; text-decoration-color: #800000\">ERR</span> <span style=\"color: #008080; text-decoration-color: #008080\">bash</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">command</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">wc</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\"> -l </span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">/</span><span style=\"color: #ff7fff; text-decoration-color: #ff7fff\">jupyter_display.py</span> 22ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[31mERR\u001b[0m \u001b[36mbash\u001b[0m \u001b[2;33mcommand\u001b[0m\u001b[2m=\u001b[0m\u001b[2;35mwc\u001b[0m\u001b[2m -l \u001b[0m\u001b[2;35m/\u001b[0m\u001b[2;95mjupyter_display.py\u001b[0m 22ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">OK</span> <span style=\"color: #008080; text-decoration-color: #008080\">read_file</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">file_path</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #bf7fbf; text-decoration-color: #bf7fbf\">/</span><span style=\"color: #ff7fff; text-decoration-color: #ff7fff\">jupyter_display.py</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">, </span><span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">limit</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf; font-weight: bold\">-1</span> 11ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[32mOK\u001b[0m \u001b[36mread_file\u001b[0m \u001b[2;33mfile_path\u001b[0m\u001b[2m=\u001b[0m\u001b[2;35m/\u001b[0m\u001b[2;95mjupyter_display.py\u001b[0m\u001b[2m, \u001b[0m\u001b[2;33mlimit\u001b[0m\u001b[2m=\u001b[0m\u001b[1;2;36m-1\u001b[0m 11ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #008000; text-decoration-color: #008000\">OK</span> <span style=\"color: #008080; text-decoration-color: #008080\">write_todos</span> <span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">todos</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">=</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold\">[{</span><span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">'content'</span><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">: 'Use bash ls c</span><span style=\"color: #bfbf7f; text-decoration-color: #bfbf7f\">...</span> 36ms\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[32mOK\u001b[0m \u001b[36mwrite_todos\u001b[0m \u001b[2;33mtodos\u001b[0m\u001b[2m=\u001b[0m\u001b[1;2m[\u001b[0m\u001b[1;2m{\u001b[0m\u001b[2;32m'content'\u001b[0m\u001b[2m: 'Use bash ls c\u001b[0m\u001b[2;33m...\u001b[0m 36ms\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #800080; text-decoration-color: #800080\">todos:</span> \n",
-       "  <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> Use bash ls command to list files in the current folder\n",
-       "  <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> Identify the third file from the list\n",
-       "  <span style=\"color: #008000; text-decoration-color: #008000\">✓</span> Read and display the contents of the third file\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[35mtodos:\u001b[0m \n",
-       "  \u001b[32m✓\u001b[0m Use bash ls command to list files in the current folder\n",
-       "  \u001b[32m✓\u001b[0m Identify the third file from the list\n",
-       "  \u001b[32m✓\u001b[0m Read and display the contents of the third file\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #000080; text-decoration-color: #000080\">╭───────────────────────────────── assistant ──────────────────────────────────╮</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> Perfect! I've completed the task. Here's what I found:                       <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> ## Summary                                                                   <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> The **third file** in the folder is **`jupyter_display.py`**.                <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> ### Contents:                                                                <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> This is a Python example file (265 lines) that demonstrates how to use the   <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> **JupyterDisplay adapter** from the LangGraph Stream Parser library. The     <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> file shows how to create rich, real-time visualizations of LangGraph agent   <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> output in Jupyter notebooks.                                                 <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span>                                                                              <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> **Key sections include:**                                                    <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> 1. **Basic Usage** - Simple streaming with the `stream()` method             <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">│</span> 2. **Manual...                                                               <span style=\"color: #000080; text-decoration-color: #000080\">│</span>\n",
-       "<span style=\"color: #000080; text-decoration-color: #000080\">╰──────────────────────────────────────────────────────────────────────────────╯</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[34m╭─\u001b[0m\u001b[34m────────────────────────────────\u001b[0m\u001b[34m \u001b[0m\u001b[34massistant\u001b[0m\u001b[34m \u001b[0m\u001b[34m─────────────────────────────────\u001b[0m\u001b[34m─╮\u001b[0m\n",
-       "\u001b[34m│\u001b[0m Perfect! I've completed the task. Here's what I found:                       \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                                                              \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m ## Summary                                                                   \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                                                              \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m The **third file** in the folder is **`jupyter_display.py`**.                \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                                                              \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m ### Contents:                                                                \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m This is a Python example file (265 lines) that demonstrates how to use the   \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m **JupyterDisplay adapter** from the LangGraph Stream Parser library. The     \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m file shows how to create rich, real-time visualizations of LangGraph agent   \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m output in Jupyter notebooks.                                                 \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m                                                                              \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m **Key sections include:**                                                    \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m 1. **Basic Usage** - Simple streaming with the `stream()` method             \u001b[34m│\u001b[0m\n",
-       "\u001b[34m│\u001b[0m 2. **Manual...                                                               \u001b[34m│\u001b[0m\n",
-       "\u001b[34m╰──────────────────────────────────────────────────────────────────────────────╯\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">done</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[2mdone\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Using run() - handles interrupts interactively!\n",
-    "display = JupyterDisplay()\n",
-    "\n",
-    "display.run(\n",
-    "    graph=agent,\n",
-    "    input_data=dict(messages=[\"what's in the third file of this folder? Use think_tool, write_todos to work this out. Use the bash tool for ls\"]),\n",
-    "    config=dict(configurable=dict(thread_id=\"interactive-demo\")),\n",
-    ")\n",
-    "# When an interrupt occurs, you'll be prompted: \"Decision (approve/edit/reject): \"\n",
-    "# Type your choice and the agent continues automatically!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "features-markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## Key Features\n",
-    "\n",
-    "### 1. Tool Lifecycle Tracking\n",
-    "\n",
-    "Tools show their status in real-time:\n",
-    "- `...` (yellow) - Running\n",
-    "- `OK` (green) - Success (with execution time)\n",
-    "- `ERR` (red) - Error\n",
-    "\n",
-    "### 2. Interactive Interrupt Handling\n",
-    "\n",
-    "When using `run()`, interrupts are handled automatically:\n",
-    "1. A prominent red panel shows the tool requesting approval\n",
-    "2. You're prompted for a decision: `Decision (approve/edit/reject):`\n",
-    "3. The agent resumes with your choice - no manual intervention needed!\n",
-    "\n",
-    "### 3. Content Accumulation\n",
-    "\n",
-    "Assistant responses stream smoothly in a blue panel instead of chunk-by-chunk spam.\n",
-    "\n",
-    "### 4. Todo List Visualization\n",
-    "\n",
-    "When agents use todo/task tracking tools, tasks are displayed with status icons:\n",
-    "- `✓` (green) - Completed\n",
-    "- `▶` (yellow) - In progress  \n",
-    "- `○` (dim) - Pending"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "manual-markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "## Custom Event Processing\n",
-    "\n",
-    "For advanced use cases (filtering events, custom display logic), use `StreamParser` directly:"
+    "`agent.py` (next to this notebook) is the same keyless echo agent the FastAPI example\n",
+    "uses — any `CompiledGraph` works here."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "manual-processing",
+   "id": "cell-2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from langgraph_stream_parser import StreamParser\n",
-    "from langgraph_stream_parser.events import InterruptEvent, ToolCallStartEvent\n",
+    "from langstage_core.agui import build_agent, iter_chunk_frames\n",
+    "from agent import agent as graph\n",
     "\n",
-    "parser = StreamParser()\n",
-    "display = JupyterDisplay()\n",
-    "\n",
-    "for event in parser.parse(\n",
-    "    agent.stream(\n",
-    "        dict(messages=[\"Count Python files in this directory\"]),\n",
-    "        config=dict(configurable=dict(thread_id=\"manual-demo\")),\n",
-    "        stream_mode=\"updates\"\n",
-    "    )\n",
-    "):\n",
-    "    # Custom filtering example: skip certain events\n",
-    "    if isinstance(event, ToolCallStartEvent) and event.name == \"ls\":\n",
-    "        continue  # Skip ls tool display\n",
-    "    \n",
-    "    display.update(event)\n",
-    "    \n",
-    "    # Custom handling example\n",
-    "    if isinstance(event, InterruptEvent):\n",
-    "        print(f\"\\n[Custom handler: {len(event.action_requests)} action(s) need approval]\")"
+    "# iter_chunk_frames drives an already-built AG-UI LangGraphAgent; build_agent wraps\n",
+    "# any CompiledGraph into one.\n",
+    "agent = build_agent(graph, name=\"Example\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "config-markdown",
+   "id": "cell-3",
    "metadata": {},
    "source": [
-    "---\n",
-    "## Configuration Options"
+    "## The raw frames\n",
+    "\n",
+    "Each frame is a small dict — no nested LangGraph state to wade through. (Jupyter runs\n",
+    "an event loop, so top-level `async for` works in a cell.)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "config-demo",
+   "execution_count": null,
+   "id": "cell-4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Customize the display\n",
-    "display = JupyterDisplay(\n",
-    "    show_timestamps=False,     # Show/hide timestamps\n",
-    "    show_tool_args=True,       # Show tool arguments in the status table\n",
-    "    max_content_preview=200,   # Max characters for extraction previews\n",
-    ")"
+    "async for frame in iter_chunk_frames(agent, \"hello from Jupyter\", thread_id=\"demo\"):\n",
+    "    print(frame)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "summary-markdown",
+   "id": "cell-5",
    "metadata": {},
    "source": [
-    "---\n",
-    "## Summary\n",
+    "## Accumulate the answer live\n",
     "\n",
-    "| Raw Streaming | JupyterDisplay |\n",
-    "|---------------|----------------|\n",
-    "| Nested dicts flood output | Clean, organized panels |\n",
-    "| Tool status buried in data | Visual tool lifecycle (`...` → `OK`/`ERR`) |\n",
-    "| Interrupts stop execution | Interactive prompts with auto-resume |\n",
-    "| Content comes in chunks | Smooth content accumulation |\n",
-    "| No timing information | Execution time per tool |\n",
+    "Append `chunk` deltas to render the streamed reply in place (`IPython.display` clears\n",
+    "and re-draws the cell output as tokens arrive)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import clear_output\n",
     "\n",
-    "## Quick Start\n",
+    "answer = \"\"\n",
+    "async for frame in iter_chunk_frames(agent, \"stream this back to me\", thread_id=\"demo-2\"):\n",
+    "    if frame.get(\"chunk\"):\n",
+    "        answer += frame[\"chunk\"]\n",
+    "        clear_output(wait=True)\n",
+    "        print(answer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-7",
+   "metadata": {},
+   "source": [
+    "## Tools, interrupts, and resuming\n",
+    "\n",
+    "A model-backed agent with tools also emits `tool_calls` / `tool_result` frames, and — if\n",
+    "it uses a human-in-the-loop middleware — a `{\"status\": \"interrupt\", ...}` frame. Answer it\n",
+    "by calling `iter_chunk_frames` again on the **same `thread_id`** with `resume=` (the value\n",
+    "rides `forwarded_props.command.resume` → LangGraph `Command(resume=...)`):\n",
     "\n",
     "```python\n",
-    "from langgraph_stream_parser.adapters.jupyter import JupyterDisplay\n",
-    "\n",
-    "display = JupyterDisplay()\n",
-    "\n",
-    "display.run(\n",
-    "    graph=agent,\n",
-    "    input_data={\"messages\": [(\"user\", \"Your prompt\")]},\n",
-    "    config={\"configurable\": {\"thread_id\": \"my-session\"}}\n",
-    ")\n",
+    "# after an {\"status\": \"interrupt\", ...} frame on thread \"demo\":\n",
+    "async for frame in iter_chunk_frames(\n",
+    "    agent, \"\", thread_id=\"demo\", resume=[{\"type\": \"approve\"}]\n",
+    "):\n",
+    "    print(frame)\n",
     "```\n",
     "\n",
-    "For custom event processing (filtering, transformation), use `StreamParser.parse()` with `display.update()`."
+    "To try it for real, swap the keyless agent for a model-backed one and re-run the cells\n",
+    "above (needs an API key):\n",
+    "\n",
+    "```python\n",
+    "# pip install deepagents langchain-anthropic   # + export ANTHROPIC_API_KEY\n",
+    "from deepagents import create_deep_agent\n",
+    "from langgraph.checkpoint.memory import InMemorySaver\n",
+    "\n",
+    "graph = create_deep_agent(name=\"Example\", checkpointer=InMemorySaver())\n",
+    "agent = build_agent(graph, name=\"Example\")\n",
+    "```"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "langgraph-stream-parser",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "langgraph-stream-parser"
+   "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.8"
+version = "1.0.9"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/adapters/session.py
+++ b/src/langstage_core/adapters/session.py
@@ -1,8 +1,7 @@
 """Session-scoped streaming adapter for web hosts.
 
-Where :class:`~langstage_core.adapters.fastapi.FastAPIAdapter` is
-request-scoped (one turn per call), ``SessionAdapter`` keeps a long-lived
-session that:
+Where a request-scoped adapter runs one turn per call, ``SessionAdapter`` keeps a
+long-lived session that:
 
 - survives client disconnects (a page refresh resumes the same session),
 - multiplexes a per-session event queue so a producer turn and out-of-band

--- a/src/langstage_core/host/workspace.py
+++ b/src/langstage_core/host/workspace.py
@@ -76,9 +76,15 @@ def apply_workspace(root, *, chdir: bool = False) -> "Workspace":
     Returns the :class:`Workspace`.
     """
     global _ACTIVE
-    ws = Workspace(root).ensure()
+    # Resolve to absolute ONCE, here, before storing — so the active root is
+    # immune to a later chdir. workspace_root() returns _ACTIVE.root.resolve();
+    # if the stored root were relative (e.g. "./ws"), a surface that then chdirs
+    # *into* the workspace (cli / the web app's _enter_workspace) would make every
+    # subsequent workspace_root() re-resolve "./ws" against the new cwd and double
+    # it to ws/ws — splitting the agent's cwd from the file browser root (#66).
+    ws = Workspace(Path(root).resolve()).ensure()
     _ACTIVE = ws
-    resolved = str(ws.root.resolve())
+    resolved = str(ws.root)
     os.environ[_ENV_CANONICAL] = resolved
     os.environ[_ENV_LEGACY] = resolved
     if chdir:

--- a/tests/test_workspace_apply.py
+++ b/tests/test_workspace_apply.py
@@ -17,14 +17,27 @@ from langstage_core.host import workspace as ws_mod
 @pytest.fixture(autouse=True)
 def _isolate_active_workspace(monkeypatch, tmp_path):
     """apply_workspace sets PROCESS-global state (a module global + env + maybe cwd).
-    Snapshot and restore it around each test so invocations stay isolated."""
+    Snapshot and restore it around each test so invocations stay isolated.
+
+    NB: we snapshot/restore the workspace env vars by hand rather than via
+    monkeypatch.delenv — because apply_workspace *sets* them during the test, and
+    monkeypatch.delenv(raising=False) on an already-absent key records nothing to
+    restore, so the value would leak into the next file (it broke test_host's
+    from_env under non-alphabetical test ordering)."""
     monkeypatch.chdir(tmp_path)  # a safe cwd; monkeypatch restores the real one
     saved_active = ws_mod._ACTIVE
     monkeypatch.setattr(ws_mod, "_ACTIVE", None)
-    monkeypatch.delenv("LANGSTAGE_WORKSPACE_ROOT", raising=False)
-    monkeypatch.delenv("DEEPAGENT_WORKSPACE_ROOT", raising=False)
+    env_keys = ("LANGSTAGE_WORKSPACE_ROOT", "DEEPAGENT_WORKSPACE_ROOT")
+    saved_env = {k: os.environ.get(k) for k in env_keys}
+    for k in env_keys:
+        os.environ.pop(k, None)
     yield
     ws_mod._ACTIVE = saved_active
+    for k, v in saved_env.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
 
 
 def test_apply_workspace_publishes_the_source_of_truth(tmp_path):
@@ -64,3 +77,20 @@ def test_in_process_active_beats_stale_env(tmp_path, monkeypatch):
     monkeypatch.setenv("LANGSTAGE_WORKSPACE_ROOT", str(tmp_path / "stale"))
     apply_workspace(tmp_path / "current")
     assert workspace_root() == (tmp_path / "current").resolve()
+
+
+def test_relative_workspace_is_idempotent_across_a_later_chdir(tmp_path, monkeypatch):
+    """apply_workspace() must resolve a RELATIVE root to absolute up front, so a
+    surface that later chdirs *into* the workspace (cli, the web app's
+    _enter_workspace) doesn't make workspace_root() re-resolve "./ws" against the
+    new cwd and double it to ws/ws — the #66 split-brain.
+    """
+    monkeypatch.chdir(tmp_path)
+    apply_workspace(Path("./ws"))  # relative, exactly as the README Quickstart passes
+    expected = (tmp_path / "ws").resolve()
+    assert workspace_root() == expected
+
+    # Simulate _enter_workspace()/apply_workspace(chdir=True): move the process cwd
+    # into the workspace, then read again. It must NOT double.
+    os.chdir(workspace_root())
+    assert workspace_root() == expected  # was tmp_path/ws/ws before the fix


### PR DESCRIPTION
Two nightly-dogfood findings, shipping as **langstage-core 1.0.9**.

## #66 — relative `--workspace` doubles the agent's working directory
`apply_workspace()` stored the root *as given* (e.g. `./ws`), and `workspace_root()`
re-`.resolve()`d it against the current cwd on every call. A surface that then chdir'd
*into* the workspace (the cli, or the web app's `_enter_workspace`) made every
subsequent `workspace_root()` re-resolve `./ws` against the new cwd and double it to
`ws/ws` — splitting the agent's working directory from the file browser root (the
0.12.2 split-brain, regressed for relative paths).

**Fix:** resolve the root to absolute **once**, at apply time, so `workspace_root()` is
idempotent across a later chdir. Absolute and default (`.`) workspaces were unaffected.
Regression test drives the exact repro (apply `./ws`, chdir in, assert no doubling).

Also hardened the workspace-apply test fixture: `apply_workspace` sets the workspace env
vars mid-test and `monkeypatch.delenv(raising=False)` on an already-absent key records
nothing to restore, so the value leaked into `test_host` under non-alphabetical ordering.

## #75 — both shipped `examples/` crash on import against 1.0
Both still imported symbols removed in the 1.0 rename (`FastAPIAdapter`, `JupyterDisplay`,
`StreamParser`). Rewritten on the AG-UI path the README advertises:
- `fastapi_websocket.py` → drives `agui.iter_event_frames` over the WebSocket. The HTML
  client's frame vocabulary (`content`/`tool_start`/`tool_end`/`interrupt`/`complete`/
  `error`) already matches, so it's unchanged.
- `jupyter_example.ipynb` → rewritten around `agui.iter_chunk_frames` (the whole
  `JupyterDisplay` premise was removed in 1.0).

Both run **keyless** and are verified end-to-end (FastAPI import + a real turn; notebook
executed headless via nbconvert). Also dropped the stale `FastAPIAdapter` cross-ref in
`SessionAdapter`'s docstring.

Both filed by the nightly dogfood routine. `examples/` isn't packaged in the wheel, so
#75 is repo-only; the 1.0.9 release is driven by the #66 fix.