### PR TITLE
Fix bare-list HITL resume in the FastAPI example (gh #87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.0.16] - 2026-07-10
+
+### Fixed
+- **`examples/fastapi_websocket.py` resumed an interrupt with a bare list, crashing a real
+  HITL agent — the same bug as #85, missed in the FastAPI example (gh #87).** The `decision`
+  branch forwarded the client's bare `decisions` list straight into `resume=[...]`, but the
+  HITL middleware reads it back as `interrupt(...)["decisions"]`, so a real deepagents/HITL
+  agent (the swap-in the example invites) crashed with `TypeError: list indices must be
+  integers or slices, not str` on the first Approve. The example now wraps it in the decision
+  envelope `resume={"decisions": [...]}`, matching the README, the Jupyter example (#86), and
+  `create_resume_input`. The `tests/test_example_docs.py` guard now scans **every**
+  `examples/*.py` file too — not just the notebook + README — so no shipped surface can
+  regress to the bare list again.
+
 ## [1.0.15] - 2026-07-09
 
 ### Fixed

--- a/examples/fastapi_websocket.py
+++ b/examples/fastapi_websocket.py
@@ -58,10 +58,16 @@ async def websocket_chat(websocket: WebSocket, session_id: str):
                     agent, data.get("content", ""), thread_id=session_id
                 )
             elif kind == "decision":
-                # Answer an interrupt: the decisions list rides
-                # forwarded_props.command.resume -> LangGraph Command(resume=...).
+                # Answer an interrupt. The resume value rides
+                # forwarded_props.command.resume -> LangGraph Command(resume=...),
+                # and the HITL middleware reads it back as interrupt(...)["decisions"] —
+                # so it must be the decision ENVELOPE (a dict with a "decisions" list),
+                # NOT a bare list. A bare list crashes a real HITL agent with
+                # `TypeError: list indices must be integers or slices, not str` (gh #87,
+                # the same shape create_resume_input() builds and the README documents).
                 frames = iter_event_frames(
-                    agent, "", thread_id=session_id, resume=data.get("decisions", [])
+                    agent, "", thread_id=session_id,
+                    resume={"decisions": data.get("decisions", [])},
                 )
             else:
                 await websocket.send_json(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.15"
+version = "1.0.16"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_example_docs.py
+++ b/tests/test_example_docs.py
@@ -1,13 +1,19 @@
-"""The resume snippets in the docs use the HITL *decision envelope*, not a bare list (gh #85).
+"""Every shipped doc/example resumes an interrupt with the HITL *decision envelope*,
+not a bare list (gh #85, gh #87).
 
-The Jupyter example notebook and the README both show how to answer an `interrupt`
-frame by calling `iter_chunk_frames`/`iter_event_frames` again with `resume=`. The real
-`HumanInTheLoopMiddleware` reads the resumed value back as ``interrupt(...)["decisions"]``,
-so the resume value must be a **dict** with a ``"decisions"`` list — exactly what
-``create_resume_input(decisions=[...])`` builds. An earlier draft of the notebook passed a
-bare list (``resume=[{"type": "approve"}]``); copy-pasting it crashed HITL with a
-``TypeError``/``KeyError`` because a list has no ``["decisions"]``. These tests pin the
-documented shape so it can't silently drift back.
+The README, the Jupyter notebook, and the FastAPI WebSocket example all show how to answer
+an `interrupt` frame by calling `iter_chunk_frames`/`iter_event_frames` again with `resume=`.
+The real `HumanInTheLoopMiddleware` reads the resumed value back as
+``interrupt(...)["decisions"]``, so the resume value must be a **dict** with a ``"decisions"``
+list — exactly what ``create_resume_input(decisions=[...])`` builds. A bare list
+(``resume=[{"type": "approve"}]``) is forwarded verbatim into ``Command(resume=[...])`` and
+crashes a real HITL agent with ``TypeError: list indices must be integers or slices, not
+str``.
+
+#85 fixed the notebook; #87 caught the *same* bug still present in the FastAPI example — the
+two had drifted. So this guard now scans **every** shipped doc AND every ``examples/*.py``
+file, not just the two it originally covered, so no shipped surface can regress to the bare
+list again.
 """
 
 from __future__ import annotations
@@ -18,38 +24,58 @@ from pathlib import Path
 
 from langstage_core import create_resume_input
 
-_EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
-_README = Path(__file__).resolve().parent.parent / "README.md"
+_ROOT = Path(__file__).resolve().parent.parent
+_EXAMPLES = _ROOT / "examples"
+_README = _ROOT / "README.md"
 _NOTEBOOK = _EXAMPLES / "jupyter_example.ipynb"
 
-# Any `resume=` assignment in a doc snippet. We only care that when the value opens with a
+# Any `resume=` assignment in a doc/example. We only care that when the value opens with a
 # literal, it opens with a `{` (the envelope) — never `[` (the bare-list bug).
 _RESUME_LITERAL = re.compile(r"resume=\s*([\[{])")
 
 
 def _doc_sources() -> list[tuple[str, str]]:
-    """(label, text) for every doc that carries a resume snippet."""
+    """(label, text) for every shipped doc/example that could carry a resume snippet:
+    the README, the Jupyter notebook, and every ``examples/*.py`` file."""
     nb = json.loads(_NOTEBOOK.read_text(encoding="utf-8"))
     nb_text = "\n".join("".join(cell.get("source", [])) for cell in nb["cells"])
-    return [("jupyter_example.ipynb", nb_text), ("README.md", _README.read_text(encoding="utf-8"))]
+    sources = [
+        ("jupyter_example.ipynb", nb_text),
+        ("README.md", _README.read_text(encoding="utf-8")),
+    ]
+    for py in sorted(_EXAMPLES.glob("*.py")):
+        sources.append((f"examples/{py.name}", py.read_text(encoding="utf-8")))
+    return sources
 
 
 def test_docs_never_show_a_bare_list_resume():
+    # Covers the README, the notebook, AND every examples/*.py — the #87 drift was a .py
+    # example the original (docs-only) guard didn't scan.
     for label, text in _doc_sources():
         for m in _RESUME_LITERAL.finditer(text):
             opener = m.group(1)
             assert opener == "{", (
                 f"{label}: `resume=` opens with a `{opener}` — a bare list crashes the HITL "
                 f"middleware (it reads `interrupt(...)['decisions']`). Use the decision "
-                f'envelope: resume={{"decisions": [...]}} (gh #85).'
+                f'envelope: resume={{"decisions": [...]}} (gh #85 / #87).'
             )
 
 
-def test_docs_show_the_decision_envelope():
-    # Both docs should actually demonstrate the envelope, not just avoid the bare list.
+def test_resume_snippets_use_the_decision_envelope():
+    # Any source that actually uses a `resume={...}` literal must use the `"decisions"`
+    # envelope (not some other dict). Sources with no resume literal (e.g. agent.py) are
+    # skipped rather than forced to mention it.
+    seen_any = False
     for label, text in _doc_sources():
         compact = text.replace(" ", "")
-        assert 'resume={"decisions"' in compact, f'{label}: expected a `resume={{"decisions": ...}}` snippet'
+        if "resume={" not in compact:
+            continue
+        seen_any = True
+        assert 'resume={"decisions"' in compact, (
+            f'{label}: a `resume={{...}}` literal must use the decision envelope '
+            f'`resume={{"decisions": [...]}}` (gh #85 / #87).'
+        )
+    assert seen_any, "expected at least one shipped doc/example to demonstrate resume="
 
 
 def test_documented_envelope_matches_create_resume_input():

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "langstage-core"
-version = "1.0.15"
+version = "1.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
## What

`examples/fastapi_websocket.py` — the flagship "serve a real agent to a browser" example — resumed an interrupt with a **bare list**:

```python
resume=data.get("decisions", [])      # -> Command(resume=[{"type": "approve"}])
```

The HITL middleware reads the resumed value back as `interrupt(...)["decisions"]`, so against a real deepagents/LangGraph HITL agent (the swap-in the example explicitly invites) the first **Approve** click crashes with:

```
TypeError: list indices must be integers or slices, not str
```

This is the **same bug as #85**. #86 fixed the Jupyter example but left the parallel FastAPI example untouched — the two drifted. It's invisible with the shipped keyless echo agent (it never interrupts), so it only bites once a user does the real thing the example tells them to.

## Fix

Wrap the client's list in the decision **envelope** (matching the README, the Jupyter example, and `create_resume_input`):

```python
resume={"decisions": data.get("decisions", [])}
```

The client protocol is unchanged — it still sends `{"type": "decision", "decisions": [...]}`; the server wraps it into the envelope.

## Guard against recurrence

The reason #87 existed is that the #85 guard (`tests/test_example_docs.py`) only scanned the notebook + README. It now scans **every `examples/*.py`** file too, so no shipped example can regress to the bare list again.

Closes #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)