### PR TITLE
Fix HITL resume snippet in Jupyter example (gh #85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.0.15] - 2026-07-09
+
+### Fixed
+- **The Jupyter example notebook's HITL resume snippet used a bare list, which crashes the
+  middleware (gh #85).** `examples/jupyter_example.ipynb` showed
+  `resume=[{"type": "approve"}]`, but `HumanInTheLoopMiddleware` reads the resumed value back
+  as `interrupt(...)["decisions"]` — a list has no `["decisions"]`, so copy-pasting the
+  snippet crashed the resume. Corrected to the **decision envelope**
+  `resume={"decisions": [{"type": "approve"}]}` (the same shape `create_resume_input(...)`
+  builds and the README already documents). A new `tests/test_example_docs.py` pins the
+  notebook and README to the envelope form — it forbids a bare-list `resume=` in either and
+  ties the documented literal to `create_resume_input(...)`'s output so they can't drift.
+
 ## [1.0.14] - 2026-07-08
 
 ### Changed

--- a/examples/jupyter_example.ipynb
+++ b/examples/jupyter_example.ipynb
@@ -102,34 +102,7 @@
    "cell_type": "markdown",
    "id": "cell-7",
    "metadata": {},
-   "source": [
-    "## Tools, interrupts, and resuming\n",
-    "\n",
-    "A model-backed agent with tools also emits `tool_calls` / `tool_result` frames, and — if\n",
-    "it uses a human-in-the-loop middleware — a `{\"status\": \"interrupt\", ...}` frame. Answer it\n",
-    "by calling `iter_chunk_frames` again on the **same `thread_id`** with `resume=` (the value\n",
-    "rides `forwarded_props.command.resume` → LangGraph `Command(resume=...)`):\n",
-    "\n",
-    "```python\n",
-    "# after an {\"status\": \"interrupt\", ...} frame on thread \"demo\":\n",
-    "async for frame in iter_chunk_frames(\n",
-    "    agent, \"\", thread_id=\"demo\", resume=[{\"type\": \"approve\"}]\n",
-    "):\n",
-    "    print(frame)\n",
-    "```\n",
-    "\n",
-    "To try it for real, swap the keyless agent for a model-backed one and re-run the cells\n",
-    "above (needs an API key):\n",
-    "\n",
-    "```python\n",
-    "# pip install deepagents langchain-anthropic   # + export ANTHROPIC_API_KEY\n",
-    "from deepagents import create_deep_agent\n",
-    "from langgraph.checkpoint.memory import InMemorySaver\n",
-    "\n",
-    "graph = create_deep_agent(name=\"Example\", checkpointer=InMemorySaver())\n",
-    "agent = build_agent(graph, name=\"Example\")\n",
-    "```"
-   ]
+   "source": "## Tools, interrupts, and resuming\n\nA model-backed agent with tools also emits `tool_calls` / `tool_result` frames, and — if\nit uses a human-in-the-loop middleware — a `{\"status\": \"interrupt\", ...}` frame. Answer it\nby calling `iter_chunk_frames` again on the **same `thread_id`** with `resume=` (the value\nrides `forwarded_props.command.resume` → LangGraph `Command(resume=...)`). The resume value\nis the **decision envelope** the HITL middleware reads back — a dict with a `\"decisions\"`\nlist (the same shape `create_resume_input(decisions=[...])` builds):\n\n```python\n# after an {\"status\": \"interrupt\", ...} frame on thread \"demo\":\nasync for frame in iter_chunk_frames(\n    agent, \"\", thread_id=\"demo\", resume={\"decisions\": [{\"type\": \"approve\"}]}\n):\n    print(frame)\n```\n\nTo try it for real, swap the keyless agent for a model-backed one and re-run the cells\nabove (needs an API key):\n\n```python\n# pip install deepagents langchain-anthropic   # + export ANTHROPIC_API_KEY\nfrom deepagents import create_deep_agent\nfrom langgraph.checkpoint.memory import InMemorySaver\n\ngraph = create_deep_agent(name=\"Example\", checkpointer=InMemorySaver())\nagent = build_agent(graph, name=\"Example\")\n```"
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.14"
+version = "1.0.15"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_example_docs.py
+++ b/tests/test_example_docs.py
@@ -1,0 +1,59 @@
+"""The resume snippets in the docs use the HITL *decision envelope*, not a bare list (gh #85).
+
+The Jupyter example notebook and the README both show how to answer an `interrupt`
+frame by calling `iter_chunk_frames`/`iter_event_frames` again with `resume=`. The real
+`HumanInTheLoopMiddleware` reads the resumed value back as ``interrupt(...)["decisions"]``,
+so the resume value must be a **dict** with a ``"decisions"`` list — exactly what
+``create_resume_input(decisions=[...])`` builds. An earlier draft of the notebook passed a
+bare list (``resume=[{"type": "approve"}]``); copy-pasting it crashed HITL with a
+``TypeError``/``KeyError`` because a list has no ``["decisions"]``. These tests pin the
+documented shape so it can't silently drift back.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from langstage_core import create_resume_input
+
+_EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
+_README = Path(__file__).resolve().parent.parent / "README.md"
+_NOTEBOOK = _EXAMPLES / "jupyter_example.ipynb"
+
+# Any `resume=` assignment in a doc snippet. We only care that when the value opens with a
+# literal, it opens with a `{` (the envelope) — never `[` (the bare-list bug).
+_RESUME_LITERAL = re.compile(r"resume=\s*([\[{])")
+
+
+def _doc_sources() -> list[tuple[str, str]]:
+    """(label, text) for every doc that carries a resume snippet."""
+    nb = json.loads(_NOTEBOOK.read_text(encoding="utf-8"))
+    nb_text = "\n".join("".join(cell.get("source", [])) for cell in nb["cells"])
+    return [("jupyter_example.ipynb", nb_text), ("README.md", _README.read_text(encoding="utf-8"))]
+
+
+def test_docs_never_show_a_bare_list_resume():
+    for label, text in _doc_sources():
+        for m in _RESUME_LITERAL.finditer(text):
+            opener = m.group(1)
+            assert opener == "{", (
+                f"{label}: `resume=` opens with a `{opener}` — a bare list crashes the HITL "
+                f"middleware (it reads `interrupt(...)['decisions']`). Use the decision "
+                f'envelope: resume={{"decisions": [...]}} (gh #85).'
+            )
+
+
+def test_docs_show_the_decision_envelope():
+    # Both docs should actually demonstrate the envelope, not just avoid the bare list.
+    for label, text in _doc_sources():
+        compact = text.replace(" ", "")
+        assert 'resume={"decisions"' in compact, f'{label}: expected a `resume={{"decisions": ...}}` snippet'
+
+
+def test_documented_envelope_matches_create_resume_input():
+    # The literal the docs show is exactly what the blessed helper builds, so the two can't
+    # drift: if the envelope key ever changes, this fails alongside the doc guard above.
+    cmd = create_resume_input(decisions=[{"type": "approve"}])
+    assert cmd.resume == {"decisions": [{"type": "approve"}]}

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "langstage-core"
-version = "1.0.8"
+version = "1.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
## What

The Jupyter example notebook taught a HITL resume shape that crashes.

`examples/jupyter_example.ipynb` showed:

```python
resume=[{"type": "approve"}]
```

But `HumanInTheLoopMiddleware` reads the resumed value back as `interrupt(...)["decisions"]`. A bare list has no `["decisions"]`, so copy-pasting the snippet crashed the resume with a `TypeError`. This is the doc-side tail of #82 (which fixed the double-wrap in the iterators): the code path is correct now, but the shipped example still taught the wrong envelope.

## Fix

Corrected the snippet to the **decision envelope**:

```python
resume={"decisions": [{"type": "approve"}]}
```

This is the same shape `create_resume_input(decisions=[...])` builds and the one `README.md:79` already documents.

## Regression guard

New `tests/test_example_docs.py`:
- forbids a bare-list `resume=` in **both** the notebook and README (the exact #85 regression),
- asserts both docs demonstrate the `{"decisions": ...}` envelope,
- ties the documented literal to `create_resume_input(...)`'s actual output, so if the envelope key ever changes the doc guard fails alongside it.

Docs-only behavior change (example notebook markdown); the corrected notebook ships in the sdist. Full suite green (149 passed + 3 new).

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)