### PR TITLE
Forward extractors through SessionAdapter

### DIFF
--- a/src/langstage_core/adapters/session.py
+++ b/src/langstage_core/adapters/session.py
@@ -68,13 +68,8 @@ class SessionAdapter:
 
     Attributes:
         graph: A compiled LangGraph graph (with a checkpointer for resumption).
-        stream_mode: Stream mode for ``astream`` and the parser. Defaults to
-            dual mode so content streams token-by-token while tool/interrupt
-            events arrive complete.
-        max_result_len: Max length for serialized tool results (see
-            :func:`event_to_dict`).
-        parser_kwargs: Extra kwargs forwarded to each ``StreamParser``
-            (e.g. ``skip_tools``, custom ``extractors`` via registration).
+        max_result_len: Max length for serialized tool results.
+        extractors: Tool extractors forwarded to :func:`iter_event_frames`.
 
     Example:
         adapter = SessionAdapter(graph=agent)
@@ -98,10 +93,12 @@ class SessionAdapter:
         *,
         graph: Any,
         max_result_len: int = 500,
+        extractors: Any = (),
         **_legacy: Any,  # accepts + ignores the removed stream_mode/agui/parser kwargs
     ):
         self._graph = graph
         self._max_result_len = max_result_len
+        self._extractors = extractors
         self._sessions: dict[str, Session] = {}
         # AG-UI-only since langstage-core 1.0 (ADR 0003): turns stream through the
         # in-process AG-UI adapter (``agui.iter_event_frames``) — the wrapped agent
@@ -238,6 +235,7 @@ class SessionAdapter:
                 thread_id,
                 resume=resume,
                 max_result_len=self._max_result_len,
+                extractors=self._extractors,
             ):
                 session.push(data)
                 kind = data.get("type")

--- a/tests/test_session_agui.py
+++ b/tests/test_session_agui.py
@@ -89,6 +89,34 @@ async def test_tool_frames():
     assert ends and ends[0]["result"] == "Sunny, 72F"
 
 
+async def test_extractors_are_forwarded_to_event_frames():
+    from langgraph.prebuilt import create_react_agent
+
+    class WeatherExtractor:
+        tool_name = "get_weather"
+        extracted_type = "weather"
+
+        def extract(self, content):
+            return {"forecast": content}
+
+    adapter = SessionAdapter(
+        graph=create_react_agent(_FakeToolModel(), [get_weather]),
+        extractors=[WeatherExtractor()],
+    )
+    session = adapter.submit_message(None, "weather?")
+    await session.current_task
+    frames = _drain(session.event_queue)
+    extractions = [frame for frame in frames if frame["type"] == "extraction"]
+    assert extractions == [
+        {
+            "type": "extraction",
+            "tool_name": "get_weather",
+            "extracted_type": "weather",
+            "data": {"forecast": "Sunny, 72F"},
+        }
+    ]
+
+
 async def test_interrupt_then_resume_sets_outcomes():
     def gate(state):
         d = interrupt({"action_requests": [{"tool": "approve", "args": {"x": 1}}]})


### PR DESCRIPTION
SessionAdapter accepted `extractors` but discarded the value before calling `iter_event_frames`, so web and task-board sessions never emitted extraction frames. This stores the extractor configuration, forwards it for each turn, and adds a regression test for the emitted frame.

Fixes #96

Tested with `pytest -q` (162 passed).
