### PR TITLE
fix(agui): load the agent spec before the 'Serving ...' banner (gh #100) + coerce wrong-typed TOML values (langstage-jupyter #78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,12 @@
   print, now naming the file so the user is pointed back at their config. `bool` is handled
   deliberately: because `bool` subclasses `int` in Python, `temperature = true` would otherwise
   become `1.0`, so a bool supplied *for* a numeric field is treated as malformed — while a genuine
-  bool field keeps accepting TOML `true`/`false` untouched. The note is deduped per (key, value), as
-  several surfaces each resolve the config in one process. Correctly-typed configs behave exactly as
-  before and emit no notes.
+  bool field keeps accepting TOML `true`/`false` untouched. A **fractional** value for an `int`
+  field is likewise malformed rather than truncated: `port = 8050.7` silently becoming `8050` would
+  be the very defect this fix closes, a wrong-typed value quietly accepted as something the user did
+  not write. An integral float (`8123.0`) is unambiguous and still coerces. The note is deduped per
+  (key, value), as several surfaces each resolve the config in one process. Correctly-typed configs
+  behave exactly as before and emit no notes.
 
 ## [1.0.20] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## [1.0.21] - 2026-07-18
+
+### Fixed
+- **`langstage-agui --agent <spec>` printed a fake `Serving '<spec>' over AG-UI at <url>` success
+  banner and *then* died with a raw traceback whenever the spec was unloadable (gh #100).** The
+  banner was printed unconditionally, and the spec was only resolved later — inside `serve()`, which
+  is where `load_agent_spec()` runs. So the single most likely CLI mistake (a typo'd module, a
+  missing attribute, a nonexistent file) produced the worst possible output: a line claiming the
+  server was already up at a URL, immediately followed by an unhandled `ModuleNotFoundError` /
+  `AttributeError` / `FileNotFoundError` and exit 1. That is precisely the
+  fake-success-then-traceback failure the *same function* already went out of its way to prevent for
+  its two sibling cases — the missing `[agui]` extra (`ensure_available()` fails fast to stderr
+  "so the user doesn't see a fake success line followed by a traceback") and the no-spec-at-all path
+  (`error: no agent spec — ...`, exit 2) — leaving the CLI internally inconsistent on its most
+  common error. `main()` now resolves the spec *before* announcing anything: on failure it prints a
+  clean one-line `error: could not load agent '<spec>': <reason>` to stderr and exits 2, matching
+  both siblings in style and exit code, with no banner and no traceback. `load_agent_spec()` already
+  raises descriptive errors, so the reason needs no embellishment. The happy path is unchanged — the
+  banner still prints and the server still starts — and because `serve()` accepts either a spec
+  string or an already-compiled graph, the pre-loaded graph is handed straight through, so the agent
+  module is imported exactly once and no import side effect runs twice.
+- **A wrong-*typed* value in `langstage.toml` was accepted verbatim, so `execute_timeout = "300"`
+  resolved to the Python `str` `'300'` for a field declared `float` (gh langstage-jupyter #78).**
+  `_coerce` coerced `Path` fields only and passed `int`/`float`/`bool` fields through untouched, so a
+  syntactically-valid TOML value of the wrong type was never checked against the field it landed in.
+  Quoting a number — one of the most common TOML mistakes — was therefore silently accepted, and
+  `--show-config` *strips the quotes*, making the misconfiguration visually indistinguishable from a
+  correct one in the very tool built to inspect it. The defect then surfaced far from its cause as a
+  raw `TypeError: unsupported operand type(s) for +: 'float' and 'str'` the first time a consumer did
+  arithmetic on the value, with nothing pointing back at `langstage.toml` or the offending key. The
+  prior fix for the identical hazard on the env side (langstage-jupyter #75) added a `_lenient_number`
+  wrapper but applied it only to that stage's env casters; its own suggested fix anticipated this
+  sibling and named the right layer, so the repair lands here in core where every stage inherits it
+  instead of in one host. Numeric fields are now cast to their declared type, so a coercible value is
+  coerced (`"300"` -> `300.0`, `"8123"` -> `8123`, and an int literal widens to `1.0` for a `float`
+  field). An uncoercible one (`"warm"`, a table, an array) keeps the default *and* the `default`
+  source attribution — so `--show-config` can never present an unusable value as a live TOML setting —
+  and emits the same one-line `note: ignoring malformed <key>=<value> in <file> (<Error>: ...); using
+  default <default> instead.` that the numeric env casters and malformed-syntax TOML (#42) already
+  print, now naming the file so the user is pointed back at their config. `bool` is handled
+  deliberately: because `bool` subclasses `int` in Python, `temperature = true` would otherwise
+  become `1.0`, so a bool supplied *for* a numeric field is treated as malformed — while a genuine
+  bool field keeps accepting TOML `true`/`false` untouched. The note is deduped per (key, value), as
+  several surfaces each resolve the config in one process. Correctly-typed configs behave exactly as
+  before and emit no notes.
+
 ## [1.0.20] - 2026-07-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.20"
+version = "1.0.21"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/agui/__main__.py
+++ b/src/langstage_core/agui/__main__.py
@@ -118,11 +118,30 @@ def main(argv: list[str] | None = None) -> int:
         print(str(exc), file=sys.stderr)
         return 2
 
+    # Resolve the spec BEFORE announcing success. serve() loads the spec itself, so
+    # an unloadable one (typo'd module, missing attribute, nonexistent file — the
+    # most common CLI mistake) used to surface as a raw traceback *after* a banner
+    # claiming the server was already up. Loading here gives that case the same
+    # clean one-line stderr treatment as its two siblings above — the missing
+    # [agui] extra and the no-spec-at-all path. load_agent_spec() already raises
+    # descriptive errors, so the message needs no embellishment. (gh #100)
+    from ..host import load_agent_spec
+
+    try:
+        graph = load_agent_spec(spec)
+    # ImportError covers ModuleNotFoundError, OSError covers FileNotFoundError, and
+    # ValueError is the malformed-spec ("no :attr suffix") case load_agent_spec raises.
+    except (ImportError, AttributeError, OSError, ValueError) as exc:
+        print(f"error: could not load agent {spec!r}: {exc}", file=sys.stderr)
+        return 2
+
     name = args.name or ("Demo Agent" if args.demo else DEFAULT_AGENT_NAME)
     # cfg.host/cfg.port are the resolved values --show-config prints, so the
     # advertised config and the real bind agree.
     print(f"Serving {spec!r} over AG-UI at http://{cfg.host}:{cfg.port}{args.path}")
-    serve(spec, host=cfg.host, port=cfg.port, path=args.path, name=name)
+    # Pass the loaded graph, not the spec: serve() accepts either, and handing it
+    # the graph keeps the module from being imported (and its side effects run) twice.
+    serve(graph, host=cfg.host, port=cfg.port, path=args.path, name=name)
     return 0
 
 

--- a/src/langstage_core/host/config.py
+++ b/src/langstage_core/host/config.py
@@ -552,7 +552,15 @@ def _coerce(f: Any, value: Any) -> Any:
             raise TypeError(f"expected {numeric.__name__}, got {type(value).__name__}")
         if isinstance(value, numeric):
             return value
-        return numeric(value)
+        coerced = numeric(value)
+        # Reject a fractional value for an int field rather than silently truncating
+        # it. `port = 8050.7` -> 8050 would be exactly the defect this fix exists to
+        # close: a wrong-typed value quietly accepted as something the user did not
+        # write. An integral float (`8050.0`, or a config generator's "8050.0") is
+        # unambiguous, so it still coerces. (gh langstage-jupyter #78)
+        if numeric is int and float(value) != coerced:
+            raise ValueError(f"expected int, got non-integral {value!r}")
+        return coerced
     return value
 
 

--- a/src/langstage_core/host/config.py
+++ b/src/langstage_core/host/config.py
@@ -115,6 +115,10 @@ _malformed_toml: set[str] = set()
 # Dedupe the "ignoring malformed config" notice — _read_toml is called more than once
 # per path (loader + the per-file source-labeling re-read), which double-warned (#61).
 _warned_malformed_toml: set[str] = set()
+# Same dedupe for a TOML value of the wrong TYPE (below), keyed on (dotted key, value):
+# several surfaces each call resolve() in one process (import-time module constants,
+# --show-config, the launcher), and one typo shouldn't print the same note three times.
+_warned_malformed_toml_value: set[tuple[str, str]] = set()
 
 
 def _warn_legacy_toml(path: Path, canonical_name: str) -> None:
@@ -381,8 +385,15 @@ class HostConfig:
             if tkey is not None:
                 tv = _get_dotted(toml_data, tkey)
                 if tv is not None:
-                    val = _coerce(f, tv)
-                    src = f"toml ({toml_paths[-1].name})" if toml_paths else "toml"
+                    try:
+                        val = _coerce(f, tv)
+                    except (ValueError, TypeError) as exc:
+                        # An uncoercible value keeps the default AND the "default"
+                        # source, so --show-config can never present an unusable
+                        # value as a live TOML setting. (gh langstage-jupyter #78)
+                        _warn_malformed_toml_value(tkey, tv, exc, val, toml_paths)
+                    else:
+                        src = f"toml ({toml_paths[-1].name})" if toml_paths else "toml"
 
             if name in env_map:
                 var, caster = env_map[name]
@@ -482,8 +493,86 @@ class HostConfig:
         return "\n".join(lines)
 
 
+_NUMERIC_TYPES: dict[str, type] = {"int": int, "float": float}
+
+
+def _numeric_field_type(f: Any) -> type | None:
+    """Return ``int``/``float`` if the field declares a plain numeric type, else None.
+
+    Prefers the annotation (the declared type is the authority) and falls back to
+    the default's type, so it works whether or not the declaring module uses
+    ``from __future__ import annotations``.
+
+    ``bool`` is deliberately never returned even though it is a subclass of
+    ``int``: a bool *field* must keep accepting TOML ``true``/``false`` untouched,
+    and a bool supplied *for* a numeric field is malformed input, not ``1``.
+    """
+    ann = getattr(f, "type", None)
+    if isinstance(ann, type):
+        if ann is bool:
+            return None
+        if ann in (int, float):
+            return ann
+    elif isinstance(ann, str) and ann in _NUMERIC_TYPES:
+        return _NUMERIC_TYPES[ann]
+    default = getattr(f, "default", None)
+    if isinstance(default, bool):
+        return None
+    if isinstance(default, (int, float)):
+        return type(default)
+    return None
+
+
 def _coerce(f: Any, value: Any) -> Any:
-    """Coerce a TOML value to the field's expected shape (Path fields only)."""
+    """Coerce a TOML value to the field's declared shape (Path and numeric fields).
+
+    TOML is typed, but nothing checked that a value's type matched the field it
+    landed in — only ``Path`` fields were coerced, and everything else was passed
+    through verbatim. So the single most common TOML mistake, quoting a number
+    (``execute_timeout = "300"``), yielded the Python ``str`` ``'300'`` for a field
+    declared ``float``: ``--show-config`` strips the quotes so it looked correct,
+    and the defect surfaced far away as a raw ``TypeError`` the first time
+    something did arithmetic on it, with no pointer back to ``langstage.toml``.
+
+    Numeric fields are now cast, so a value that can sensibly be coerced is
+    (``"300"`` -> ``300.0``). One that can't (``"warm"``, ``true``, a table)
+    raises ``ValueError``/``TypeError``; ``resolve()`` catches it, keeps the
+    default, and prints the same one-line ``note: ignoring malformed ...; using
+    default ... instead.`` the numeric env casters and malformed-syntax TOML
+    (gh #42) already emit. (gh langstage-jupyter #78)
+    """
     if isinstance(getattr(f, "default", None), Path) and not isinstance(value, Path):
         return Path(value)
+
+    numeric = _numeric_field_type(f)
+    if numeric is not None:
+        # Check bool BEFORE the isinstance(value, numeric) fast path: bool subclasses
+        # int, so `temperature = true` would otherwise sail through (or coerce to 1.0).
+        if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+            raise TypeError(f"expected {numeric.__name__}, got {type(value).__name__}")
+        if isinstance(value, numeric):
+            return value
+        return numeric(value)
     return value
+
+
+def _warn_malformed_toml_value(
+    key: str, value: Any, exc: Exception, default: Any, paths: list[Path]
+) -> None:
+    """One-line stderr note when a TOML value can't be coerced to its field's type.
+
+    Mirrors the numeric env casters' note and #42's malformed-syntax note: name what
+    was ignored, why, and what is used instead. It also names the file, because the
+    whole point of gh langstage-jupyter #78 is that the user was never pointed back
+    at ``langstage.toml``. ASCII-only so it can't crash a cp1252 Windows console.
+    """
+    dedupe = (key, repr(value))
+    if dedupe in _warned_malformed_toml_value:
+        return
+    _warned_malformed_toml_value.add(dedupe)
+    where = f" in {paths[-1]}" if paths else ""
+    print(
+        f"note: ignoring malformed {key}={value!r}{where} "
+        f"({type(exc).__name__}: {exc}); using default {default!r} instead.",
+        file=sys.stderr,
+    )

--- a/tests/test_agui_cli.py
+++ b/tests/test_agui_cli.py
@@ -6,6 +6,9 @@ server actually bound 127.0.0.1:8000 — the shown config and the real bind
 disagreed. host/port now come from the resolved HostConfig (CLI flags override),
 so --show-config reflects exactly what serve() binds.
 """
+import pytest
+
+import langstage_core.agui as agui_pkg
 from langstage_core.agui.__main__ import main
 
 
@@ -56,3 +59,101 @@ def test_show_config_omits_keys_the_server_ignores(capsys):
     assert "agent_spec" in out and "host" in out and "port" in out
     for inert in ("workspace_root", "debug", "title", "LANGSTAGE_TITLE", "LANGSTAGE_DEBUG"):
         assert inert not in out, inert
+
+
+class TestInvalidSpecFailsBeforeBanner:
+    """gh #100: an unloadable --agent spec printed the "Serving '<spec>' over AG-UI
+    at <url>" success banner and *then* died with a raw traceback, because the spec
+    was only loaded inside serve(). That is the exact fake-success-line-then-traceback
+    failure the two sibling paths in the same function already avoid (the missing
+    [agui] extra, and the no-spec-at-all `error: no agent spec ...` / exit 2). The
+    spec now resolves before the banner: clean one-line `error: ...` on stderr,
+    exit 2, no banner, no traceback.
+    """
+
+    @pytest.fixture
+    def stub_serve(self, monkeypatch):
+        """Neutralise the [agui]-extra gate and capture what serve() is handed.
+
+        main() does `from . import ... ensure_available, serve` at call time, so
+        patching the package attributes is what the CLI actually resolves.
+        """
+        calls: list = []
+        monkeypatch.setattr(agui_pkg, "ensure_available", lambda: None)
+        monkeypatch.setattr(agui_pkg, "serve", lambda graph, **kw: calls.append((graph, kw)))
+        return calls
+
+    @pytest.mark.parametrize(
+        "spec, needle",
+        [
+            # The three variants from the issue, one per leaked exception type.
+            ("myagent:graph", "No module named 'myagent'"),                    # ModuleNotFoundError
+            ("langstage_core.demo.stub:not_a_real_attr", "not_a_real_attr"),   # AttributeError
+            ("./no_such_file.py:graph", "Agent file not found"),               # FileNotFoundError
+        ],
+    )
+    def test_unloadable_spec_is_a_clean_stderr_error(self, spec, needle, stub_serve, capsys):
+        rc = main(["--agent", spec])
+        captured = capsys.readouterr()
+
+        assert rc == 2, "must exit non-zero, matching the sibling error paths"
+        assert "error: could not load agent" in captured.err
+        assert needle in captured.err
+        assert "Traceback" not in captured.err, "the raw traceback must not leak"
+        # The regression itself: no fake success line claiming the server is up.
+        assert "Serving" not in captured.out
+        assert stub_serve == [], "serve() must not be reached with a bad spec"
+        captured.err.encode("ascii")  # cp1252-safe
+
+    def test_malformed_spec_without_attr_suffix_is_also_clean(self, stub_serve, capsys):
+        # load_agent_spec raises ValueError (not Import/Attribute/OSError) when the
+        # required ':attr' suffix is missing — same clean treatment, no traceback.
+        rc = main(["--agent", "myagent"])
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "error: could not load agent" in captured.err
+        assert "Serving" not in captured.out
+        assert stub_serve == []
+
+    def test_valid_spec_still_prints_banner_and_serves_the_loaded_graph(
+        self, stub_serve, tmp_path, capsys
+    ):
+        # The happy path must be untouched: banner still printed, server still started.
+        agent = tmp_path / "good_agent.py"
+        agent.write_text("graph = {'marker': 'the-real-graph'}\n")
+        spec = f"{agent}:graph"
+
+        rc = main(["--agent", spec, "--port", "9111"])
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert f"Serving {spec!r} over AG-UI at" in out
+        assert "9111" in out
+        assert len(stub_serve) == 1
+        graph, kwargs = stub_serve[0]
+        # serve() accepts a spec string OR a loaded graph; it is handed the already
+        # loaded graph so the spec is not resolved a second time.
+        assert graph == {"marker": "the-real-graph"}
+        assert not isinstance(graph, str)
+        assert kwargs["port"] == 9111
+
+    def test_spec_module_is_imported_exactly_once(self, stub_serve, tmp_path, capsys):
+        """Pre-loading must not double-run the agent module's import side effects.
+
+        A file-path spec gets a fresh unique module name per load, so loading twice
+        would execute the module body twice — this pins that it happens once.
+        """
+        marker = tmp_path / "imports.log"
+        agent = tmp_path / "side_effect_agent.py"
+        agent.write_text(
+            "from pathlib import Path\n"
+            f"Path(r'{marker}').open('a').write('imported\\n')\n"
+            "graph = object()\n"
+        )
+
+        rc = main(["--agent", f"{agent}:graph"])
+        capsys.readouterr()
+
+        assert rc == 0
+        assert marker.read_text().count("imported") == 1
+        assert len(stub_serve) == 1

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -343,3 +343,158 @@ class TestFromEnvBackCompat:
         monkeypatch.delenv("DEEPAGENT_PORT", raising=False)
         # from_env ignores TOML even though deepagents.toml is in cwd
         assert HostConfig.from_env().port == 8050
+
+
+@dataclass
+class NumericHost(HostConfig):
+    """Mirrors langstage-jupyter's LabConfig numeric fields — the ones gh
+    langstage-jupyter #78 was filed against."""
+
+    model_temperature: float = 0.0
+    execute_timeout: float = 300.0
+    virtual_mode: bool = False
+    _TOML: ClassVar[dict] = {
+        "model_temperature": "model.temperature",
+        "execute_timeout": "jupyter.execute_timeout",
+        "virtual_mode": "jupyter.virtual_mode",
+    }
+
+
+class TestTomlValueTypes:
+    """gh langstage-jupyter #78: `_coerce` handled Path fields only, so a
+    syntactically-valid TOML value of the WRONG TYPE was accepted verbatim.
+    Quoting a number — `execute_timeout = "300"`, the most common TOML mistake —
+    handed downstream code the str '300' for a field declared float. --show-config
+    strips the quotes, so the misconfiguration was invisible in the very tool built
+    to inspect it, and it surfaced far from the cause as a raw TypeError the first
+    time something did arithmetic on it. Numeric fields are now coerced when they
+    sensibly can be, and otherwise degrade to the default with the same one-line
+    `note: ignoring malformed ...; using default ...` the numeric env casters and
+    malformed-syntax TOML (#42) emit.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_note_dedupe(self):
+        # The note is deduped per (key, value) for the whole process, so clear it
+        # or a second test asserting the same note would see nothing. getattr'd so
+        # that reverting the fix makes these tests fail on the *behaviour* rather
+        # than erroring out here on a missing symbol.
+        import langstage_core.host.config as config_mod
+
+        seen = getattr(config_mod, "_warned_malformed_toml_value", set())
+        seen.clear()
+        yield
+        seen.clear()
+
+    def test_quoted_number_is_coerced_to_the_declared_type(self, isolated_global, tmp_path):
+        _toml(tmp_path, '[jupyter]\nexecute_timeout = "300"\n[model]\ntemperature = "0.5"\n')
+        cfg = NumericHost.resolve(env={}, toml_start=tmp_path)
+
+        assert cfg.execute_timeout == 300.0
+        assert isinstance(cfg.execute_timeout, float)
+        assert cfg.model_temperature == 0.5
+        assert isinstance(cfg.model_temperature, float)
+        # Coercion succeeded, so TOML is still (correctly) credited as the source.
+        assert cfg.sources["execute_timeout"].startswith("toml")
+
+    def test_coerced_value_survives_downstream_arithmetic(self, isolated_global, tmp_path):
+        # The headline crash from the issue: notebook_tools.py's
+        # `deadline = time.monotonic() + EXECUTE_TIMEOUT` died with
+        # "unsupported operand type(s) for +: 'float' and 'str'".
+        _toml(tmp_path, '[jupyter]\nexecute_timeout = "300"\n')
+        cfg = NumericHost.resolve(env={}, toml_start=tmp_path)
+        assert 1000.0 + cfg.execute_timeout == 1300.0
+
+    def test_quoted_int_is_coerced_for_an_int_field(self, isolated_global, tmp_path):
+        _toml(tmp_path, '[server]\nport = "8123"\n')
+        cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
+        assert cfg.port == 8123
+        assert isinstance(cfg.port, int)
+
+    def test_uncoercible_string_falls_back_to_default_with_a_note(
+        self, isolated_global, tmp_path, capsys
+    ):
+        _toml(tmp_path, '[model]\ntemperature = "warm"\n')
+        cfg = NumericHost.resolve(env={}, toml_start=tmp_path)
+
+        assert cfg.model_temperature == 0.0
+        # --show-config must not present an unusable value as a live TOML setting:
+        # the row shows the default value attributed to [default], never 'warm'.
+        assert cfg.sources["model_temperature"] == "default"
+        row = next(
+            line for line in cfg.describe().splitlines() if "model_temperature" in line
+        )
+        assert "[default]" in row and "0.0" in row and "warm" not in row
+
+        err = capsys.readouterr().err
+        assert "note: ignoring malformed model.temperature='warm'" in err
+        assert "using default 0.0 instead." in err
+        assert "langstage.toml" in err or "deepagents.toml" in err  # points back at the file
+        err.encode("cp1252")  # ASCII-only — must not crash a cp1252 console
+
+    def test_bool_for_a_numeric_field_is_malformed_not_one(
+        self, isolated_global, tmp_path, capsys
+    ):
+        # bool is a subclass of int in Python, so `temperature = true` would
+        # otherwise sail through (or coerce to 1.0) — a silently wrong model setting.
+        _toml(tmp_path, "[model]\ntemperature = true\n")
+        cfg = NumericHost.resolve(env={}, toml_start=tmp_path)
+
+        assert cfg.model_temperature == 0.0
+        assert cfg.model_temperature is not True
+        assert cfg.sources["model_temperature"] == "default"
+        err = capsys.readouterr().err
+        assert "ignoring malformed model.temperature=True" in err
+        assert "expected float, got bool" in err
+
+    def test_genuine_bool_field_still_accepts_toml_booleans(self, isolated_global, tmp_path, capsys):
+        # The converse guard: a real bool field must be untouched by all of this.
+        _toml(tmp_path, "[jupyter]\nvirtual_mode = true\n")
+        cfg = NumericHost.resolve(env={}, toml_start=tmp_path)
+        assert cfg.virtual_mode is True
+        assert cfg.sources["virtual_mode"].startswith("toml")
+
+        _toml(tmp_path, "[jupyter]\nvirtual_mode = false\n")
+        cfg = NumericHost.resolve(env={}, toml_start=tmp_path)
+        assert cfg.virtual_mode is False
+        assert cfg.sources["virtual_mode"].startswith("toml")
+        assert "ignoring malformed" not in capsys.readouterr().err
+
+    def test_non_scalar_for_a_numeric_field_degrades(self, isolated_global, tmp_path, capsys):
+        _toml(tmp_path, "[server]\nport = [1, 2]\n")
+        cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
+        assert cfg.port == 8050
+        assert cfg.sources["port"] == "default"
+        assert "expected int, got list" in capsys.readouterr().err
+
+    def test_correctly_typed_toml_is_untouched(self, isolated_global, tmp_path, capsys):
+        # No behaviour change for a clean config — and no spurious notes.
+        _toml(tmp_path, '[server]\nport = 7000\n[agent]\nspec = "x.py:graph"\n'
+                        "[jupyter]\nexecute_timeout = 45.5\n")
+        cfg = NumericHost.resolve(env={}, toml_start=tmp_path)
+        assert cfg.port == 7000
+        assert cfg.agent_spec == "x.py:graph"
+        assert cfg.execute_timeout == 45.5
+        assert "ignoring malformed" not in capsys.readouterr().err
+
+    def test_int_literal_widens_for_a_float_field(self, isolated_global, tmp_path):
+        # TOML has no float literal for a whole number, so `temperature = 1` parses
+        # as int; a field declared float should get 1.0, not the int.
+        _toml(tmp_path, "[model]\ntemperature = 1\n")
+        cfg = NumericHost.resolve(env={}, toml_start=tmp_path)
+        assert cfg.model_temperature == 1.0
+        assert isinstance(cfg.model_temperature, float)
+
+    def test_path_fields_still_coerce(self, isolated_global, tmp_path):
+        # The pre-existing Path behaviour must be preserved.
+        _toml(tmp_path, '[workspace]\nroot = "/tmp/ws"\n')
+        cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
+        assert isinstance(cfg.workspace_root, Path)
+
+    def test_note_is_emitted_once_per_bad_value(self, isolated_global, tmp_path, capsys):
+        # Several surfaces each call resolve() in one process; one typo must not
+        # print the same note three times (same dedupe as #61's malformed-file note).
+        _toml(tmp_path, '[model]\ntemperature = "warm"\n')
+        for _ in range(3):
+            NumericHost.resolve(env={}, toml_start=tmp_path)
+        assert capsys.readouterr().err.count("ignoring malformed model.temperature") == 1

--- a/tests/test_host_config.py
+++ b/tests/test_host_config.py
@@ -477,6 +477,26 @@ class TestTomlValueTypes:
         assert cfg.execute_timeout == 45.5
         assert "ignoring malformed" not in capsys.readouterr().err
 
+    def test_fractional_value_for_an_int_field_is_rejected(
+        self, isolated_global, tmp_path, capsys
+    ):
+        # Truncating 8050.7 -> 8050 would be the very defect this fix closes: a
+        # wrong-typed value silently accepted as something the user never wrote.
+        _toml(tmp_path, "[server]\nport = 8050.7\n")
+        cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
+
+        assert cfg.port == 8050  # the default, not a truncation of 8050.7
+        assert cfg.sources["port"] == "default"
+        assert "ignoring malformed" in capsys.readouterr().err
+
+    def test_integral_float_still_coerces_for_an_int_field(self, isolated_global, tmp_path):
+        # `8123.0` is unambiguous (and what some config generators emit), so it is
+        # coerced rather than rejected — only a fractional part is an error.
+        _toml(tmp_path, "[server]\nport = 8123.0\n")
+        cfg = HostConfig.resolve(env={}, toml_start=tmp_path)
+        assert cfg.port == 8123
+        assert isinstance(cfg.port, int)
+
     def test_int_literal_widens_for_a_float_field(self, isolated_global, tmp_path):
         # TOML has no float literal for a whole number, so `temperature = 1` parses
         # as int; a field declared float should get 1.0, not the int.


### PR DESCRIPTION
Fixes #100. Also fixes the core half of dkedar7/langstage-jupyter#78.

Two error-path holes where a plausible user mistake surfaced as a raw traceback or a silently wrong value instead of a clean, actionable message. Both are "untreated sibling" cases — each has a directly analogous path in the *same* function/module that was already hardened.

---

## Issue 1 — `langstage-agui` printed a fake success banner, then crashed (gh #100)

**Problem.** `main()` printed `Serving '<spec>' over AG-UI at http://host:port/` unconditionally, and only resolved the spec *afterwards*, inside `serve()` — which is where `load_agent_spec()` actually runs. So an unloadable spec (typo'd module, missing attribute, nonexistent file — the most common CLI mistake) produced a line claiming the server was already up at a URL, immediately followed by an unhandled traceback and exit 1.

This is precisely the failure the same function already goes out of its way to prevent for its two siblings: the missing `[agui]` extra (whose comment literally reads *"so the user doesn't see a fake success line followed by a traceback"*) and the no-spec-at-all path (`error: no agent spec — ...`, exit 2). Only the likeliest error was left with the old behavior.

**Fix.** Resolve the spec *before* announcing anything. On failure, print a one-line `error: could not load agent '<spec>': <reason>` to stderr and exit 2 — matching both siblings in message style and exit code. `load_agent_spec()` already raises descriptive errors, so the reason needs no embellishment. `serve()` accepts either a spec string or an already-compiled graph, so the pre-loaded graph is handed straight through: the module is imported exactly once and no import side effect runs twice.

Caught: `ImportError` (covers `ModuleNotFoundError`), `AttributeError`, `OSError` (covers `FileNotFoundError`), and `ValueError` (the malformed "no `:attr` suffix" spec).

### Before

```console
$ langstage-agui --agent myagent:graph
Serving 'myagent:graph' over AG-UI at http://localhost:8050/
Traceback (most recent call last):
  File "...\langstage_core\agui\__main__.py", line 125, in main
    serve(spec, host=cfg.host, port=cfg.port, path=args.path, name=name)
  File "...\langstage_core\agui\__init__.py", line 220, in serve
    graph = load_agent_spec(spec_or_graph)
  File "...\langstage_core\host\loader.py", line 53, in load_agent_spec
    module = _import_module(module_path)
  ...
ModuleNotFoundError: No module named 'myagent'
[exit 1]
```

(Same shape for `langstage_core.demo.stub:not_a_real_attr` → `AttributeError`, and `./no_such_file.py:graph` → `FileNotFoundError`.)

### After

```console
$ langstage-agui --agent myagent:graph
error: could not load agent 'myagent:graph': No module named 'myagent'
[exit 2]

$ langstage-agui --agent langstage_core.demo.stub:not_a_real_attr
error: could not load agent 'langstage_core.demo.stub:not_a_real_attr': Module 'langstage_core.demo.stub' has no attribute 'not_a_real_attr'.
[exit 2]

$ langstage-agui --agent ./no_such_file.py:graph
error: could not load agent './no_such_file.py:graph': Agent file not found: C:\...\no_such_file.py
[exit 2]
```

No banner, no traceback, exit 2 — consistent with the sibling `error: no agent spec — ...` path. The happy path is unchanged (banner still prints, server still starts), pinned by tests.

---

## Issue 2 — a wrong-*typed* TOML value was accepted verbatim (langstage-jupyter#78)

**Problem.** `langstage_core/host/config.py::_coerce` coerced `Path` fields only and passed `int`/`float`/`bool` fields through untouched, so a syntactically valid TOML value was never checked against the type of the field it landed in. Quoting a number — one of the most common TOML mistakes — was silently accepted: `execute_timeout = "300"` resolved to the Python `str` `'300'` for a field declared `float`.

Worse, `--show-config` *strips the quotes*, so the misconfiguration was visually indistinguishable from a correct one in the very tool built to inspect it. The defect surfaced far from its cause as a raw `TypeError` the first time something did arithmetic on the value, with nothing pointing back at `langstage.toml`.

The env half of this exact hazard was fixed in langstage-jupyter#75 via a `_lenient_number` wrapper — but applied only to that one stage's env casters. That issue's own suggested fix named `resolve()` as the layer that would cover env *and* the TOML wrong-type case in one place, so the repair lands **here in core**, where every stage inherits it, rather than in a single host.

**Fix.** Numeric (`int`/`float`) fields are cast to their declared type:

- coercible → coerced: `"300"` → `300.0`, `"8123"` → `8123`, and an int literal widens to `1.0` for a `float` field (TOML has no float literal for a whole number)
- uncoercible (`"warm"`, an array, a table) → keeps the default **and** the `default` source attribution, so `--show-config` can never present an unusable value as a live TOML setting, plus the same one-line note the env casters and malformed-syntax TOML (#42) already emit, now naming the file

`bool` is handled deliberately: since `bool` subclasses `int` in Python, `temperature = true` would otherwise become `1.0`, so a bool supplied *for* a numeric field is malformed — while a genuine bool field keeps accepting TOML `true`/`false` untouched. The note is deduped per `(key, value)`, since several surfaces each resolve the config in one process. Correctly-typed configs behave exactly as before and emit no notes.

Field type is taken from the annotation first (the declared type is the authority), falling back to the default's type, so it works whether or not a subclass uses `from __future__ import annotations`.

### Repro config

```toml
[jupyter]
execute_timeout = "300"
virtual_mode = true
[model]
temperature = "0.5"
[server]
port = "8123"
```

### Before

```
--- resolved ---
  model_temperature  = '0.5'      type=str   [toml (langstage.toml)]
  execute_timeout    = '300'      type=str   [toml (langstage.toml)]
  virtual_mode       = True       type=bool  [toml (langstage.toml)]
  port               = '8123'     type=str   [toml (langstage.toml)]
--- downstream (notebook_tools.py:467 equivalent) ---
  TypeError: unsupported operand type(s) for +: 'float' and 'str'
```

### After

```
--- resolved ---
  model_temperature  = 0.5        type=float [toml (langstage.toml)]
  execute_timeout    = 300.0      type=float [toml (langstage.toml)]
  virtual_mode       = True       type=bool  [toml (langstage.toml)]
  port               = 8123       type=int   [toml (langstage.toml)]
--- downstream (notebook_tools.py:467 equivalent) ---
  deadline = 204220.89
```

### Uncoercible values degrade with a note

Config: `execute_timeout = true`, `temperature = "warm"`, `virtual_mode = false`

```
note: ignoring malformed model.temperature='warm' in C:\...\langstage.toml (ValueError: could not convert string to float: 'warm'); using default 0.0 instead.
note: ignoring malformed jupyter.execute_timeout=True in C:\...\langstage.toml (TypeError: expected float, got bool); using default 300.0 instead.
--- resolved ---
  model_temperature  = 0.0        type=float [default]
  execute_timeout    = 300.0      type=float [default]
  virtual_mode       = False      type=bool  [toml (langstage.toml)]
  port               = 8050       type=int   [default]
```

Note the `[default]` attribution on the two rejected rows, and `virtual_mode` — a genuine bool field — still resolving from TOML.

---

## Verification

- **Full suite: 181 passed** (164 before this PR; +17 new regression tests).
- **The regression tests were verified to actually fail without the fix.** With `src/langstage_core/host/config.py` and `src/langstage_core/agui/__main__.py` stashed and the new tests left in place, 14 of the 17 fail on real behavior assertions — e.g. `assert '300' == 300.0`, `TypeError: unsupported operand type(s) for +: 'float' and 'str'`, `assert True == 0.0`, `assert 0 == 2` (exit code), and `assert '<path>:graph' == {'marker': 'the-real-graph'}` (serve received the spec string, not the loaded graph). The remaining 3 are deliberate must-not-regress guards (correctly-typed TOML untouched, genuine bool fields, `Path` coercion) that pass both before and after, as intended.
- Both issues' stated repros were run before and after the fix; the literal output is above. Issue 1 was reproduced against a clean venv with the real `[agui,stub]` extras installed, using the actual `langstage-agui` console script.

New tests: `tests/test_agui_cli.py::TestInvalidSpecFailsBeforeBanner` (6) and `tests/test_host_config.py::TestTomlValueTypes` (11).

## Files changed

- `src/langstage_core/agui/__main__.py` — load the spec before the banner; clean stderr error + exit 2; pass the loaded graph to `serve()`
- `src/langstage_core/host/config.py` — `_coerce` handles numeric fields; new `_numeric_field_type` / `_warn_malformed_toml_value`; `resolve()` keeps the default *and* the `default` source on an uncoercible TOML value
- `tests/test_agui_cli.py`, `tests/test_host_config.py` — regression tests
- `pyproject.toml`, `CHANGELOG.md` — 1.0.21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B
