### PR TITLE
fix(session): forward `extractors` through SessionAdapter so the web surface emits `extraction` frames (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [1.0.20] - 2026-07-16
+
+### Fixed
+- **`SessionAdapter` silently dropped the `extractors` argument, so the web / task-board surface
+  could never emit `extraction` frames (gh #96).** `SessionAdapter` is the streaming engine behind
+  the web app + task board, yet its `__init__` accepted only `graph` / `max_result_len` and funneled
+  everything else into `**_legacy` — so `SessionAdapter(graph=g, extractors=[...])` was accepted
+  without error but the extractors were discarded, and `_produce` called `iter_event_frames(...)`
+  with no `extractors=`. Every *other* surface (CLI/Jupyter via `iter_chunk_frames`, VS Code via
+  `iter_event_frames`) could pass `extractors=[...]` and render skill/memory/todo/`display_inline`
+  callouts, but the headline web/task-board surface could not — a documented public feature was
+  unreachable there, and the misconfiguration failed silently. `SessionAdapter.__init__` now accepts
+  an `extractors=[...]` iterable and forwards it into `iter_event_frames`, so the SSE stream carries
+  `extraction` frames for matching tools — parity with `iter_event_frames` / `iter_chunk_frames`
+  (same by-tool-name dispatch, same `"*"`-sentinel `GenericToolExtractor` fallback). It stays opt-in:
+  with no `extractors` (the default), the stream is unchanged, so existing consumers see no new
+  frames. The stale class docstring (which still referenced the retired
+  `stream_mode` / `parser_kwargs` / `StreamParser` / `event_to_dict` layer) now documents the real
+  `extractors` argument.
+
 ## [1.0.19] - 2026-07-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.19"
+version = "1.0.20"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/adapters/session.py
+++ b/src/langstage_core/adapters/session.py
@@ -66,15 +66,23 @@ class Session:
 class SessionAdapter:
     """Session-scoped streaming for LangGraph agents.
 
+    Turns stream through the in-process AG-UI adapter (:func:`agui.iter_event_frames`)
+    since langstage-core 1.0 (ADR 0003).
+
     Attributes:
         graph: A compiled LangGraph graph (with a checkpointer for resumption).
-        stream_mode: Stream mode for ``astream`` and the parser. Defaults to
-            dual mode so content streams token-by-token while tool/interrupt
-            events arrive complete.
-        max_result_len: Max length for serialized tool results (see
-            :func:`event_to_dict`).
-        parser_kwargs: Extra kwargs forwarded to each ``StreamParser``
-            (e.g. ``skip_tools``, custom ``extractors`` via registration).
+        max_result_len: Max length for serialized tool results.
+        extractors: Optional iterable of
+            :class:`~langstage_core.extractors.base.ToolExtractor` forwarded to
+            :func:`agui.iter_event_frames`. After a matching tool result the
+            extractor runs and its non-None return is emitted as an ``extraction``
+            frame on the SSE stream — the same skill/memory/todo/``display_inline``
+            callouts the ``iter_*`` mappings emit, for parity with the CLI/Jupyter
+            (``iter_chunk_frames``) and VS Code (``iter_event_frames``) surfaces.
+            Defaults to none (no ``extraction`` frames). An extractor whose
+            ``tool_name`` is the ``"*"`` sentinel (e.g.
+            :class:`~langstage_core.GenericToolExtractor`) is the fallback for any
+            tool without a dedicated extractor.
 
     Example:
         adapter = SessionAdapter(graph=agent)
@@ -98,10 +106,14 @@ class SessionAdapter:
         *,
         graph: Any,
         max_result_len: int = 500,
+        extractors: Any = (),
         **_legacy: Any,  # accepts + ignores the removed stream_mode/agui/parser kwargs
     ):
         self._graph = graph
         self._max_result_len = max_result_len
+        # Forwarded to iter_event_frames so the web/task-board surface can emit
+        # `extraction` frames too — parity with the iter_* surfaces (gh #96).
+        self._extractors = extractors
         self._sessions: dict[str, Session] = {}
         # AG-UI-only since langstage-core 1.0 (ADR 0003): turns stream through the
         # in-process AG-UI adapter (``agui.iter_event_frames``) — the wrapped agent
@@ -238,6 +250,7 @@ class SessionAdapter:
                 thread_id,
                 resume=resume,
                 max_result_len=self._max_result_len,
+                extractors=self._extractors,
             ):
                 session.push(data)
                 kind = data.get("type")

--- a/tests/test_session_agui.py
+++ b/tests/test_session_agui.py
@@ -89,6 +89,59 @@ async def test_tool_frames():
     assert ends and ends[0]["result"] == "Sunny, 72F"
 
 
+# ── Extractors reach the web/task-board surface (gh #96) ─────────────────────
+
+
+async def test_constructor_accepts_extractors_param():
+    """gh #96: `extractors=` must be a real, honored parameter — not silently
+    swallowed by ``**_legacy``. Before the fix it fell into `**_legacy` and the
+    signature exposed no `extractors`, so the misconfiguration failed silently."""
+    import inspect
+
+    assert "extractors" in inspect.signature(SessionAdapter.__init__).parameters
+
+
+class _WeatherExtractor:
+    tool_name = "get_weather"
+    extracted_type = "weather"
+
+    def extract(self, content):
+        return {"summary": str(content)} if content else None
+
+
+async def test_extractors_emit_extraction_frames():
+    """gh #96: extractors forwarded to the AG-UI producer, so the web/task-board
+    surface emits `extraction` frames too — parity with iter_event_frames /
+    iter_chunk_frames. Before the fix, extractors fell into ``**_legacy`` and were
+    dropped, so no `extraction` frame ever reached the SSE stream."""
+    from langgraph.prebuilt import create_react_agent
+
+    adapter = SessionAdapter(
+        graph=create_react_agent(_FakeToolModel(), [get_weather]),
+        extractors=[_WeatherExtractor()],
+    )
+    session = adapter.submit_message(None, "weather?")
+    await session.current_task
+    frames = _drain(session.event_queue)
+    extraction = [f for f in frames if f.get("type") == "extraction"]
+    assert extraction, f"no extraction frame emitted: {[f.get('type') for f in frames]}"
+    assert extraction[0]["tool_name"] == "get_weather"
+    assert extraction[0]["extracted_type"] == "weather"
+    assert extraction[0]["data"] == {"summary": "Sunny, 72F"}
+
+
+async def test_no_extractors_emits_no_extraction_frame():
+    """Opt-in + backward compatible: with no extractors (the default) the SSE
+    stream carries no `extraction` frame, so existing web consumers are unchanged."""
+    from langgraph.prebuilt import create_react_agent
+
+    adapter = SessionAdapter(graph=create_react_agent(_FakeToolModel(), [get_weather]))
+    session = adapter.submit_message(None, "weather?")
+    await session.current_task
+    frames = _drain(session.event_queue)
+    assert not any(f.get("type") == "extraction" for f in frames), frames
+
+
 async def test_interrupt_then_resume_sets_outcomes():
     def gate(state):
         d = interrupt({"action_requests": [{"tool": "approve", "args": {"x": 1}}]})


### PR DESCRIPTION
## Summary

Closes #96.

`SessionAdapter` — the streaming engine behind the web app + task board — **silently dropped the `extractors` argument**, so its SSE stream could never carry `extraction` frames. `__init__` accepted only `graph` / `max_result_len` and funneled everything else into `**_legacy`, so `SessionAdapter(graph=g, extractors=[...])` was accepted **without error** but the extractors were discarded, and `_produce` called `iter_event_frames(...)` with **no** `extractors=`.

Net effect: every *other* surface (CLI/Jupyter via `iter_chunk_frames`, VS Code via `iter_event_frames`) could pass `extractors=[...]` and render skill/memory/todo/`display_inline` callouts, but the headline web/task-board surface could not — a documented public feature was unreachable there, and the misconfiguration failed silently. This is the classic "advertised != honored" bug.

## Fix

- Add a real `extractors=[...]` parameter to `SessionAdapter.__init__`, store it, and forward it into `iter_event_frames` in `_produce`. Same by-tool-name dispatch and same `"*"`-sentinel `GenericToolExtractor` fallback as the `iter_*` surfaces.
- **Opt-in + backward compatible:** with no `extractors` (the default `()`), the stream is byte-for-byte unchanged — existing consumers see no new frames.
- Refresh the stale class docstring, dropping the retired `stream_mode` / `parser_kwargs` / `StreamParser` / `event_to_dict` references and documenting the real `extractors` argument.

## Before / after (issue repro)

```
# before
SessionAdapter frame types -> ['tool_start', 'tool_end', 'content', 'complete']
# after
SessionAdapter frame types -> ['tool_start', 'tool_end', 'extraction', 'content', 'complete']
```

## Tests

Added to `tests/test_session_agui.py` (fail-before / pass-after):
- `test_constructor_accepts_extractors_param` — `extractors` is a real, honored signature parameter (not swallowed by `**_legacy`).
- `test_extractors_emit_extraction_frames` — an adapter built with an extractor emits an `extraction` frame on a tool turn, with the right `tool_name` / `extracted_type` / `data`.
- `test_no_extractors_emits_no_extraction_frame` — opt-in guard: with no extractors, no `extraction` frame.

Fail-before verified by reverting only `session.py`: the two new behavioral/signature tests fail; the backward-compat guard passes both ways. **Full suite green: 164 passed.**

## Notes

- No new imports; the no-extras import job is unaffected.
- Additive + backward compatible, so downstream pins (`langstage web` depends on core `>=1.0.9`) keep working unchanged; a consumer that wants to *use* the new capability would bump its floor to `>=1.0.20` and pass `extractors=[...]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY
