### PR TITLE
fix: normalize the HumanInterrupt shape so an interrupt turn doesn't crash (langstage-vscode #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.0.10] - 2026-07-06
+
+### Fixed
+- **The standard HumanInterrupt shape no longer crashes an interrupt turn (gh
+  langstage-vscode #40).** The `on_interrupt` handler in `iter_event_frames` /
+  `iter_chunk_frames` assumed the interrupt value was a dict keyed `action_requests`
+  and did `payload.get(...)` — so the **list of HumanInterrupt dicts** that deepagents /
+  langchain HITL actually emit (`[{"action_request": {...}, "config": {...}}, ...]`)
+  raised `'list' object has no attribute 'get'` and failed the turn, while any other
+  plain dict returned an empty `action_requests` (the advertised field never populated).
+  A shared `_normalize_interrupt` now handles all three shapes: the HumanInterrupt list
+  (unwrapping each `action_request` and deriving `allowed_decisions` from the `config`
+  flags), our own `action_requests`-keyed dict, and a plain dict (surfaced as a single
+  action request). Fixes the crash on every surface — the vscode sidecar and web
+  (`iter_event_frames`) and the cli (which reads `frame["interrupt"]["action_requests"]`
+  off `iter_chunk_frames` and would otherwise hit the same list crash).
+
 ## [1.0.9] - 2026-07-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.9"
+version = "1.0.10"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/agui/__init__.py
+++ b/src/langstage_core/agui/__init__.py
@@ -228,6 +228,63 @@ def serve(
     uvicorn.run(app, host=host, port=port)
 
 
+_DEFAULT_DECISIONS = ["reject", "edit", "respond", "approve"]
+
+# HumanInterrupt.config key -> the decision it permits (the deepagents / langchain
+# HITL convention). Used to derive allowed_decisions from a HumanInterrupt list.
+_CONFIG_DECISION = {
+    "allow_accept": "approve",
+    "allow_edit": "edit",
+    "allow_respond": "respond",
+    "allow_ignore": "reject",
+}
+
+
+def _normalize_interrupt(payload, default_decisions=_DEFAULT_DECISIONS):
+    """Normalize a langgraph interrupt value to ``(action_requests, review_configs,
+    allowed_decisions)``, tolerating the shapes real agents actually produce.
+
+    The on_interrupt handler used to assume the value was a dict keyed
+    ``action_requests``/``allowed_decisions`` and did ``payload.get(...)`` — which
+    crashed on the **standard HumanInterrupt list** that deepagents / langchain HITL
+    emit (``'list' object has no attribute 'get'``) and returned an empty
+    ``action_requests`` for any other dict (gh langstage-vscode #40). Handled shapes:
+
+    - a **list of HumanInterrupt dicts** —
+      ``[{"action_request": {...}, "config": {...}, "description": ...}, ...]`` — the
+      deepagents / langchain convention: each ``action_request`` becomes an action
+      request, and ``config``'s ``allow_*`` flags derive the allowed decisions;
+    - a dict **already keyed** ``action_requests`` (our own shape) — used as-is;
+    - any other **plain dict** — treated as a single action request (so a
+      ``interrupt({...})`` value surfaces instead of vanishing to ``[]``).
+    """
+    if isinstance(payload, list):
+        action_requests = []
+        allowed: set = set()
+        for item in payload:
+            if isinstance(item, dict):
+                action_requests.append(item.get("action_request", item))
+                cfg = item.get("config")
+                if isinstance(cfg, dict):
+                    allowed.update(
+                        dec for key, dec in _CONFIG_DECISION.items() if cfg.get(key)
+                    )
+            else:
+                action_requests.append(item)
+        decisions = [d for d in default_decisions if d in allowed] or list(default_decisions)
+        return action_requests, [], decisions
+    if isinstance(payload, dict):
+        if "action_requests" in payload:
+            return (
+                payload.get("action_requests", []),
+                payload.get("review_configs", []),
+                payload.get("allowed_decisions", default_decisions),
+            )
+        if payload:  # a plain dict interrupt value -> a single action request
+            return [payload], [], list(default_decisions)
+    return [], [], list(default_decisions)
+
+
 async def iter_event_frames(
     agent: Any,
     message: str,
@@ -369,12 +426,14 @@ async def iter_event_frames(
                     payload = json.loads(payload)
                 except json.JSONDecodeError:
                     payload = {}
-            payload = payload or {}
+            action_requests, review_configs, decisions = _normalize_interrupt(
+                payload, allowed_decisions
+            )
             yield {
                 "type": "interrupt",
-                "action_requests": payload.get("action_requests", []),
-                "review_configs": payload.get("review_configs", []),
-                "allowed_decisions": payload.get("allowed_decisions", allowed_decisions),
+                "action_requests": action_requests,
+                "review_configs": review_configs,
+                "allowed_decisions": decisions,
             }
         elif t == "MessagesSnapshotEvent" and not streamed_text:
             # Non-streaming graphs deliver content in one final snapshot. The snapshot
@@ -482,8 +541,19 @@ async def iter_chunk_frames(
                 try:
                     payload = json.loads(payload)
                 except json.JSONDecodeError:
-                    payload = {"action_requests": []}
-            yield {"status": "interrupt", "interrupt": payload or {"action_requests": []}}
+                    payload = {}
+            # Normalize to a dict with action_requests so a chunk-wire consumer
+            # (cli: interrupt_data.get("action_requests")) doesn't crash on the
+            # standard HumanInterrupt *list* shape and gets a populated request. (#40)
+            action_requests, review_configs, decisions = _normalize_interrupt(payload)
+            yield {
+                "status": "interrupt",
+                "interrupt": {
+                    "action_requests": action_requests,
+                    "review_configs": review_configs,
+                    "allowed_decisions": decisions,
+                },
+            }
         elif t == "MessagesSnapshotEvent" and not streamed_text:
             # Non-streaming graphs deliver content in one final snapshot. The snapshot
             # is the FULL thread, so slice to what follows the last user message —

--- a/tests/test_interrupt_normalize.py
+++ b/tests/test_interrupt_normalize.py
@@ -1,0 +1,111 @@
+"""The interrupt payload normalizer (gh langstage-vscode #40).
+
+The on_interrupt handler used to do ``payload.get("action_requests", ...)``, which
+crashed on the standard **HumanInterrupt list** that deepagents / langchain HITL emit
+(``'list' object has no attribute 'get'``) and returned an empty ``action_requests``
+for any other dict. ``_normalize_interrupt`` handles all three shapes; these tests pin
+the unit behavior and drive both frame iterators end-to-end with a list-shape agent.
+"""
+
+import asyncio
+
+from langchain_core.messages import AIMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.types import interrupt
+
+from langstage_core.agui import (
+    _normalize_interrupt,
+    build_agent,
+    iter_chunk_frames,
+    iter_event_frames,
+)
+
+# The standard HumanInterrupt list shape deepagents / langchain HITL produce.
+HUMAN_INTERRUPT = [
+    {
+        "action_request": {"action": "delete_file", "args": {"path": "/tmp/x"}},
+        "config": {"allow_accept": True, "allow_respond": True},
+        "description": "Approve deleting the file?",
+    }
+]
+
+
+# ── unit: _normalize_interrupt across shapes ─────────────────────────
+
+
+def test_human_interrupt_list_unwraps_action_request_and_derives_decisions():
+    action_requests, review_configs, decisions = _normalize_interrupt(HUMAN_INTERRUPT)
+    assert action_requests == [{"action": "delete_file", "args": {"path": "/tmp/x"}}]
+    assert review_configs == []
+    # config allow_accept + allow_respond -> approve + respond (in default order)
+    assert decisions == ["respond", "approve"]
+
+
+def test_list_without_config_falls_back_to_all_decisions():
+    action_requests, _, decisions = _normalize_interrupt([{"action_request": {"a": 1}}])
+    assert action_requests == [{"a": 1}]
+    assert decisions == ["reject", "edit", "respond", "approve"]
+
+
+def test_plain_dict_becomes_a_single_action_request():
+    # Previously returned action_requests=[] (the advertised field never populated).
+    action_requests, _, decisions = _normalize_interrupt({"action": "x", "path": "/y"})
+    assert action_requests == [{"action": "x", "path": "/y"}]
+    assert decisions == ["reject", "edit", "respond", "approve"]
+
+
+def test_our_keyed_dict_is_used_as_is():
+    action_requests, _, decisions = _normalize_interrupt(
+        {"action_requests": [{"tool": "t"}], "allowed_decisions": ["approve"]}
+    )
+    assert action_requests == [{"tool": "t"}]
+    assert decisions == ["approve"]
+
+
+def test_empty_or_none_is_safe():
+    assert _normalize_interrupt(None) == ([], [], ["reject", "edit", "respond", "approve"])
+    assert _normalize_interrupt({}) == ([], [], ["reject", "edit", "respond", "approve"])
+
+
+# ── integration: both iterators survive a list-shape interrupt ───────
+
+
+def _human_interrupt_agent():
+    def ask(state):
+        decision = interrupt(HUMAN_INTERRUPT)
+        return {"messages": [AIMessage(content=f"resumed: {decision}")]}
+
+    b = StateGraph(MessagesState)
+    b.add_node("ask", ask)
+    b.add_edge(START, "ask")
+    b.add_edge("ask", END)
+    return b.compile(checkpointer=InMemorySaver())
+
+
+async def _collect(aiter):
+    return [f async for f in aiter]
+
+
+def test_iter_event_frames_surfaces_human_interrupt_without_crashing():
+    agent = build_agent(_human_interrupt_agent(), name="HITL")
+    frames = asyncio.run(_collect(iter_event_frames(agent, "delete it", thread_id="e1")))
+    interrupts = [f for f in frames if f.get("type") == "interrupt"]
+    assert interrupts, f"no interrupt frame; got {[f.get('type') for f in frames]}"
+    assert not any(f.get("type") == "error" for f in frames)
+    # the advertised action_requests is populated from the HumanInterrupt list
+    assert interrupts[0]["action_requests"] == [
+        {"action": "delete_file", "args": {"path": "/tmp/x"}}
+    ]
+
+
+def test_iter_chunk_frames_surfaces_human_interrupt_without_crashing():
+    agent = build_agent(_human_interrupt_agent(), name="HITL")
+    frames = asyncio.run(_collect(iter_chunk_frames(agent, "delete it", thread_id="c1")))
+    interrupts = [f for f in frames if f.get("status") == "interrupt"]
+    assert interrupts, f"no interrupt frame; got {[f.get('status') for f in frames]}"
+    assert not any(f.get("status") == "error" for f in frames)
+    # a chunk-wire consumer (cli) reads frame["interrupt"]["action_requests"]
+    assert interrupts[0]["interrupt"]["action_requests"] == [
+        {"action": "delete_file", "args": {"path": "/tmp/x"}}
+    ]


### PR DESCRIPTION
Root cause of langstage-vscode #40 (nightly dogfood), fixed here in core so every surface benefits.

The `on_interrupt` handler in `iter_event_frames` / `iter_chunk_frames` did
`payload.get("action_requests", ...)`, assuming the interrupt value is a dict keyed
`action_requests`. But:
- the **standard HumanInterrupt list** deepagents / langchain HITL emit —
  `[{"action_request": {...}, "config": {...}, "description": ...}, ...]` — has no
  `.get`, so the turn crashed with `'list' object has no attribute 'get'`;
- any other **plain dict** (`interrupt({"action": ...})`) returned an empty
  `action_requests` — the advertised field never populated;
- only a dict literally keyed `action_requests`/`allowed_decisions` (a shape no adopter
  would guess) worked.

**Fix:** a shared `_normalize_interrupt(payload)` handles all three shapes — the
HumanInterrupt list (unwrapping each `action_request`, deriving `allowed_decisions` from
the `config` `allow_*` flags), our own keyed dict, and a plain dict (surfaced as a single
action request). Applied to **both** iterators, so it fixes the crash on the event wire
(vscode sidecar, web) and the chunk wire (cli reads `frame["interrupt"]["action_requests"]`
and would hit the same list crash).

Unit tests for every shape + integration tests driving both iterators with a real
`interrupt([HumanInterrupt])` agent (the exact repro) — no crash, `action_requests`
populated. Full suite 138 passed. Ships as **1.0.10**.