### PR TITLE
feat: describe() is the single complete config diagnostic — renders [configurable] too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.0.14] - 2026-07-08
+
+### Changed
+- **`HostConfig.describe()` is now the single, complete config diagnostic — it renders the
+  `[configurable]` table too (new `configurable=` arg).** A run of nightly issues
+  (#55/#57/#61/#64/#66) were all "config-diagnostic drift": each surface assembled its own
+  `--show-config` / interactive `/config` output (base dump + a separately-rendered
+  `[configurable]` table + footer tweaks), and the pieces drifted. Folding the
+  `[configurable]` table into `describe()` means the whole diagnostic comes from one method,
+  so every surface's two config views render identically by construction. Purely additive —
+  callers that don't pass `configurable` are unchanged.
+
 ## [1.0.13] - 2026-07-08
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.13"
+version = "1.0.14"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/host/config.py
+++ b/src/langstage_core/host/config.py
@@ -423,7 +423,11 @@ class HostConfig:
         """Per-field origin from the last ``resolve()`` (field -> source)."""
         return getattr(self, "_sources", {})
 
-    def describe(self, omit_keys: list[str] | None = None) -> str:
+    def describe(
+        self,
+        omit_keys: list[str] | None = None,
+        configurable: dict | None = None,
+    ) -> str:
         """Human-readable dump: value, source, and the env var / TOML key.
 
         This is what ``python -m langstage_core.host`` prints.
@@ -432,6 +436,13 @@ class HostConfig:
         honor — e.g. a stdio-only sidecar passes ``omit_keys=["host", "port"]``
         so ``--show-config`` never advertises an env var (with a confident
         source attribution) that has zero effect on that surface.
+
+        ``configurable`` is the resolved ``[configurable]`` TOML table (the keys
+        forwarded to the graph's ``config["configurable"]``). It is rendered here so
+        the COMPLETE config diagnostic comes from this one method — every surface's
+        ``--show-config`` and interactive ``/config`` render it identically instead of
+        each bolting the table on separately and drifting (the recurring gh #55/#57/
+        #61/#64/#66 "config-diagnostic drift" class).
         """
         omit = set(omit_keys or ())
         env_map = type(self)._env_map()
@@ -460,6 +471,14 @@ class HostConfig:
             lines.append("  TOML read from: " + ", ".join(str(p) for p in toml_paths))
         else:
             lines.append("  TOML: no langstage.toml (or legacy deepagents.toml) found")
+        if configurable:
+            lines.append("")
+            lines.append("  LangGraph configurable:")
+            for k, v in configurable.items():
+                v_str = str(v)
+                if len(v_str) > 50:
+                    v_str = v_str[:50] + "..."
+                lines.append(f"    {k}: {v_str}")
         return "\n".join(lines)
 
 

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -104,6 +104,19 @@ class TestIntrospection:
         # keys it DOES honor are still shown
         assert "agent_spec" in trimmed and "workspace_root" in trimmed
 
+    def test_describe_renders_the_configurable_table(self, isolated_global, tmp_path):
+        # The complete config diagnostic — including the [configurable] table — comes
+        # from this one method, so every surface's --show-config / /config render it
+        # identically instead of bolting it on separately and drifting (gh #66 class).
+        cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
+        # no configurable -> no section
+        assert "LangGraph configurable" not in cfg.describe()
+        # a configurable table is rendered under the dump
+        text = cfg.describe(configurable={"model_name": "gpt-4o-mini", "temperature": "0.2"})
+        assert "LangGraph configurable:" in text
+        assert "model_name: gpt-4o-mini" in text
+        assert "temperature: 0.2" in text
+
 
 class TestSubclass:
     def test_subclass_adds_keys_to_same_chain(self, isolated_global, tmp_path):


### PR DESCRIPTION
The keystone of a **config-diagnostic consolidation**. Five nightly issues in a row
(#55/#57/#61/#64/#66) were the same class: *"the config diagnostic reports something wrong or
inconsistent."* Root cause across them — each surface assembles its own `--show-config` /
interactive `/config` output from pieces (`describe()` base dump **plus** a
separately-rendered `[configurable]` table **plus** footer tweaks), and the pieces drift.

**Fix:** make `HostConfig.describe()` the *complete* diagnostic. It already renders fields +
source + env/TOML keys + the TOML footer; it now also renders the `[configurable]` table via
a new `configurable=` arg. So the entire diagnostic comes from **one** method — every
surface's `--show-config` and `/config` render identically by construction, instead of each
bolting the table on separately.

Purely additive (callers that don't pass `configurable` are unchanged). Surfaces adopt it +
add parity tests in follow-up releases. Full suite 146 passed. Ships as **1.0.14**.