### PR TITLE
fix: re-export SessionAdapter/Session at the top level, matching the docs (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.0.12] - 2026-07-07
+
+### Fixed
+- **`from langstage_core import SessionAdapter` / `Session` now works, matching the docs
+  (gh #80).** The README's "What's in the box" says everything is re-exported at the top
+  level (except the AG-UI helpers), and lists `SessionAdapter` / `Session` — but they were
+  only importable from `langstage_core.adapters`, so the documented top-level import raised
+  `ImportError`. They are now re-exported at the top level (still available under
+  `langstage_core.adapters` too). Also corrected the package docstring, which had
+  miscategorized `SessionAdapter` under the `agui` bullet (implying
+  `from langstage_core.agui import SessionAdapter`, which never worked).
+
 ## [1.0.11] - 2026-07-06
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Everything is re-exported from the top-level `langstage_core` package (except th
 |---|---|---|
 | **Host** | `load_agent_spec`, `HostConfig`, `Workspace` | Load a graph from a `module:attr` / `file.py:attr` spec; resolve layered config (defaults < `langstage.toml` < `LANGSTAGE_*` env < overrides). |
 | **AG-UI bridge** (`langstage_core.agui`) | `build_agent`, `iter_event_frames`, `iter_chunk_frames`, `build_app`, `serve`, `add_agui_endpoint` | Stream any `CompiledGraph` in-process (the `iter_*` mappings) or serve it as an AG-UI HTTP endpoint. |
-| **Session adapter** (`langstage_core.adapters`) | `SessionAdapter`, `Session` | A session-scoped driver over the AG-UI agent with a typed terminal `outcome` — the streaming engine behind the web app + task board. |
+| **Session adapter** (top-level; also `langstage_core.adapters`) | `SessionAdapter`, `Session` | A session-scoped driver over the AG-UI agent with a typed terminal `outcome` — the streaming engine behind the web app + task board. |
 | **Input helpers** | `prepare_agent_input`, `create_resume_input` | Build graph input from a message (+ optional context) or a resume decision. |
 | **Extractors** | `ToolExtractor` + built-ins (`ThinkToolExtractor`, `TodoExtractor`, `DisplayInlineExtractor`, `SkillManageExtractor`, `MemoryExtractor`, …) | Turn a tool's result into a structured `extraction` frame; pass `extractors=[...]` to the `iter_*` mappings. |
 | **Task engine** | `TaskRunner`, `TaskStore`, `InMemoryTaskStore`, `TASK_TOOLS`, `set_runner`, `get_runner` | Async delegate-and-walk-away worker pool + a persistence-agnostic store Protocol; `TASK_TOOLS` are the agent-facing delegation tools. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.11"
+version = "1.0.12"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/__init__.py
+++ b/src/langstage_core/__init__.py
@@ -8,8 +8,10 @@ AG-UI adapter instead. What remains is the *durable* core —
   - **host**: ``load_agent_spec`` + ``HostConfig`` + ``Workspace`` (write once,
     run on every surface with the same spec string and ``langstage.toml`` config).
   - **agui**: ``build_agent`` + ``iter_event_frames`` / ``iter_chunk_frames``
-    (the in-process AG-UI stream, with an ``extractors=`` hook), ``build_app`` /
-    ``serve`` for the wire, and ``SessionAdapter`` for session-scoped streaming.
+    (the in-process AG-UI stream, with an ``extractors=`` hook), and ``build_app`` /
+    ``serve`` for the wire. (These live under ``langstage_core.agui``, not top-level.)
+  - **adapters**: ``SessionAdapter`` / ``Session`` for session-scoped streaming
+    (also re-exported at the top level).
   - **tasks**: the durable task-delegation engine.
   - **extractors**: the ``ToolExtractor`` protocol + reusable built-ins.
 
@@ -33,6 +35,7 @@ from .extractors import (
     TodoExtractor,
     ToolExtractor,
 )
+from .adapters import Session, SessionAdapter
 from .host import (
     HostConfig,
     Workspace,
@@ -66,6 +69,9 @@ __all__ = [
     "Workspace",
     "apply_workspace",
     "workspace_root",
+    # Session-scoped streaming adapter (also under langstage_core.adapters)
+    "SessionAdapter",
+    "Session",
     # Input helpers
     "prepare_agent_input",
     "create_resume_input",

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,48 @@
+"""The top-level public API matches what the README documents (gh #80).
+
+The README's "What's in the box" says everything is re-exported from the top-level
+`langstage_core` package (except the AG-UI helpers under `langstage_core.agui`). Two docs
+pointed `SessionAdapter` / `Session` at import paths that raised ImportError; these tests
+pin the documented surface so it can't silently drift again.
+"""
+
+import langstage_core
+
+
+def test_session_adapter_is_importable_top_level():
+    # gh #80: `from langstage_core import SessionAdapter, Session` was promised by the
+    # README's blanket top-level claim but used to ImportError.
+    from langstage_core import Session, SessionAdapter
+
+    assert SessionAdapter is not None and Session is not None
+
+
+def test_top_level_matches_the_adapters_submodule():
+    from langstage_core import Session, SessionAdapter
+    from langstage_core.adapters import Session as S2
+    from langstage_core.adapters import SessionAdapter as SA2
+
+    assert SessionAdapter is SA2
+    assert Session is S2
+
+
+def test_documented_top_level_names_are_all_exported():
+    # A representative slice of the README "What's in the box" top-level surface.
+    expected = {
+        "load_agent_spec",
+        "HostConfig",
+        "Workspace",
+        "apply_workspace",
+        "workspace_root",
+        "SessionAdapter",
+        "Session",
+        "prepare_agent_input",
+        "create_resume_input",
+        "ToolExtractor",
+        "TaskRunner",
+    }
+    missing = expected - set(langstage_core.__all__)
+    assert not missing, f"missing from __all__: {missing}"
+    # everything advertised in __all__ actually imports off the package
+    for name in langstage_core.__all__:
+        assert hasattr(langstage_core, name), f"{name} in __all__ but not importable"


### PR DESCRIPTION
Closes #80 (nightly dogfood).

The README's "What's in the box" says *"Everything is re-exported from the top-level
`langstage_core` package (except the AG-UI helpers under `langstage_core.agui`)"* and lists
`SessionAdapter` / `Session` as their own area — so `from langstage_core import SessionAdapter`
is promised. And the package `__init__` docstring filed `SessionAdapter` under the **agui**
bullet, implying `from langstage_core.agui import SessionAdapter`. **Both raised ImportError** —
the only working path was `from langstage_core.adapters import SessionAdapter, Session`.

**Fix:** honor the documented contract — re-export `SessionAdapter` / `Session` at the top
level (still available under `langstage_core.adapters`), and fix the docstring
miscategorization (moved to its own `adapters` bullet, agui bullet clarified as submodule-only).

Regression test pins the top-level surface (both import paths resolve to the same objects,
and every `__all__` name is importable). Docs-adjacent but ships as **1.0.12** so the
working import reaches PyPI.