### PR TITLE
fix(agui): render mixed-mode finished messages (#89) + make GenericToolExtractor's "*" fallback reachable (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [1.0.17] - 2026-07-12
+
+### Fixed
+- **A mixed-mode turn silently dropped a finished (non-streamed) `AIMessage` from a
+  later node once any earlier node had streamed tokens (gh #89).** Both
+  `iter_event_frames` and `iter_chunk_frames` rendered non-streamed assistant content
+  only through the final `MessagesSnapshotEvent`, but that branch was guarded by
+  `and not streamed_text` — so a turn that streamed one node (e.g. a model node) and
+  then appended a finished message from a later node (a guardrail / disclaimer /
+  formatting / fallback node) suppressed the *entire* snapshot, and the later node's
+  reply vanished with no error. The guard is replaced by per-message dedup keyed on
+  the streamed message ids: the snapshot now always runs and emits the assistant
+  messages it did **not** already stream token-by-token. A fully-streamed turn still
+  emits nothing extra (every id is deduped, so no duplication) and a fully-snapshot
+  turn is unchanged (nothing was streamed, so all messages emit) — preserving the
+  #67 history-slicing and #43 node-mapping behavior.
+
 ## [1.0.16] - 2026-07-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@
   emits nothing extra (every id is deduped, so no duplication) and a fully-snapshot
   turn is unchanged (nothing was streamed, so all messages emit) — preserving the
   #67 history-slicing and #43 node-mapping behavior.
+- **`GenericToolExtractor` was unreachable on the 1.0 AG-UI path — a shipped, top-level
+  importable public built-in that was 100% dead code (gh #90).** Its documented purpose
+  is to be the *fallback* extractor (any tool without a dedicated extractor emits a
+  generic `tool_call` extraction), but its only registration API —
+  `StreamParser(default_extractor=…)` — was removed in 1.0 (ADR 0003), and the
+  replacement `iter_event_frames(…, extractors=[…])` dispatched **strictly by
+  `tool_name`**, so its `"*"` sentinel was registered under the literal key `"*"` and no
+  real tool name ever matched it. `iter_event_frames` now treats an extractor whose
+  `tool_name == "*"` as the fallback (consulted when no specific extractor matches), so
+  the built-in fires through the supported public API; a dedicated extractor still wins
+  over the fallback. Also refreshed the stale docstrings that pointed at the removed
+  `StreamParser` API — the public `ToolExtractor` protocol Example (`base.py`) and
+  `GenericToolExtractor` (`builtins.py`) now document the `extractors=[…]` path.
 
 ## [1.0.16] - 2026-07-10
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.16"
+version = "1.0.17"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/agui/__init__.py
+++ b/src/langstage_core/agui/__init__.py
@@ -335,7 +335,11 @@ async def iter_event_frames(
     (``tool_name`` / ``extracted_type`` / ``extract(content)``). After each tool
     result, the matching extractor (by tool name) runs; a non-None return emits an
     ``extraction`` frame identical to ``event_to_dict(ToolExtractedEvent)`` — the
-    AG-UI home for domain callouts (e.g. hermes' skill/memory events).
+    AG-UI home for domain callouts (e.g. hermes' skill/memory events). An extractor
+    whose ``tool_name`` is the ``"*"`` sentinel (e.g.
+    :class:`~langstage_core.GenericToolExtractor`) is used as the *fallback* for any
+    tool without a specific extractor, so a generic tool-callout card can render
+    without per-tool knowledge (gh #90).
     """
     try:
         from ag_ui.core.types import RunAgentInput, UserMessage
@@ -345,7 +349,14 @@ async def iter_event_frames(
     import uuid
 
     allowed_decisions = ["reject", "edit", "respond", "approve"]
-    by_tool = {e.tool_name: e for e in extractors}
+    # Dispatch extractors by tool name. An extractor whose tool_name is the "*"
+    # sentinel (GenericToolExtractor) is the fallback, applied to any tool without a
+    # dedicated extractor — otherwise "*" is just a dict key no real tool matches, so
+    # the documented public fallback is dead code on the 1.0 wire (gh #90).
+    by_tool = {e.tool_name: e for e in extractors if getattr(e, "tool_name", None) != "*"}
+    default_extractor = next(
+        (e for e in extractors if getattr(e, "tool_name", None) == "*"), None
+    )
     resume = _unwrap_resume(resume)  # accept create_resume_input()'s Command too (gh #82)
     forwarded_props = {"command": {"resume": resume}} if resume is not None else {}
     run_input = RunAgentInput(
@@ -442,7 +453,7 @@ async def iter_event_frames(
                 "error_message": result if is_error else None,
                 "duration_ms": None,
             }
-            extractor = by_tool.get(name)
+            extractor = by_tool.get(name, default_extractor)
             if extractor is not None:
                 data = extractor.extract(getattr(ev, "content", ""))
                 if data is not None:

--- a/src/langstage_core/agui/__init__.py
+++ b/src/langstage_core/agui/__init__.py
@@ -359,6 +359,12 @@ async def iter_event_frames(
     )
 
     streamed_text = False
+    # Message ids already emitted token-by-token (from TextMessageContentEvent), so
+    # the final snapshot can emit the assistant messages it did NOT stream without
+    # duplicating the streamed ones. A mixed turn — an earlier node streams, a later
+    # node returns a finished AIMessage — otherwise dropped the finished message,
+    # because the whole snapshot was suppressed once anything streamed (gh #89).
+    streamed_ids: set[str] = set()
     tool_args: dict[str, str] = {}
     tool_names: dict[str, str] = {}
     # The langgraph node currently executing, from StepStartedEvent — so a
@@ -387,6 +393,9 @@ async def iter_event_frames(
                     errored_tools[nm] = errored_tools.get(nm, 0) + 1
         elif t == "TextMessageContentEvent":
             streamed_text = True
+            mid = getattr(ev, "message_id", None)
+            if mid is not None:
+                streamed_ids.add(mid)
             yield {"type": "content", "content": ev.delta, "role": "assistant", "node": current_node}
         elif t in ("ReasoningMessageContentEvent", "ThinkingTextMessageContentEvent"):
             # Reasoning-model chain-of-thought (Anthropic extended thinking, o-series,
@@ -459,12 +468,21 @@ async def iter_event_frames(
                 "review_configs": review_configs,
                 "allowed_decisions": decisions,
             }
-        elif t == "MessagesSnapshotEvent" and not streamed_text:
-            # Non-streaming graphs deliver content in one final snapshot. The snapshot
-            # is the FULL thread (prior turns come from the checkpointer), so slice to
-            # what follows the last user message — otherwise the agent re-emits its
-            # entire history every turn (gh #67). Then map the trailing assistant
-            # messages back to the steps that produced them (gh #43).
+        elif t == "MessagesSnapshotEvent":
+            # The final snapshot carries every assistant message the turn produced,
+            # including any a later node returned finished (non-streamed). Emit the
+            # ones NOT already streamed token-by-token — keyed by message id — so a
+            # mixed turn (an earlier node streams, a later node appends a finished
+            # AIMessage) renders the finished message too, instead of dropping it once
+            # anything streamed (gh #89). A fully-streamed turn skips them all (already
+            # emitted); a fully-snapshot turn emits them all (gh #67).
+            #
+            # The snapshot is the FULL thread (prior turns come from the checkpointer),
+            # so slice to what follows the last user message — otherwise the agent
+            # re-emits its entire history every turn (gh #67). Then map the trailing
+            # assistant messages back to the steps that produced them (gh #43); the
+            # index alignment uses the full assistant list so skipping streamed ones
+            # doesn't shift the node mapping.
             msgs = list(ev.messages)
             last_user = max(
                 (i for i, m in enumerate(msgs) if getattr(m, "role", None) in ("user", "human")),
@@ -476,6 +494,8 @@ async def iter_event_frames(
             ]
             offset = max(0, len(assistant) - len(step_nodes))
             for i, m in enumerate(assistant):
+                if getattr(m, "id", None) in streamed_ids:
+                    continue  # already emitted token-by-token; don't duplicate
                 idx = i - offset
                 node = step_nodes[idx] if 0 <= idx < len(step_nodes) else current_node
                 yield {"type": "content", "content": m.content, "role": "assistant", "node": node}
@@ -523,6 +543,10 @@ async def iter_chunk_frames(
     )
 
     streamed_text = False
+    # Message ids already streamed token-by-token, so the final snapshot can emit the
+    # assistant messages it did NOT stream without duplicating them — the mixed-turn
+    # fix (gh #89), see iter_event_frames for the full rationale.
+    streamed_ids: set[str] = set()
     tool_buf: dict[str, dict[str, str]] = {}
     # The langgraph node currently executing (from StepStartedEvent) so a multi-node
     # graph's chunks carry the real node instead of a fixed "agent" — renderers use
@@ -539,6 +563,9 @@ async def iter_chunk_frames(
                 step_nodes.append(step)
         elif t == "TextMessageContentEvent":
             streamed_text = True
+            mid = getattr(ev, "message_id", None)
+            if mid is not None:
+                streamed_ids.add(mid)
             yield {"status": "streaming", "chunk": ev.delta, "node": current_node}
         elif t in ("ReasoningMessageContentEvent", "ThinkingTextMessageContentEvent"):
             # Reasoning-model chain-of-thought on the chunk wire — a distinct
@@ -579,11 +606,20 @@ async def iter_chunk_frames(
                     "allowed_decisions": decisions,
                 },
             }
-        elif t == "MessagesSnapshotEvent" and not streamed_text:
-            # Non-streaming graphs deliver content in one final snapshot. The snapshot
-            # is the FULL thread, so slice to what follows the last user message —
-            # otherwise the agent re-emits its whole history every turn (gh #67). Then
-            # map the trailing assistant messages back to their steps (gh #43).
+        elif t == "MessagesSnapshotEvent":
+            # The final snapshot carries every assistant message the turn produced,
+            # including any a later node returned finished (non-streamed). Emit the
+            # ones NOT already streamed token-by-token — keyed by message id — so a
+            # mixed turn (an earlier node streams, a later node appends a finished
+            # AIMessage) renders the finished message too, instead of dropping it once
+            # anything streamed (gh #89). A fully-streamed turn skips them all; a
+            # fully-snapshot turn emits them all (gh #67).
+            #
+            # The snapshot is the FULL thread, so slice to what follows the last user
+            # message — otherwise the agent re-emits its whole history every turn (gh
+            # #67). Then map the trailing assistant messages back to their steps (gh
+            # #43); the index alignment uses the full assistant list so skipping
+            # streamed ones doesn't shift the node mapping.
             msgs = list(ev.messages)
             last_user = max(
                 (i for i, m in enumerate(msgs) if getattr(m, "role", None) in ("user", "human")),
@@ -595,6 +631,8 @@ async def iter_chunk_frames(
             ]
             offset = max(0, len(assistant) - len(step_nodes))
             for i, m in enumerate(assistant):
+                if getattr(m, "id", None) in streamed_ids:
+                    continue  # already emitted token-by-token; don't duplicate
                 idx = i - offset
                 node = step_nodes[idx] if 0 <= idx < len(step_nodes) else current_node
                 yield {"status": "streaming", "chunk": m.content, "node": node}

--- a/src/langstage_core/extractors/base.py
+++ b/src/langstage_core/extractors/base.py
@@ -14,7 +14,9 @@ class ToolExtractor(Protocol):
     """Protocol for custom tool content extractors.
 
     Implement this protocol to create extractors for domain-specific tools.
-    Register extractors with StreamParser.register_extractor().
+    Register extractors by passing them to ``iter_event_frames(agent, ...,
+    extractors=[...])``; after each tool result the extractor whose ``tool_name``
+    matches runs, and a non-None return emits an ``extraction`` frame.
 
     Example:
         class CanvasExtractor:
@@ -32,8 +34,10 @@ class ToolExtractor(Protocol):
                         return {"type": "markdown", "data": content}
                 return None
 
-        parser = StreamParser()
-        parser.register_extractor(CanvasExtractor())
+        from langstage_core.agui import iter_event_frames
+        async for frame in iter_event_frames(agent, "hi", "t",
+                                             extractors=[CanvasExtractor()]):
+            ...
     """
 
     @property

--- a/src/langstage_core/extractors/builtins.py
+++ b/src/langstage_core/extractors/builtins.py
@@ -350,31 +350,38 @@ class GenericToolExtractor:
     — never ``ToolExtractedEvent`` — so hosts that switch on extracted
     events to render rich cards have no signal to act on.
 
-    Registering this as a fallback (``StreamParser(default_extractor=
-    GenericToolExtractor())``) closes that gap: any tool name without a
-    specific extractor will emit a ``ToolExtractedEvent`` of
+    Registering this as the fallback closes that gap: any tool name without a
+    specific extractor emits an ``extraction`` frame of
     ``extracted_type="tool_call"`` whose data preserves the raw content
-    (and the optional artifact) so downstream renderers can build a
-    generic "tool callout" card without per-tool knowledge.
+    so downstream renderers can build a generic "tool callout" card
+    without per-tool knowledge. Pass it alongside any specific extractors::
 
-    This is intentionally *opt-in* via the new
-    :class:`~langstage_core.StreamParser` ``default_extractor``
-    kwarg. The historical behaviour (only emit ``ToolExtractedEvent`` for
-    tools with explicit extractors) is preserved by default so existing
-    hosts that switch on specific extracted types don't suddenly receive
-    new events.
+        from langstage_core.agui import iter_event_frames
+        from langstage_core import GenericToolExtractor
+
+        async for frame in iter_event_frames(
+            agent, "hi", "t", extractors=[MyToolExtractor(), GenericToolExtractor()]
+        ):
+            ...
+
+    This is intentionally *opt-in* — you only get generic tool-call frames when
+    you include ``GenericToolExtractor`` in ``extractors``. The historical
+    behaviour (only emit an ``extraction`` frame for tools with a dedicated
+    extractor) is preserved when it is absent, so existing hosts that switch on
+    specific extracted types don't suddenly receive new events.
 
     Notes:
-        - ``tool_name`` is the sentinel ``"*"`` for documentation / hosts
-          that introspect ``parser._default_extractor``; the parser
-          never indexes ``_extractors`` by this value.
+        - ``tool_name`` is the sentinel ``"*"``: ``iter_event_frames`` treats an
+          extractor with this ``tool_name`` as the fallback (used when no
+          specific extractor matches the tool) rather than dispatching on it
+          literally (gh #90).
         - Returns ``None`` when content is also ``None`` so a tool that
           legitimately returns nothing doesn't fire a spurious empty
           card. Empty strings and empty dicts still surface (they may
           carry meaning to the host's renderer).
     """
 
-    tool_name = "*"  # sentinel; not used for dispatch lookup
+    tool_name = "*"  # sentinel; treated as the fallback, not a literal dispatch key
     extracted_type = "tool_call"
 
     def extract(self, content: Any) -> dict[str, Any] | None:

--- a/tests/test_agui_frames.py
+++ b/tests/test_agui_frames.py
@@ -304,3 +304,85 @@ async def test_chunk_frames_fully_streamed_no_duplicate():
     frames = await _collect(iter_chunk_frames(build_agent(_single_streaming_graph()), "hi", "m89dupC"))
     text = "".join(f["chunk"] for f in frames if "chunk" in f)
     assert text == "hi from model", f"duplicated streamed content: {text!r}"
+
+
+# --- gh #90: GenericToolExtractor's "*" tool_name is the fallback, reachable through
+# the supported `extractors=[...]` API. ---
+
+def _custom_tool_graph():
+    """A graph that calls one tool with no dedicated extractor, then replies."""
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.messages import AIMessage, ToolMessage
+    from langchain_core.outputs import ChatGeneration, ChatResult
+    from langchain_core.tools import tool
+    from langgraph.graph import END, START, MessagesState, StateGraph
+    from langgraph.prebuilt import ToolNode
+
+    @tool
+    def my_custom_tool(q: str) -> str:
+        """A custom tool the parser has no dedicated extractor for."""
+        return "custom-tool-output"
+
+    class ToolThenDone(BaseChatModel):
+        @property
+        def _llm_type(self):
+            return "t"
+
+        def _generate(self, messages, stop=None, run_manager=None, **k):
+            if any(isinstance(m, ToolMessage) for m in messages):
+                return ChatResult(generations=[ChatGeneration(message=AIMessage(content="ok"))])
+            m = AIMessage(content="", tool_calls=[{"name": "my_custom_tool", "args": {"q": "x"}, "id": "c1"}])
+            return ChatResult(generations=[ChatGeneration(message=m)])
+
+    model = ToolThenDone()
+    b = StateGraph(MessagesState)
+    b.add_node("model", lambda s: {"messages": [model.invoke(s["messages"])]})
+    b.add_node("tools", ToolNode([my_custom_tool]))
+    b.add_edge(START, "model")
+    b.add_conditional_edges(
+        "model",
+        lambda s: "tools" if getattr(s["messages"][-1], "tool_calls", None) else END,
+        {"tools": "tools", END: END},
+    )
+    b.add_edge("tools", "model")
+    return b.compile()
+
+
+async def test_generic_tool_extractor_fires_as_fallback():
+    # gh #90: GenericToolExtractor (tool_name == "*") was inert — "*" was a plain
+    # dict key no real tool name matched. It's now the fallback for any tool without a
+    # dedicated extractor, so it fires here and emits a generic `extraction` frame.
+    from langstage_core import GenericToolExtractor
+
+    agent = build_agent(_custom_tool_graph())
+    frames = await _collect(
+        iter_event_frames(agent, "go", "g90", extractors=[GenericToolExtractor()])
+    )
+    extraction = [f for f in frames if f["type"] == "extraction"]
+    assert extraction, f"generic fallback never fired: {[f['type'] for f in frames]}"
+    assert extraction[0]["tool_name"] == "my_custom_tool"
+    assert extraction[0]["extracted_type"] == "tool_call"
+    assert extraction[0]["data"] == {"content": "custom-tool-output"}
+
+
+async def test_specific_extractor_wins_over_generic_fallback():
+    # A dedicated extractor must still take precedence over the "*" fallback when both
+    # are registered — the fallback only applies to tools without a specific match.
+    from langstage_core import GenericToolExtractor
+
+    class MyToolExtractor:
+        tool_name = "my_custom_tool"
+        extracted_type = "custom_specific"
+
+        def extract(self, content):
+            return {"specific": content}
+
+    agent = build_agent(_custom_tool_graph())
+    frames = await _collect(
+        iter_event_frames(
+            agent, "go", "g90b", extractors=[MyToolExtractor(), GenericToolExtractor()]
+        )
+    )
+    extraction = [f for f in frames if f["type"] == "extraction"]
+    assert extraction and extraction[0]["extracted_type"] == "custom_specific", extraction
+    assert extraction[0]["data"] == {"specific": "custom-tool-output"}

--- a/tests/test_agui_frames.py
+++ b/tests/test_agui_frames.py
@@ -213,3 +213,94 @@ async def test_iter_chunk_frames_emits_reasoning():
     assert "".join(reasoning) == "Let me think... 2+2=4. "
     chunks = [f["chunk"] for f in frames if "chunk" in f]
     assert "".join(chunks) == "The answer is 4."
+
+
+# --- gh #89: mixed-mode turn (an earlier node streams, a later node returns a
+# finished, non-streamed AIMessage) must render both, not silently drop the finished
+# message once anything streamed. ---
+
+def _streaming_model():
+    """A keyless, deterministic BaseChatModel that streams tokens ("hi from model")."""
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.messages import AIMessage, AIMessageChunk
+    from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+
+    class Streamer(BaseChatModel):
+        @property
+        def _llm_type(self):
+            return "streamer"
+
+        def _generate(self, messages, stop=None, run_manager=None, **k):
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content="hi from model"))])
+
+        def _stream(self, messages, stop=None, run_manager=None, **k):
+            for tok in ("hi ", "from ", "model"):
+                ch = ChatGenerationChunk(message=AIMessageChunk(content=tok))
+                if run_manager:
+                    run_manager.on_llm_new_token(tok, chunk=ch)
+                yield ch
+
+    return Streamer()
+
+
+def _mixed_mode_graph():
+    """`model` streams tokens; a later `finalize` node appends a finished AIMessage."""
+    from langchain_core.messages import AIMessage
+    from langgraph.graph import END, START, MessagesState, StateGraph
+
+    model = _streaming_model()
+    b = StateGraph(MessagesState)
+    b.add_node("model", lambda s: {"messages": [model.invoke(s["messages"])]})
+    b.add_node("finalize", lambda s: {"messages": [AIMessage(content="[Reviewed by policy engine]")]})
+    b.add_edge(START, "model")
+    b.add_edge("model", "finalize")
+    b.add_edge("finalize", END)
+    return b.compile()
+
+
+async def test_event_frames_mixed_mode_keeps_finished_message():
+    # gh #89: the finished `finalize` message used to vanish — once `model` streamed,
+    # the whole final snapshot was suppressed (`and not streamed_text`), dropping every
+    # later non-streamed message. It must now render, mapped to its node.
+    frames = await _collect(iter_event_frames(build_agent(_mixed_mode_graph()), "hi", "m89e"))
+    text = "".join(f["content"] for f in frames if f.get("type") == "content")
+    assert "hi from model" in text
+    assert "[Reviewed by policy engine]" in text, f"finished message dropped: {text!r}"
+    finalize = [
+        f for f in frames
+        if f.get("type") == "content" and "[Reviewed by policy engine]" in f["content"]
+    ]
+    assert finalize and finalize[0]["node"] == "finalize", finalize
+
+
+async def test_chunk_frames_mixed_mode_keeps_finished_message():
+    frames = await _collect(iter_chunk_frames(build_agent(_mixed_mode_graph()), "hi", "m89c"))
+    text = "".join(f["chunk"] for f in frames if "chunk" in f)
+    assert "hi from model" in text
+    assert "[Reviewed by policy engine]" in text, f"finished message dropped: {text!r}"
+
+
+def _single_streaming_graph():
+    from langgraph.graph import END, START, MessagesState, StateGraph
+
+    model = _streaming_model()
+    b = StateGraph(MessagesState)
+    b.add_node("model", lambda s: {"messages": [model.invoke(s["messages"])]})
+    b.add_edge(START, "model")
+    b.add_edge("model", END)
+    return b.compile()
+
+
+async def test_event_frames_fully_streamed_no_duplicate():
+    # Guard the #89 fix: dropping the coarse `not streamed_text` guard must not make a
+    # fully-streamed turn re-emit its streamed message from the final snapshot — the
+    # streamed message id is deduped.
+    frames = await _collect(iter_event_frames(build_agent(_single_streaming_graph()), "hi", "m89dupE"))
+    text = "".join(f["content"] for f in frames if f.get("type") == "content")
+    assert text == "hi from model", f"duplicated streamed content: {text!r}"
+
+
+async def test_chunk_frames_fully_streamed_no_duplicate():
+    frames = await _collect(iter_chunk_frames(build_agent(_single_streaming_graph()), "hi", "m89dupC"))
+    text = "".join(f["chunk"] for f in frames if "chunk" in f)
+    assert text == "hi from model", f"duplicated streamed content: {text!r}"


### PR DESCRIPTION
Two AG-UI mapping bugs on the 1.0 path (`langstage_core.agui`), one commit each, both fully keyless/deterministic to reproduce. Bumps the version to `1.0.17` with a CHANGELOG entry per fix.

Closes #89
Closes #90

## #89 — Mixed-mode turn drops a later node's finished (non-streamed) message

**Root cause.** `iter_event_frames` / `iter_chunk_frames` render non-streamed assistant content only through the final `MessagesSnapshotEvent`, and that branch was guarded by `and not streamed_text`. So a *mixed* turn — an earlier node streams tokens (setting `streamed_text = True`), then a later node returns a finished `AIMessage` (guardrail / disclaimer / formatting / fallback) — suppressed the **entire** snapshot, and the later node's reply was silently dropped (no error). Instrumenting the raw AG-UI events confirmed the adapter *does* deliver the finished message in the snapshot; the guard threw it away.

**Fix.** Replace the coarse `not streamed_text` guard with per-message dedup keyed on the streamed message ids. Each `TextMessageContentEvent.message_id` is recorded; the snapshot branch now always runs and emits the assistant messages it did **not** already stream token-by-token (skipping any whose `id` is in the streamed set). The message id in the snapshot matches the `message_id` on the streaming events (both are the LangChain run id — verified empirically), so:
- **mixed turn** → the finished message renders, mapped to its node;
- **fully-streamed turn** → every id is deduped, so nothing is re-emitted (no duplication);
- **fully-snapshot turn** → nothing was streamed, so all messages emit — preserving the #67 history-slicing and #43 node-mapping behavior.

Applied identically to both wires (`iter_event_frames` and `iter_chunk_frames`).

## #90 — `GenericToolExtractor` unreachable ("*" sentinel never matches)

**Root cause.** `GenericToolExtractor` is a shipped, top-level-importable public built-in whose documented job is to be the *fallback* extractor. On 1.0 it was 100% dead code: its only registration API (`StreamParser(default_extractor=…)`) was removed in 1.0 (ADR 0003), and the replacement `iter_event_frames(…, extractors=[…])` dispatched **strictly by `tool_name`** (`by_tool = {e.tool_name: e ...}` / `by_tool.get(name)`), so its `"*"` sentinel was keyed under the literal `"*"` and no real tool name ever matched it.

**Fix.** `iter_event_frames` now treats an extractor whose `tool_name == "*"` as the fallback: `"*"` extractors are pulled out of `by_tool` into a `default_extractor`, consulted via `by_tool.get(name, default_extractor)` when no specific extractor matches. A dedicated extractor still wins over the fallback. Also refreshed the stale docstrings that pointed at the removed `StreamParser` API — the public `ToolExtractor` protocol Example (`base.py`) and `GenericToolExtractor` (`builtins.py`) now document the `extractors=[…]` path.

## Verification

- Reproduced both issues from the issue bodies (keyless, deterministic) — before: `finalize text present: False` (#89) and `GenericToolExtractor fired: False` (#90); after: both render/fire.
- Added regression tests in `tests/test_agui_frames.py`:
  - #89: `test_event_frames_mixed_mode_keeps_finished_message`, `test_chunk_frames_mixed_mode_keeps_finished_message` (both **fail before, pass after**), plus `test_event/chunk_frames_fully_streamed_no_duplicate` guards against re-emit.
  - #90: `test_generic_tool_extractor_fires_as_fallback` (**fails before, passes after**) + `test_specific_extractor_wins_over_generic_fallback` (precedence).
- Confirmed the 3 fail-before tests fail against the pre-fix source (stashed src, tests kept) and pass with the fix.
- Full suite green: `pytest -q` → **155 passed** (up from 149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY
