### PR TITLE
docs: stop over-promising the langgraph_stream_parser compat shim (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.0.11] - 2026-07-06
+
+### Docs
+- **The README no longer over-promises the `langgraph_stream_parser` compat shim (gh
+  #77).** The banner and migration guide said the old import "still works via a compat
+  shim," which read as "install `langstage-core` and `import langgraph_stream_parser`
+  keeps working" — but the shim is a **separate** distribution (`langgraph-stream-parser`
+  1.0, which re-exports `langstage_core`) that `langstage-core` neither bundles nor
+  depends on (depending on it would be circular). So a fresh `pip install langstage-core`
+  hit `ModuleNotFoundError` on the old import. The README now states the old name keeps
+  working only while the separate `langgraph-stream-parser` package stays installed
+  (kept on an in-place upgrade; add it explicitly, or just `import langstage_core`, on a
+  fresh install).
+
 ## [1.0.10] - 2026-07-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 The shared core behind the **[LangStage](https://github.com/dkedar7/langstage) family**: a host layer for LangGraph agents (spec-loading + layered config), an in-process **AG-UI** bridge that streams any `CompiledGraph` to a frontend, an async task-delegation engine, and interrupt-aware input helpers. Write your agent once — any LangGraph `CompiledGraph` — and every LangStage surface runs it the same way.
 
-> **1.0 — renamed from `langgraph-stream-parser`.** The old `StreamParser` / `events` / `event_to_dict` event layer was retired in favor of the AG-UI wire (see [Migrating](#migrating-from-langgraph-stream-parser) and [ADR 0003](docs/adr/0003-deprecate-the-event-layer.md)). The old import name still works via a compat shim.
+> **1.0 — renamed from `langgraph-stream-parser`.** The old `StreamParser` / `events` / `event_to_dict` event layer was retired in favor of the AG-UI wire (see [Migrating](#migrating-from-langgraph-stream-parser) and [ADR 0003](docs/adr/0003-deprecate-the-event-layer.md)). The old `import langgraph_stream_parser` keeps working **as long as the separate `langgraph-stream-parser` compat package stays installed** (it re-exports `langstage_core`); a fresh install of `langstage-core` alone does not provide it.
 
 ## Every stage for your LangGraph agent
 
@@ -121,7 +121,10 @@ python -m langstage_core.host      # or each surface's --show-config
 
 ## Migrating from langgraph-stream-parser
 
-`langstage-core` **1.0** is the rename of `langgraph-stream-parser`. Importing the old name still works via a compat shim that re-exports `langstage_core` (with a `DeprecationWarning`), so `import langgraph_stream_parser` and its submodules keep resolving — but update to `import langstage_core` when convenient.
+`langstage-core` **1.0** is the rename of `langgraph-stream-parser`. The old import name keeps working **through a separate compat package** — `langgraph-stream-parser` 1.0, which now just re-exports `langstage_core` (with a `DeprecationWarning`). So `import langgraph_stream_parser` and its submodules keep resolving **only while that package remains installed**:
+
+- **Upgrading in place** (`pip install -U langgraph-stream-parser`) → you keep the shim package, so the old import keeps working. Update to `import langstage_core` when convenient.
+- **Installing `langstage-core` fresh** does **not** pull the shim (it's a separate distribution, and depending on it would be circular). Either `import langstage_core` (recommended), or `pip install langgraph-stream-parser` alongside if you need the old name during a transition.
 
 The **event layer was removed** in 1.0. If you used it directly, migrate:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.10"
+version = "1.0.11"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Closes #77 (nightly dogfood). Docs-only.

The README banner and "Migrating" section said the old import name "still works via a
compat shim" — which reads as "install `langstage-core` and `import langgraph_stream_parser`
keeps working." But the shim is a **separate** PyPI distribution (`langgraph-stream-parser`
1.0, which now re-exports `langstage_core` with a `DeprecationWarning`) that `langstage-core`
neither bundles nor depends on — depending on it would be circular (the shim requires core).
So a clean `pip install "langstage-core[agui]"` followed by `import langgraph_stream_parser`
hits `ModuleNotFoundError`, contradicting the migration guide readers consult when upgrading.

**Fix (docs):** the README now states the old import keeps working **only while the separate
`langgraph-stream-parser` package stays installed** — you keep it on an in-place upgrade
(`pip install -U langgraph-stream-parser`); on a fresh `langstage-core` install, either
`import langstage_core` (recommended) or `pip install langgraph-stream-parser` alongside.

Ships as **1.0.11** so the corrected README reaches PyPI.