### PR TITLE
fix: unwrap create_resume_input's Command (#82) + malformed-TOML source/warning (hermes #61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [1.0.13] - 2026-07-08
+
+### Fixed
+- **`create_resume_input(...)` no longer double-wraps under `iter_event_frames` /
+  `iter_chunk_frames`, crashing HITL resume (gh #82).** `create_resume_input()` returns a
+  LangGraph `Command`, but the iterators' `resume=` builds the `Command` themselves
+  (`forwarded_props.command.resume`), so passing the helper's output produced
+  `Command(resume=Command(...))` — the graph's `interrupt()` then returned the inner
+  `Command` and a realistic HITL node crashed with `'Command' object is not subscriptable`.
+  The iterators now unwrap a `Command`'s `.resume`, so **both** `resume=create_resume_input(...)`
+  and a raw `resume={"decisions": [...]}` converge on a single, correct wrap. Also refreshed
+  `create_resume_input`'s docstring (its examples used the removed `StreamParser.parse` API).
+- **A malformed TOML config is no longer listed as "read", and its warning prints once
+  (gh langstage-hermes #61).** `_read_toml` caught a `TOMLDecodeError`, returned `{}`, and
+  warned — but `load_toml_config` still appended the file to `sources` (so `--show-config`
+  printed `TOML read from: <it>`, contradicting the "ignoring malformed" note), and the note
+  was emitted twice (the loader plus the source-labeling re-read each warned). `_read_toml`
+  now records malformed paths and dedupes the warning; loaders skip listing a malformed file.
+
 ## [1.0.12] - 2026-07-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.12"
+version = "1.0.13"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/agui/__init__.py
+++ b/src/langstage_core/agui/__init__.py
@@ -285,6 +285,29 @@ def _normalize_interrupt(payload, default_decisions=_DEFAULT_DECISIONS):
     return [], [], list(default_decisions)
 
 
+def _unwrap_resume(resume):
+    """Return the raw resume payload, accepting either the payload OR a langgraph
+    ``Command`` built by :func:`create_resume_input`.
+
+    ``iter_event_frames`` / ``iter_chunk_frames`` wrap ``resume`` into
+    ``forwarded_props.command.resume``, which ag-ui-langgraph turns into
+    ``Command(resume=...)``. But ``create_resume_input()`` *also* returns a
+    ``Command``, so passing it straight through double-wrapped it — the graph's
+    ``interrupt()`` then returned the inner ``Command`` instead of the decision and
+    a realistic HITL node crashed with ``'Command' object is not subscriptable``
+    (gh #82). If the caller already built a ``Command``, use its ``.resume`` value so
+    both ``resume=create_resume_input(...)`` and a raw ``resume={"decisions": ...}``
+    converge on the same single wrap.
+    """
+    if resume is None:
+        return None
+    try:
+        from langgraph.types import Command
+    except ImportError:  # pragma: no cover - langgraph is always present in practice
+        return resume
+    return resume.resume if isinstance(resume, Command) else resume
+
+
 async def iter_event_frames(
     agent: Any,
     message: str,
@@ -323,6 +346,7 @@ async def iter_event_frames(
 
     allowed_decisions = ["reject", "edit", "respond", "approve"]
     by_tool = {e.tool_name: e for e in extractors}
+    resume = _unwrap_resume(resume)  # accept create_resume_input()'s Command too (gh #82)
     forwarded_props = {"command": {"resume": resume}} if resume is not None else {}
     run_input = RunAgentInput(
         thread_id=thread_id,
@@ -486,6 +510,7 @@ async def iter_chunk_frames(
     import json
     import uuid
 
+    resume = _unwrap_resume(resume)  # accept create_resume_input()'s Command too (gh #82)
     forwarded_props = {"command": {"resume": resume}} if resume is not None else {}
     run_input = RunAgentInput(
         thread_id=thread_id,

--- a/src/langstage_core/host/config.py
+++ b/src/langstage_core/host/config.py
@@ -109,6 +109,13 @@ def _print_legacy_env_notice(legacy: str, canonical: str) -> None:
 
 _warned_legacy_toml: set[str] = set()
 
+# Paths whose TOML parse failed. Callers (loaders, --show-config) consult this so a
+# malformed/ignored file is never listed as "read" (gh langstage-hermes #61).
+_malformed_toml: set[str] = set()
+# Dedupe the "ignoring malformed config" notice — _read_toml is called more than once
+# per path (loader + the per-file source-labeling re-read), which double-warned (#61).
+_warned_malformed_toml: set[str] = set()
+
 
 def _warn_legacy_toml(path: Path, canonical_name: str) -> None:
     """Visible deprecation notice when a legacy-named TOML file is resolved
@@ -195,19 +202,25 @@ def _read_toml(path: Path) -> dict:
     # Windows, and `tomllib.load()` (binary) chokes on it with a cryptic
     # "Invalid statement (at line 1, column 1)" — which, because jupyter's
     # config resolves at import time, bricked the whole extension. (gh #-dogfood)
+    key = str(path)
     try:
-        return _tomllib.loads(path.read_text(encoding="utf-8-sig"))
+        data = _tomllib.loads(path.read_text(encoding="utf-8-sig"))
+        _malformed_toml.discard(key)  # a file that previously failed now parses
+        return data
     except Exception as exc:  # noqa: BLE001 — a broken config must not brick every entrypoint
         # Several surfaces resolve config at import time, so a raw TOMLDecodeError
         # (or an unreadable file) here would kill --version / --help / --demo,
         # `import langstage_jupyter`, and the server extension — not just the command
-        # that needs the config. Skip the bad file with a visible one-line notice and
-        # fall back to env + defaults. ASCII-only (cp1252-safe). (gh #42)
-        print(
-            f"note: ignoring malformed config {path} "
-            f"({type(exc).__name__}: {exc}); using environment + defaults instead.",
-            file=sys.stderr,
-        )
+        # that needs the config. Skip the bad file, record it as malformed so it isn't
+        # later listed as "read", and warn ONCE (ASCII-only, cp1252-safe). (gh #42, #61)
+        _malformed_toml.add(key)
+        if key not in _warned_malformed_toml:
+            print(
+                f"note: ignoring malformed config {path} "
+                f"({type(exc).__name__}: {exc}); using environment + defaults instead.",
+                file=sys.stderr,
+            )
+            _warned_malformed_toml.add(key)
         return {}
 
 
@@ -229,15 +242,17 @@ def load_toml_config(start: Path | None = None) -> tuple[dict, list[Path]]:
     gpath = _global_toml_path()
     if gpath.is_file():
         merged = _deep_merge(merged, _read_toml(gpath))
-        sources.append(gpath)
-        if gpath == LEGACY_GLOBAL_TOML:
-            _warn_legacy_toml(gpath, str(GLOBAL_TOML))
+        if str(gpath) not in _malformed_toml:  # don't list an ignored file as read (#61)
+            sources.append(gpath)
+            if gpath == LEGACY_GLOBAL_TOML:
+                _warn_legacy_toml(gpath, str(GLOBAL_TOML))
     ppath = _find_project_toml(start)
     if ppath is not None:
         merged = _deep_merge(merged, _read_toml(ppath))
-        sources.append(ppath)
-        if ppath.name == LEGACY_PROJECT_TOML:
-            _warn_legacy_toml(ppath, PROJECT_TOML)
+        if str(ppath) not in _malformed_toml:
+            sources.append(ppath)
+            if ppath.name == LEGACY_PROJECT_TOML:
+                _warn_legacy_toml(ppath, PROJECT_TOML)
     return merged, sources
 
 

--- a/src/langstage_core/resume.py
+++ b/src/langstage_core/resume.py
@@ -25,24 +25,27 @@ def create_resume_input(
             simple confirmation.
 
     Returns:
-        A LangGraph Command object ready to pass to graph.stream().
+        A LangGraph ``Command``. Pass it to the 1.0 streaming path via
+        ``iter_event_frames``/``iter_chunk_frames``'s ``resume=`` (they accept
+        either this ``Command`` or the raw resume payload — gh #82), or to
+        ``graph.stream(...)`` directly.
 
     Raises:
         ValueError: If neither decisions nor value is provided,
             or if both are provided.
 
     Example:
-        # Resume with approval decisions
-        resume_input = create_resume_input(
-            decisions=[{"type": "approve"}]
-        )
-        for event in parser.parse(graph.stream(resume_input, config=config)):
-            handle_event(event)
+        # Resume an interrupt over the 1.0 AG-UI streaming path:
+        from langstage_core.agui import iter_event_frames
+        resume = create_resume_input(decisions=[{"type": "approve"}])
+        async for frame in iter_event_frames(agent, "", thread_id, resume=resume):
+            handle(frame)
 
-        # Resume with simple value
-        resume_input = create_resume_input(value=True)
-        for event in parser.parse(graph.stream(resume_input, config=config)):
-            handle_event(event)
+        # A raw payload works too — resume={"decisions": [{"type": "approve"}]}.
+
+        # Or resume a bare graph.stream() directly (a Command is what it expects):
+        for event in graph.stream(resume, config=config):
+            ...
     """
     if decisions is None and value is None:
         raise ValueError("Must provide either 'decisions' or 'value'")

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -228,6 +228,27 @@ class TestLangstageVocabulary:
         assert "ignoring malformed config" in err and "langstage.toml" in err
         err.encode("cp1252")  # ASCII-only — must not crash a cp1252 console
 
+    def test_malformed_toml_not_listed_as_read_and_warns_once(
+        self, isolated_global, tmp_path, monkeypatch, capsys
+    ):
+        # gh langstage-hermes #61: a malformed file was appended to `sources`
+        # (so --show-config printed "TOML read from: <it>", contradicting the
+        # "ignoring malformed" note) and the note was emitted twice (the loader plus
+        # the source-labeling re-read each warned).
+        import langstage_core.host.config as config_mod
+
+        p = tmp_path / "langstage.toml"
+        p.write_text("[ok]\nx = 1\n[oops\n")  # line 3: unterminated table header
+        config_mod._malformed_toml.discard(str(p))
+        config_mod._warned_malformed_toml.discard(str(p))
+        monkeypatch.chdir(tmp_path)
+
+        merged, sources = config_mod.load_toml_config(start=tmp_path)
+        config_mod._read_toml(p)  # a second read (as --show-config source-labeling does)
+
+        assert p not in sources, "an ignored/malformed file must not be listed as read"
+        assert capsys.readouterr().err.count("ignoring malformed config") == 1
+
     def test_legacy_toml_warns(self, isolated_global, tmp_path):
         # gh #25: legacy DEEPAGENT_* env warns, but a legacy deepagents.toml used to
         # resolve silently. It now raises a DeprecationWarning too.

--- a/tests/test_interrupt_normalize.py
+++ b/tests/test_interrupt_normalize.py
@@ -14,8 +14,10 @@ from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.graph import END, START, MessagesState, StateGraph
 from langgraph.types import interrupt
 
+from langstage_core import create_resume_input
 from langstage_core.agui import (
     _normalize_interrupt,
+    _unwrap_resume,
     build_agent,
     iter_chunk_frames,
     iter_event_frames,
@@ -109,3 +111,54 @@ def test_iter_chunk_frames_surfaces_human_interrupt_without_crashing():
     assert interrupts[0]["interrupt"]["action_requests"] == [
         {"action": "delete_file", "args": {"path": "/tmp/x"}}
     ]
+
+
+# ── resume: create_resume_input()'s Command must not double-wrap (gh #82) ──
+
+
+def test_unwrap_resume_accepts_command_and_raw_payload():
+    cmd = create_resume_input(decisions=[{"type": "approve"}])
+    # a Command is unwrapped to its .resume payload...
+    assert _unwrap_resume(cmd) == {"decisions": [{"type": "approve"}]}
+    # ...and a raw payload passes through untouched; None stays None.
+    raw = {"decisions": [{"type": "approve"}]}
+    assert _unwrap_resume(raw) is raw
+    assert _unwrap_resume(None) is None
+
+
+def _decision_reading_agent():
+    """A realistic HITL node that reads the resume decision as a mapping — it crashes
+    (`'Command' object is not subscriptable`) if resume was double-wrapped (gh #82)."""
+    def act(state):
+        decision = interrupt([{"action_request": {"action": "delete", "args": {}},
+                               "config": {"allow_accept": True}}])
+        choice = decision["decisions"][0]["type"]
+        return {"messages": [AIMessage(content=f"chose: {choice}")]}
+
+    b = StateGraph(MessagesState)
+    b.add_node("act", act)
+    b.add_edge(START, "act")
+    b.add_edge("act", END)
+    return b.compile(checkpointer=InMemorySaver())
+
+
+def _resume_roundtrip(thread_id, resume):
+    agent = build_agent(_decision_reading_agent(), name="HITL")
+    asyncio.run(_collect(iter_event_frames(agent, "go", thread_id)))  # hit the interrupt
+    return asyncio.run(_collect(iter_event_frames(agent, "", thread_id, resume=resume)))
+
+
+def test_resume_with_create_resume_input_command_does_not_double_wrap():
+    # The exact #82 repro: resume= create_resume_input(...) (a Command) used to
+    # double-wrap and crash the HITL node.
+    frames = _resume_roundtrip("r-cmd", create_resume_input(decisions=[{"type": "accept"}]))
+    assert not any(f.get("type") == "error" for f in frames), frames
+    content = "".join(f.get("content", "") for f in frames if f.get("type") == "content")
+    assert "chose: accept" in content
+
+
+def test_resume_with_raw_payload_still_works():
+    frames = _resume_roundtrip("r-raw", {"decisions": [{"type": "accept"}]})
+    assert not any(f.get("type") == "error" for f in frames), frames
+    content = "".join(f.get("content", "") for f in frames if f.get("type") == "content")
+    assert "chose: accept" in content


### PR DESCRIPTION
Two nightly-dogfood findings that both root-cause in core.

## #82 — `create_resume_input()` double-wraps and crashes HITL resume
`create_resume_input()` returns a LangGraph `Command`, but `iter_event_frames` /
`iter_chunk_frames`'s `resume=` builds the `Command` itself
(`forwarded_props = {"command": {"resume": resume}}`). Passing the helper's output gave
`Command(resume=Command(...))`; the graph's `interrupt()` then returned the inner `Command`
and a realistic HITL node (`decision["decisions"][0]`) crashed with `'Command' object is not
subscriptable`. **Fix:** `_unwrap_resume` unwraps a `Command`'s `.resume`, so **both**
`resume=create_resume_input(...)` and a raw `resume={"decisions": [...]}` converge on a single
correct wrap. Docstring refreshed (it used the removed `StreamParser.parse` API).

## langstage-hermes #61 — malformed TOML listed as "read" + double warning
`_read_toml` caught the `TOMLDecodeError`, returned `{}`, and warned — but `load_toml_config`
still appended the file to `sources`, so `--show-config` printed `TOML read from: <it>`,
contradicting its own "ignoring malformed config" note. And the note printed **twice** (the
loader plus the #55 source-labeling re-read each warned). **Fix:** `_read_toml` records
malformed paths + dedupes the warning; loaders skip listing a malformed file. (The
hermes-project-TOML footer + its loader get the matching fix in a follow-up hermes release
that consults the new `_malformed_toml` set.)

Tests: both resume shapes round-trip without crashing; malformed file excluded from `sources`
and warned exactly once. Full suite 145 passed. Ships as **1.0.13**.