### PR TITLE
fix(agui): honor max_result_len on iter_chunk_frames so the CLI/Jupyter wire caps tool results (gh #102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [1.0.22] - 2026-07-19
+
+### Fixed
+- **`iter_chunk_frames` ignored `max_result_len`, so the CLI/Jupyter wire emitted tool results
+  uncapped with no knob to bound them (gh #102).** The two `iter_*` mappings are documented
+  counterparts on the same wire vocabulary, but they disagreed on tool-result truncation:
+  `iter_event_frames` capped each result at `max_result_len` (default 500) and appended a
+  `…(truncated)` marker, while `iter_chunk_frames` yielded `ToolCallResultEvent.content` straight
+  through and **had no `max_result_len` parameter at all** — there was no way to cap it, not even
+  by opting in. The asymmetry pointed exactly the wrong way: the README assigns `iter_chunk_frames`
+  to *"the CLI and Jupyter surfaces"* ("terminal-friendly chunk dicts"), so the one wire that renders
+  directly into a terminal or notebook cell was the one with no bound, while the event wire —
+  consumed by the web/VS Code surfaces that already paginate and scroll — was protected. A tool
+  returning a large blob (a file read, a search result set, an API dump) therefore flooded the
+  render loop unbounded: a 2 MB result is a 2 MB wall of text in the user's terminal, and the
+  documented fix (pass `max_result_len=`) raised `TypeError: unexpected keyword argument`.
+  `iter_chunk_frames` now takes the same `max_result_len: int = 500` and truncates its
+  `tool_result` chunk identically, so the counterparts agree by default and the terminal surfaces
+  inherit the protection `SessionAdapter` has always had. The truncation itself moved into one
+  shared `_truncate_result()` that both mappings call, rather than a second inline copy of the
+  slice-and-mark — this is the third parity gap between the pair (after `extractors` in #92 and
+  the `error` frame in #93), and a duplicated implementation is what let the two drift in the
+  first place. Two boundaries are deliberate. A result at or under the cap is emitted
+  byte-identical with no marker, so every existing CLI/Jupyter consumer of a normal-sized result
+  is untouched. And the *extractor* still receives the full, untruncated content: truncation is a
+  display concern, so capping the extractor's input would corrupt the payload it parses — the
+  event wire feeds its extractor the raw content for the same reason. A non-`str` result is passed
+  through rather than sliced (AG-UI types `content` as `str`, so this is defensive — but the chunk
+  wire yields `content` as-is where the event wire coerces with `str()`, and slicing a dict would
+  raise `TypeError`).
+
 ## [1.0.21] - 2026-07-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.21"
+version = "1.0.22"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/agui/__init__.py
+++ b/src/langstage_core/agui/__init__.py
@@ -285,6 +285,28 @@ def _normalize_interrupt(payload, default_decisions=_DEFAULT_DECISIONS):
     return [], [], list(default_decisions)
 
 
+def _truncate_result(result, max_result_len):
+    """Cap a tool result at ``max_result_len``, appending the ``…(truncated)`` marker.
+
+    The single implementation both ``iter_*`` mappings call, so the two counterparts
+    can't drift on truncation the way they did before gh #102 (``iter_event_frames``
+    capped; ``iter_chunk_frames`` — the CLI/Jupyter wire, where an unbounded blob is
+    arguably *more* harmful — emitted the full result with no knob at all).
+
+    Boundary: a result of exactly ``max_result_len`` or shorter is returned unchanged
+    and unmarked; a longer one is sliced to ``max_result_len`` *and then* marked, so
+    the yielded string is ``max_result_len`` + 12 characters.
+
+    A non-``str`` result is passed through untouched rather than sliced. AG-UI types
+    ``ToolCallResultEvent.content`` as ``str``, so this is defensive — but the chunk
+    wire yields ``content`` as-is (only the event wire coerces with ``str()``), and
+    slicing e.g. a dict a fake or future adapter produced would raise ``TypeError``.
+    """
+    if isinstance(result, str) and len(result) > max_result_len:
+        return result[:max_result_len] + "…(truncated)"
+    return result
+
+
 def _unwrap_resume(resume):
     """Return the raw resume payload, accepting either the payload OR a langgraph
     ``Command`` built by :func:`create_resume_input`.
@@ -438,9 +460,7 @@ async def iter_event_frames(
                     "node": current_node,
                 }
             elif t == "ToolCallResultEvent":
-                result = str(getattr(ev, "content", ""))
-                if len(result) > max_result_len:
-                    result = result[:max_result_len] + "…(truncated)"
+                result = _truncate_result(str(getattr(ev, "content", "")), max_result_len)
                 name = tool_names.get(ev.tool_call_id, "tool")
                 is_error = errored_tools.get(name, 0) > 0
                 if is_error:
@@ -531,6 +551,7 @@ async def iter_chunk_frames(
     thread_id: str,
     *,
     resume: Any = None,
+    max_result_len: int = 500,
     extractors: Any = (),
     state: Any = None,
 ):
@@ -542,6 +563,13 @@ async def iter_chunk_frames(
     for surfaces on the ``stream_graph_updates`` wire (the cli and Jupyter render
     loops). ``resume`` rides ``forwarded_props.command.resume``; ``state`` seeds the
     graph input (for agents whose input carries more than ``messages``).
+
+    ``max_result_len`` caps each ``tool_result`` chunk exactly as it caps
+    :func:`iter_event_frames`' ``tool_end`` frame — same default (500), same
+    ``…(truncated)`` marker, one shared :func:`_truncate_result`. Before gh #102 this
+    mapping had no such parameter and emitted the full result, so a tool returning a
+    large blob (a file read, a search dump) flooded the terminal/notebook with no way
+    to bound it — on the very wire the README assigns to the CLI and Jupyter surfaces.
 
     ``extractors`` is the same optional iterable of
     :class:`~langstage_core.extractors.base.ToolExtractor` that :func:`iter_event_frames`
@@ -629,7 +657,15 @@ async def iter_chunk_frames(
                     args = {"_raw": tc["args"]}
                 yield {"status": "streaming", "tool_calls": [{"name": tc["name"], "args": args}]}
             elif t == "ToolCallResultEvent":
-                yield {"status": "streaming", "tool_result": getattr(ev, "content", "")}
+                # Cap the result the way the event wire has always capped its `tool_end`
+                # frame (gh #102) — the CLI/Jupyter render loops read this chunk straight
+                # to the terminal. The extractor below still sees the FULL content: it
+                # parses a payload, and truncation is a display concern (iter_event_frames
+                # feeds its extractor the raw content for the same reason).
+                yield {
+                    "status": "streaming",
+                    "tool_result": _truncate_result(getattr(ev, "content", ""), max_result_len),
+                }
                 # Run the matching extractor over the tool result and, on a non-None
                 # return, emit an `extraction` chunk — parity with iter_event_frames'
                 # `extraction` frame so the CLI/Jupyter surfaces can render the same

--- a/tests/test_agui_frames.py
+++ b/tests/test_agui_frames.py
@@ -480,3 +480,116 @@ async def test_chunk_frames_node_exception_becomes_terminal_error_frame():
     assert frames[-1]["status"] == "error", frames
     assert "RuntimeError" in frames[-1]["error"] and "model call failed" in frames[-1]["error"]
     assert not any(f.get("status") == "complete" for f in frames), frames
+
+
+# --- gh #102: `max_result_len` is honored on BOTH `iter_*` mappings. The event wire has
+# always capped its `tool_end` result at 500 with a `…(truncated)` marker; the chunk wire —
+# the one the README assigns to the CLI and Jupyter surfaces — emitted the full result and
+# had no `max_result_len` parameter at all, so a large tool blob flooded the terminal with
+# no knob to bound it. Same parity-gap class as #92 (`extractors`). ---
+
+def _big_result_graph(size=2000):
+    """A graph whose single tool returns a `size`-char blob — the file read / search dump /
+    API response that floods a terminal when the wire doesn't cap it."""
+    from langchain_core.messages import AIMessage
+    from langchain_core.tools import tool
+    from langgraph.graph import END, START, MessagesState, StateGraph
+    from langgraph.prebuilt import ToolNode
+
+    @tool
+    def big(q: str) -> str:
+        """Return a big result."""
+        return "X" * size
+
+    def call(state):
+        return {
+            "messages": [
+                AIMessage(content="", tool_calls=[{"name": "big", "id": "b1", "args": {"q": "go"}}])
+            ]
+        }
+
+    b = StateGraph(MessagesState)
+    b.add_node("call", call)
+    b.add_node("tools", ToolNode([big]))
+    b.add_edge(START, "call")
+    b.add_edge("call", "tools")
+    b.add_edge("tools", END)
+    return b.compile()
+
+
+async def _chunk_tool_results(agent, thread_id, **kw):
+    frames = await _collect(iter_chunk_frames(agent, "go", thread_id, **kw))
+    return [f["tool_result"] for f in frames if "tool_result" in f]
+
+
+async def test_iter_chunk_frames_accepts_max_result_len_param():
+    # The knob the report asks for: `max_result_len` must exist on the chunk mapping, with
+    # the same default as its counterpart, so the two signatures agree.
+    import inspect
+
+    params = inspect.signature(iter_chunk_frames).parameters
+    assert "max_result_len" in params
+    assert params["max_result_len"].default == 500
+    assert (
+        params["max_result_len"].default
+        == inspect.signature(iter_event_frames).parameters["max_result_len"].default
+    )
+
+
+async def test_iter_chunk_frames_truncates_tool_result_by_default():
+    # Before the fix this yielded all 2000 characters, uncapped, straight to the terminal.
+    results = await _chunk_tool_results(build_agent(_big_result_graph()), "c102a")
+    assert results, "no tool_result chunk emitted"
+    assert len(results[0]) == 500 + len("…(truncated)")
+    assert results[0].endswith("…(truncated)")
+    assert results[0][:500] == "X" * 500
+
+
+async def test_iter_chunk_frames_truncation_matches_iter_event_frames():
+    # The whole point of #102: the counterparts must produce the SAME capped string, so
+    # neither marker nor boundary can drift again.
+    agent = build_agent(_big_result_graph())
+    chunk = (await _chunk_tool_results(agent, "c102b"))[0]
+    event_frames = await _collect(iter_event_frames(agent, "go", "e102b"))
+    event = [f["result"] for f in event_frames if f.get("type") == "tool_end"][0]
+    assert chunk == event
+
+
+async def test_iter_chunk_frames_honors_custom_max_result_len():
+    results = await _chunk_tool_results(build_agent(_big_result_graph()), "c102c", max_result_len=10)
+    assert results[0] == "X" * 10 + "…(truncated)"
+
+
+async def test_iter_chunk_frames_leaves_short_result_untouched():
+    # The boundary: a result at or under the cap is emitted byte-identical, with no marker —
+    # so every existing CLI/Jupyter consumer of a normal-sized result is unchanged.
+    results = await _chunk_tool_results(build_agent(_big_result_graph(size=500)), "c102d")
+    assert results[0] == "X" * 500
+    assert "(truncated)" not in results[0]
+
+
+async def test_iter_chunk_frames_extractor_still_sees_the_full_result():
+    # Truncation is a *display* concern: the extractor parses the payload, so it must keep
+    # receiving the untruncated content (iter_event_frames feeds its extractor the raw
+    # content for the same reason). Capping the extractor's input would corrupt parsed data.
+    from langstage_core import GenericToolExtractor
+
+    frames = await _collect(
+        iter_chunk_frames(
+            build_agent(_big_result_graph()), "go", "c102e", extractors=[GenericToolExtractor()]
+        )
+    )
+    extraction = [f["extraction"] for f in frames if "extraction" in f]
+    assert extraction, f"no extraction chunk emitted: {frames}"
+    assert extraction[0]["data"] == {"content": "X" * 2000}
+
+
+async def test_truncate_result_passes_non_str_through_untouched():
+    # A non-str tool result (a dict/list/None a fake or future adapter yields) must not be
+    # sliced — `{...}[:500]` is a TypeError. AG-UI types `content` as str, so this is the
+    # defensive path both mappings share.
+    from langstage_core.agui import _truncate_result
+
+    assert _truncate_result({"a": 1}, 1) == {"a": 1}
+    assert _truncate_result([1, 2, 3], 1) == [1, 2, 3]
+    assert _truncate_result(None, 1) is None


### PR DESCRIPTION
Closes #102.

## The problem

The two `iter_*` mappings are documented counterparts on the same wire vocabulary, but they disagreed on tool-result truncation:

- `iter_event_frames` capped each result at `max_result_len` (default 500) and appended `…(truncated)`.
- `iter_chunk_frames` yielded `ToolCallResultEvent.content` straight through, and had **no `max_result_len` parameter at all** — no way to cap it, not even by opting in.

The asymmetry pointed exactly the wrong way. The README assigns `iter_chunk_frames` to *"the CLI and Jupyter surfaces"*, so the one wire that renders directly into a terminal or notebook cell was the unbounded one, while the event wire — consumed by web/VS Code surfaces that already scroll — was protected. A tool returning a large blob (file read, search results, API dump) flooded the render loop, and the obvious fix (`max_result_len=`) raised `TypeError: unexpected keyword argument`.

## The fix

`iter_chunk_frames` takes the same `max_result_len: int = 500` and truncates its `tool_result` chunk identically.

The slice-and-mark moved into one shared `_truncate_result()` that both mappings call, rather than a second inline copy. This is the third parity gap between the pair (after `extractors` in #92 and the `error` frame in #93) — a duplicated implementation is what let them drift, so the fix removes the duplication rather than adding to it.

Three boundaries are deliberate:

- **A result at or under the cap is emitted byte-identical, with no marker** — every existing CLI/Jupyter consumer of a normal-sized result is untouched.
- **The extractor still receives the full, untruncated content.** Truncation is a display concern; capping the extractor's input would corrupt the payload it parses. The event wire feeds its extractor raw content for the same reason.
- **A non-`str` result passes through rather than being sliced.** AG-UI types `content` as `str` so this is defensive, but the chunk wire yields `content` as-is where the event wire coerces with `str()` — slicing a dict would raise `TypeError`.

## Verification

The issue's own repro, before → after:

```
iter_event_frames tool_end result len = 512 ends '…(truncated)'
iter_chunk_frames tool_result len = 2000            ->  512 ends '…(truncated)'
iter_chunk_frames has max_result_len param: False   ->  True
```

7 regression tests added in `tests/test_agui_frames.py` covering the parameter and its default, default truncation, byte-for-byte equality with `iter_event_frames`' capped string, a custom `max_result_len`, the at-cap no-marker boundary, the extractor's full-content input, and non-`str` pass-through. Reverting the source change fails 5 of them; the other 2 lock in behavior that was already correct.

Full suite: **190 passed** (183 baseline + 7 new).

## Scope note

No in-repo caller needed threading. `SessionAdapter` is on the event wire and already accepts and forwards `max_result_len`; nothing in `src/` calls `iter_chunk_frames`. The downstream CLI and Jupyter surfaces live in separate repos and can now pass the parameter — that's the point of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B
