### PR TITLE
fix(agui): snapshot path emits tool frames (#91), cap extraction (#106); add --verify (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## [1.0.24] - 2026-07-23
+
+### Fixed
+- **The snapshot (non-token) path now surfaces tool calls and tool results, not just text
+  (gh #91, filed via langstage-cli).** A graph whose messages are produced *without token
+  streaming* — a custom node calling `model.invoke()`, a non-streaming provider, a rule-based
+  node that returns a finished `AIMessage`/`ToolMessage` (the "Creating Your Own Agent" shape) —
+  delivers everything through the final `MessagesSnapshotEvent`, and that branch of **both**
+  `iter_*` mappings yielded text only: it filtered to `role=="assistant" and content`, so a
+  `ToolMessage` result was dropped, a tool call carried on a snapshot `AIMessage` was never
+  surfaced, and a tool-call-only `AIMessage(content="", tool_calls=[...])` was dropped whole —
+  rendering a completely empty turn while `verify()`/the exit code reported success. The headline
+  "tool-call rendering" feature was invisible on this entire class of agent. (A tool executed via
+  a real `ToolNode` emits streaming `ToolCall*` events and rendered fine, which is exactly why the
+  gap went unnoticed.) The snapshot branch now emits `tool_calls`/`tool_result` (chunk wire) and
+  `tool_start`/`tool_end` (event wire) for the not-yet-streamed messages, via a shared
+  `_snapshot_items` walk so the two wires can't drift. Dedup keeps a fully-streamed turn from
+  double-rendering: content by message id, tool calls by `tool_call_id` (populated only on the
+  streaming `ToolCallStart`), tool results by a new `streamed_result_ids` set. The snapshot
+  `tool_result` honors `max_result_len` and runs extractors, at parity with the streaming path.
+- **The `extraction` frame no longer defeats `max_result_len` for the generic tool-callout card
+  (gh #106).** `GenericToolExtractor` echoes the tool result verbatim as a display card
+  (`{"content": <raw>}`), and the `iter_*` mappings ran every extractor on the *raw* content — so
+  with `GenericToolExtractor` in `extractors=[...]` the wire carried a 512-char capped `tool_end`
+  **and** the full 5000-char blob in the adjacent `extraction` frame, reintroducing exactly the
+  unbounded-terminal-output harm `#102`'s cap exists to prevent. A `caps_content` marker now
+  distinguishes a display-passthrough extractor (fed the already-truncated result) from a
+  *structured* extractor that parses content (still fed the raw content, because capping its input
+  would corrupt the parse — the deliberate #102 decision). `GenericToolExtractor` sets it; custom
+  structured extractors do not.
+
+### Added
+- **`langstage-agui --verify` runs one keyless turn against the agent and reports whether it
+  actually works (gh #105).** The already-shipped, exported `verify()` preflight was reachable only
+  from Python and wired to no CLI flag, so the question every adopter asks right after `--agent` —
+  "did it load *and* produce a turn?" — had no one-command answer (`--show-config` proves the spec
+  *resolves*, not that it *runs*; a typo'd `module:attr` or a graph that yields an empty/erroring
+  turn both pass `--show-config` and only surface at first chat). `--verify` loads the spec with the
+  same clean error handling as the serve path, drives `verify()`, prints the result, and exits
+  `0` ok / `1` failed — keyless, so it fits a CI/deploy gate. Documented in the README.
+
 ## [1.0.23] - 2026-07-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -102,7 +102,10 @@ Any LangGraph agent can be served over the **[AG-UI protocol](https://github.com
 ```bash
 langstage-agui --agent my_agent.py:graph     # serve over AG-UI at http://localhost:8050
 langstage-agui --demo                          # keyless echo agent, no API key
+langstage-agui --agent my_agent.py:graph --verify   # run one keyless turn; exit 0 ok / 1 failed
 ```
+
+`--verify` is the preflight to run right after wiring up an agent: `--show-config` proves the config chain *resolves* a spec, but `--verify` proves it **loads and actually produces a turn** — catching the two most common failures (a typo'd `module:attr`, or a graph that loads but yields an empty/erroring turn) that otherwise only surface at first chat. Keyless, so it fits a CI/deploy gate.
 
 ```python
 from langstage_core.agui import build_app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.23"
+version = "1.0.24"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/agui/__init__.py
+++ b/src/langstage_core/agui/__init__.py
@@ -307,6 +307,87 @@ def _truncate_result(result, max_result_len):
     return result
 
 
+def _snapshot_items(messages, *, streamed_ids, tool_names, streamed_result_ids, step_nodes, current_node):
+    """Yield the not-yet-emitted items from a final ``MessagesSnapshotEvent``.
+
+    Shared by both ``iter_*`` mappings so the two wires can't drift on snapshot
+    handling. The snapshot branch used to yield **only** assistant text and drop
+    every message with empty content, so a turn whose messages are produced
+    *without token streaming* (a custom node calling ``model.invoke()``, a
+    non-streaming provider, a rule-based node) surfaced no tool call and no tool
+    result, and a tool-call-only ``AIMessage(content="", tool_calls=[...])``
+    rendered as a completely empty turn while ``--verify`` reported success
+    (gh #91). This walks assistant **and** tool messages and yields normalized
+    items each wire renders in its own vocabulary:
+
+      ``{"kind": "content", "text", "node"}``          — an assistant text message
+      ``{"kind": "tool_call", "name", "args", "id"}``  — a tool call not streamed
+      ``{"kind": "tool_result", "name", "raw", "id", "error"}`` — a result not streamed
+
+    Dedup mirrors how a fully-streamed turn already emitted things during the run,
+    so nothing double-renders: content by message id (``streamed_ids``), tool calls
+    by ``tool_call_id`` (``tool_names`` is populated only on the streaming
+    ``ToolCallStartEvent``), tool results by ``tool_call_id``
+    (``streamed_result_ids``). A non-streaming turn streamed none of these, so the
+    snapshot is the sole source and everything is emitted; a fully-streamed turn
+    finds them all already emitted and yields nothing.
+    """
+    import json
+
+    msgs = list(messages)
+    last_user = max(
+        (i for i, m in enumerate(msgs) if getattr(m, "role", None) in ("user", "human")),
+        default=-1,
+    )
+    tail = msgs[last_user + 1:]
+    # Node mapping aligns to assistant *content* messages only (gh #43), so keep the
+    # index space the pre-#91 code used — interleaving tool messages must not shift it.
+    content_msgs = [
+        m for m in tail
+        if getattr(m, "role", None) == "assistant" and getattr(m, "content", None)
+    ]
+    offset = max(0, len(content_msgs) - len(step_nodes))
+    # Local name map so a tool result can still name its tool on a fully-snapshot turn,
+    # where ToolCallStart never populated the shared tool_names.
+    names = dict(tool_names)
+    ci = 0
+    for m in tail:
+        role = getattr(m, "role", None)
+        if role == "assistant":
+            for tc in getattr(m, "tool_calls", None) or []:
+                tcid = getattr(tc, "id", None)
+                fn = getattr(tc, "function", None)
+                name = getattr(fn, "name", "tool") if fn is not None else "tool"
+                if tcid is not None:
+                    names.setdefault(tcid, name)
+                if tcid in tool_names:
+                    continue  # already emitted via streaming ToolCall events
+                raw_args = (getattr(fn, "arguments", "") if fn is not None else "") or ""
+                try:
+                    args = json.loads(raw_args) if raw_args else {}
+                except json.JSONDecodeError:
+                    args = {"_raw": raw_args}
+                yield {"kind": "tool_call", "name": name, "args": args, "id": tcid}
+            content = getattr(m, "content", None)
+            if content:
+                if getattr(m, "id", None) not in streamed_ids:
+                    idx = ci - offset
+                    node = step_nodes[idx] if 0 <= idx < len(step_nodes) else current_node
+                    yield {"kind": "content", "text": content, "node": node}
+                ci += 1
+        elif role == "tool":
+            tcid = getattr(m, "tool_call_id", None)
+            if tcid in streamed_result_ids:
+                continue  # already emitted via the streaming ToolCallResultEvent
+            yield {
+                "kind": "tool_result",
+                "name": names.get(tcid, "tool"),
+                "raw": getattr(m, "content", "") or "",
+                "id": tcid,
+                "error": bool(getattr(m, "error", None)),
+            }
+
+
 def _unwrap_resume(resume):
     """Return the raw resume payload, accepting either the payload OR a langgraph
     ``Command`` built by :func:`create_resume_input`.
@@ -400,6 +481,10 @@ async def iter_event_frames(
     streamed_ids: set[str] = set()
     tool_args: dict[str, str] = {}
     tool_names: dict[str, str] = {}
+    # Tool results already emitted via the streaming ToolCallResultEvent, so the
+    # final snapshot re-emits only the results a non-streaming turn never streamed
+    # (gh #91), the tool-frame counterpart of streamed_ids.
+    streamed_result_ids: set[str] = set()
     # The langgraph node currently executing, from StepStartedEvent — so a
     # multi-node graph's frames carry the real node instead of a fixed "agent",
     # letting renderers separate one node's output from the next (gh #43).
@@ -460,6 +545,7 @@ async def iter_event_frames(
                     "node": current_node,
                 }
             elif t == "ToolCallResultEvent":
+                streamed_result_ids.add(ev.tool_call_id)
                 result = _truncate_result(str(getattr(ev, "content", "")), max_result_len)
                 name = tool_names.get(ev.tool_call_id, "tool")
                 is_error = errored_tools.get(name, 0) > 0
@@ -476,7 +562,13 @@ async def iter_event_frames(
                 }
                 extractor = by_tool.get(name, default_extractor)
                 if extractor is not None:
-                    data = extractor.extract(getattr(ev, "content", ""))
+                    # A structured extractor parses raw content, so it must see the
+                    # full result. A display-passthrough one (GenericToolExtractor,
+                    # caps_content=True) echoes content verbatim, so feed it the
+                    # already-truncated `result` — otherwise its extraction frame
+                    # carries the full blob next to the capped tool_end (gh #106).
+                    ex_content = result if getattr(extractor, "caps_content", False) else getattr(ev, "content", "")
+                    data = extractor.extract(ex_content)
                     if data is not None:
                         yield {
                             "type": "extraction",
@@ -501,36 +593,40 @@ async def iter_event_frames(
                     "allowed_decisions": decisions,
                 }
             elif t == "MessagesSnapshotEvent":
-                # The final snapshot carries every assistant message the turn produced,
-                # including any a later node returned finished (non-streamed). Emit the
-                # ones NOT already streamed token-by-token — keyed by message id — so a
-                # mixed turn (an earlier node streams, a later node appends a finished
-                # AIMessage) renders the finished message too, instead of dropping it once
-                # anything streamed (gh #89). A fully-streamed turn skips them all (already
-                # emitted); a fully-snapshot turn emits them all (gh #67).
-                #
-                # The snapshot is the FULL thread (prior turns come from the checkpointer),
-                # so slice to what follows the last user message — otherwise the agent
-                # re-emits its entire history every turn (gh #67). Then map the trailing
-                # assistant messages back to the steps that produced them (gh #43); the
-                # index alignment uses the full assistant list so skipping streamed ones
-                # doesn't shift the node mapping.
-                msgs = list(ev.messages)
-                last_user = max(
-                    (i for i, m in enumerate(msgs) if getattr(m, "role", None) in ("user", "human")),
-                    default=-1,
-                )
-                assistant = [
-                    m for m in msgs[last_user + 1:]
-                    if getattr(m, "role", None) == "assistant" and getattr(m, "content", None)
-                ]
-                offset = max(0, len(assistant) - len(step_nodes))
-                for i, m in enumerate(assistant):
-                    if getattr(m, "id", None) in streamed_ids:
-                        continue  # already emitted token-by-token; don't duplicate
-                    idx = i - offset
-                    node = step_nodes[idx] if 0 <= idx < len(step_nodes) else current_node
-                    yield {"type": "content", "content": m.content, "role": "assistant", "node": node}
+                # The final snapshot carries every message the turn produced. Emit the
+                # ones NOT already streamed — content, tool calls, AND tool results —
+                # via the shared _snapshot_items walk, so a non-streaming turn renders
+                # its tool call/result and a tool-call-only AIMessage isn't dropped
+                # (gh #91), while a mixed turn still emits a later node's finished
+                # AIMessage (gh #89) and a fully-streamed turn double-renders nothing.
+                for item in _snapshot_items(
+                    ev.messages,
+                    streamed_ids=streamed_ids,
+                    tool_names=tool_names,
+                    streamed_result_ids=streamed_result_ids,
+                    step_nodes=step_nodes,
+                    current_node=current_node,
+                ):
+                    if item["kind"] == "content":
+                        yield {"type": "content", "content": item["text"],
+                               "role": "assistant", "node": item["node"]}
+                    elif item["kind"] == "tool_call":
+                        # A snapshot tool call reconstructs the streaming tool_start;
+                        # its result arrives as a separate tool message -> tool_end below.
+                        yield {"type": "tool_start", "id": item["id"], "name": item["name"],
+                               "args": item["args"], "node": current_node}
+                    elif item["kind"] == "tool_result":
+                        result = _truncate_result(str(item["raw"]), max_result_len)
+                        yield {"type": "tool_end", "id": item["id"], "name": item["name"],
+                               "result": result, "status": "error" if item["error"] else "success",
+                               "error_message": result if item["error"] else None, "duration_ms": None}
+                        extractor = by_tool.get(item["name"], default_extractor)
+                        if extractor is not None:
+                            ex = result if getattr(extractor, "caps_content", False) else str(item["raw"])
+                            data = extractor.extract(ex)
+                            if data is not None:
+                                yield {"type": "extraction", "tool_name": item["name"],
+                                       "extracted_type": extractor.extracted_type, "data": data}
             elif t == "RunErrorEvent":
                 yield {"type": "error", "error": getattr(ev, "message", "unknown error")}
                 return
@@ -617,6 +713,9 @@ async def iter_chunk_frames(
     # tool_call_id -> tool name, retained past ToolCallEndEvent (which pops tool_buf) so
     # the later ToolCallResultEvent can dispatch the right extractor by name (gh #92).
     tool_names: dict[str, str] = {}
+    # Tool results already streamed (ToolCallResultEvent), so the final snapshot
+    # re-emits only what a non-streaming turn never streamed (gh #91).
+    streamed_result_ids: set[str] = set()
     # The langgraph node currently executing (from StepStartedEvent) so a multi-node
     # graph's chunks carry the real node instead of a fixed "agent" — renderers use
     # it to separate one node's output from the next (gh #43).
@@ -659,13 +758,12 @@ async def iter_chunk_frames(
             elif t == "ToolCallResultEvent":
                 # Cap the result the way the event wire has always capped its `tool_end`
                 # frame (gh #102) — the CLI/Jupyter render loops read this chunk straight
-                # to the terminal. The extractor below still sees the FULL content: it
-                # parses a payload, and truncation is a display concern (iter_event_frames
-                # feeds its extractor the raw content for the same reason).
-                yield {
-                    "status": "streaming",
-                    "tool_result": _truncate_result(getattr(ev, "content", ""), max_result_len),
-                }
+                # to the terminal. A structured extractor below still sees the FULL
+                # content (it parses a payload; truncation is a display concern); a
+                # display-passthrough one is fed the capped result (gh #106).
+                streamed_result_ids.add(ev.tool_call_id)
+                result = _truncate_result(getattr(ev, "content", ""), max_result_len)
+                yield {"status": "streaming", "tool_result": result}
                 # Run the matching extractor over the tool result and, on a non-None
                 # return, emit an `extraction` chunk — parity with iter_event_frames'
                 # `extraction` frame so the CLI/Jupyter surfaces can render the same
@@ -673,7 +771,8 @@ async def iter_chunk_frames(
                 name = tool_names.get(ev.tool_call_id, "tool")
                 extractor = by_tool.get(name, default_extractor)
                 if extractor is not None:
-                    data = extractor.extract(getattr(ev, "content", ""))
+                    ex_content = result if getattr(extractor, "caps_content", False) else getattr(ev, "content", "")
+                    data = extractor.extract(ex_content)
                     if data is not None:
                         yield {
                             "status": "streaming",
@@ -703,35 +802,37 @@ async def iter_chunk_frames(
                     },
                 }
             elif t == "MessagesSnapshotEvent":
-                # The final snapshot carries every assistant message the turn produced,
-                # including any a later node returned finished (non-streamed). Emit the
-                # ones NOT already streamed token-by-token — keyed by message id — so a
-                # mixed turn (an earlier node streams, a later node appends a finished
-                # AIMessage) renders the finished message too, instead of dropping it once
-                # anything streamed (gh #89). A fully-streamed turn skips them all; a
-                # fully-snapshot turn emits them all (gh #67).
-                #
-                # The snapshot is the FULL thread, so slice to what follows the last user
-                # message — otherwise the agent re-emits its whole history every turn (gh
-                # #67). Then map the trailing assistant messages back to their steps (gh
-                # #43); the index alignment uses the full assistant list so skipping
-                # streamed ones doesn't shift the node mapping.
-                msgs = list(ev.messages)
-                last_user = max(
-                    (i for i, m in enumerate(msgs) if getattr(m, "role", None) in ("user", "human")),
-                    default=-1,
-                )
-                assistant = [
-                    m for m in msgs[last_user + 1:]
-                    if getattr(m, "role", None) == "assistant" and getattr(m, "content", None)
-                ]
-                offset = max(0, len(assistant) - len(step_nodes))
-                for i, m in enumerate(assistant):
-                    if getattr(m, "id", None) in streamed_ids:
-                        continue  # already emitted token-by-token; don't duplicate
-                    idx = i - offset
-                    node = step_nodes[idx] if 0 <= idx < len(step_nodes) else current_node
-                    yield {"status": "streaming", "chunk": m.content, "node": node}
+                # Emit the not-yet-streamed content, tool calls, AND tool results from
+                # the final snapshot via the shared _snapshot_items walk. Before gh #91
+                # this branch yielded only text and dropped empty-content messages, so a
+                # non-streaming tool agent showed no tool call/result and a tool-call-only
+                # AIMessage rendered empty. Still emits a later node's finished message
+                # (gh #89) and double-renders nothing on a fully-streamed turn.
+                for item in _snapshot_items(
+                    ev.messages,
+                    streamed_ids=streamed_ids,
+                    tool_names=tool_names,
+                    streamed_result_ids=streamed_result_ids,
+                    step_nodes=step_nodes,
+                    current_node=current_node,
+                ):
+                    if item["kind"] == "content":
+                        yield {"status": "streaming", "chunk": item["text"], "node": item["node"]}
+                    elif item["kind"] == "tool_call":
+                        yield {"status": "streaming",
+                               "tool_calls": [{"name": item["name"], "args": item["args"]}]}
+                    elif item["kind"] == "tool_result":
+                        result = _truncate_result(item["raw"], max_result_len)
+                        yield {"status": "streaming", "tool_result": result}
+                        extractor = by_tool.get(item["name"], default_extractor)
+                        if extractor is not None:
+                            ex = result if getattr(extractor, "caps_content", False) else item["raw"]
+                            data = extractor.extract(ex)
+                            if data is not None:
+                                yield {"status": "streaming",
+                                       "extraction": {"tool_name": item["name"],
+                                                      "extracted_type": extractor.extracted_type,
+                                                      "data": data}}
             elif t == "RunErrorEvent":
                 yield {"status": "error", "error": getattr(ev, "message", "unknown error")}
 

--- a/src/langstage_core/agui/__main__.py
+++ b/src/langstage_core/agui/__main__.py
@@ -50,6 +50,12 @@ def main(argv: list[str] | None = None) -> int:
         help="Print the resolved host config and exit.",
     )
     parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Run one keyless turn against the agent and report whether it works, "
+        "then exit (0 ok / 1 failed). The preflight to run right after --agent.",
+    )
+    parser.add_argument(
         "--version",
         action="store_true",
         help="Print the langstage-core version and exit.",
@@ -134,6 +140,22 @@ def main(argv: list[str] | None = None) -> int:
     except (ImportError, AttributeError, OSError, ValueError) as exc:
         print(f"error: could not load agent {spec!r}: {exc}", file=sys.stderr)
         return 2
+
+    # --verify: the question every adopter asks right after --agent — "did it load
+    # AND actually produce a turn?" — which --show-config can't answer (a spec that
+    # resolves can still fail to run). Drive the already-shipped keyless verify()
+    # over the loaded graph and report, instead of making the user hand-craft an
+    # AG-UI POST or write async Python around iter_*. (gh #105)
+    if args.verify:
+        from . import verify
+
+        result = verify(graph)
+        if result.ok:
+            print(f"ok: {result.reason} ({result.frames} frames, {result.content_chars} chars)")
+            return 0
+        detail = result.error_message or result.reason
+        print(f"error: agent did not complete a turn: {detail}", file=sys.stderr)
+        return 1
 
     name = args.name or ("Demo Agent" if args.demo else DEFAULT_AGENT_NAME)
     # cfg.host/cfg.port are the resolved values --show-config prints, so the

--- a/src/langstage_core/extractors/builtins.py
+++ b/src/langstage_core/extractors/builtins.py
@@ -383,6 +383,13 @@ class GenericToolExtractor:
 
     tool_name = "*"  # sentinel; treated as the fallback, not a literal dispatch key
     extracted_type = "tool_call"
+    # This extractor echoes the tool result verbatim as a display card, so its
+    # output is subject to the same `max_result_len` cap as the tool_end/tool_result
+    # frame — otherwise the wire carries a capped copy AND the full blob side by side
+    # (gh #106). Structured extractors that PARSE content leave this False so they
+    # still see the raw content and parse correctly. The iter_* mappings feed a
+    # caps_content extractor the already-truncated result.
+    caps_content = True
 
     def extract(self, content: Any) -> dict[str, Any] | None:
         if content is None:

--- a/tests/test_agui_frames.py
+++ b/tests/test_agui_frames.py
@@ -568,20 +568,29 @@ async def test_iter_chunk_frames_leaves_short_result_untouched():
     assert "(truncated)" not in results[0]
 
 
-async def test_iter_chunk_frames_extractor_still_sees_the_full_result():
-    # Truncation is a *display* concern: the extractor parses the payload, so it must keep
-    # receiving the untruncated content (iter_event_frames feeds its extractor the raw
-    # content for the same reason). Capping the extractor's input would corrupt parsed data.
-    from langstage_core import GenericToolExtractor
+async def test_iter_chunk_frames_structured_extractor_still_sees_the_full_result():
+    # A *structured* extractor parses the payload, so it must keep receiving the
+    # untruncated content — capping its input would corrupt the parse. (Truncation is
+    # a display concern; iter_event_frames feeds its structured extractors raw content
+    # for the same reason.) A display-passthrough extractor is the OTHER case — see
+    # test_generic_extractor_extraction_frame_is_capped, where gh #106 caps its output.
+    class LenExtractor:
+        tool_name = "*"
+        extracted_type = "len"
+
+        def extract(self, content):
+            return {"len": len(content)}
 
     frames = await _collect(
         iter_chunk_frames(
-            build_agent(_big_result_graph()), "go", "c102e", extractors=[GenericToolExtractor()]
+            build_agent(_big_result_graph()), "go", "c102e",
+            max_result_len=500, extractors=[LenExtractor()],
         )
     )
     extraction = [f["extraction"] for f in frames if "extraction" in f]
     assert extraction, f"no extraction chunk emitted: {frames}"
-    assert extraction[0]["data"] == {"content": "X" * 2000}
+    # saw the full 2000 chars, not the 500-capped tool_result on the same wire
+    assert extraction[0]["data"] == {"len": 2000}
 
 
 async def test_truncate_result_passes_non_str_through_untouched():
@@ -593,3 +602,153 @@ async def test_truncate_result_passes_non_str_through_untouched():
     assert _truncate_result({"a": 1}, 1) == {"a": 1}
     assert _truncate_result([1, 2, 3], 1) == [1, 2, 3]
     assert _truncate_result(None, 1) is None
+
+
+# ── gh #91: the snapshot (non-token) path must surface tool calls + results ──────
+def _snapshot_tool_graph(result: str = "Sunny, 24C"):
+    """The issue's exact 'Creating Your Own Agent' shape: custom nodes that RETURN
+    finished messages and append the ToolMessage **manually** (no ToolNode), so the
+    AG-UI adapter emits no ToolCall events — every message arrives only via the final
+    MessagesSnapshotEvent. Before gh #91 that path yielded text only, so the tool
+    call + result never rendered. (A ToolNode-executed tool DOES emit streaming
+    ToolCall events and hides this bug — which is exactly why it went unnoticed.)"""
+    from langchain_core.messages import AIMessage, ToolMessage
+    from langgraph.graph import START, END, MessagesState, StateGraph
+
+    def call_tool(state):
+        return {"messages": [AIMessage(content="Let me check the weather.", tool_calls=[
+            {"name": "get_weather", "args": {"city": "Paris"}, "id": "call_1"}])]}
+
+    def run_tool(state):
+        return {"messages": [ToolMessage(content=result, tool_call_id="call_1")]}
+
+    def final(state):
+        return {"messages": [AIMessage(content="The weather in Paris is sunny, 24C.")]}
+
+    g = StateGraph(MessagesState)
+    for n, f in [("call_tool", call_tool), ("run_tool", run_tool), ("final", final)]:
+        g.add_node(n, f)
+    g.add_edge(START, "call_tool"); g.add_edge("call_tool", "run_tool")
+    g.add_edge("run_tool", "final"); g.add_edge("final", END)
+    return g.compile()
+
+
+def _toolonly_graph():
+    """A tool-call-only assistant message (empty content) with no following tool
+    message — the issue's `toolonly_agent.py`, which rendered ZERO output (only a
+    `complete` frame) while --verify reported success."""
+    from langchain_core.messages import AIMessage
+    from langgraph.graph import START, END, MessagesState, StateGraph
+
+    def call(state):
+        return {"messages": [AIMessage(content="", tool_calls=[
+            {"name": "get_weather", "args": {"city": "Paris"}, "id": "only_1"}])]}
+
+    g = StateGraph(MessagesState)
+    g.add_node("call", call)
+    g.add_edge(START, "call"); g.add_edge("call", END)
+    return g.compile()
+
+
+async def test_snapshot_chunk_wire_emits_tool_call_and_result():
+    frames = await _collect(iter_chunk_frames(build_agent(_snapshot_tool_graph()), "weather?", "s91c"))
+    calls = [f for f in frames if "tool_calls" in f]
+    results = [f for f in frames if "tool_result" in f]
+    chunks = [f["chunk"] for f in frames if "chunk" in f]
+    assert calls and calls[0]["tool_calls"][0]["name"] == "get_weather", "tool call dropped on snapshot wire (gh #91)"
+    assert results and results[0]["tool_result"] == "Sunny, 24C", "tool result dropped on snapshot wire (gh #91)"
+    assert "Let me check the weather." in chunks and "The weather in Paris is sunny, 24C." in chunks
+
+
+async def test_snapshot_event_wire_emits_tool_start_and_end():
+    frames = await _collect(iter_event_frames(build_agent(_snapshot_tool_graph()), "weather?", "s91e"))
+    starts = [f for f in frames if f.get("type") == "tool_start"]
+    ends = [f for f in frames if f.get("type") == "tool_end"]
+    contents = [f["content"] for f in frames if f.get("type") == "content"]
+    assert starts and starts[0]["name"] == "get_weather", "tool_start dropped on snapshot event wire (gh #91)"
+    assert ends and ends[0]["result"] == "Sunny, 24C", "tool_end dropped on snapshot event wire (gh #91)"
+    assert "The weather in Paris is sunny, 24C." in contents
+
+
+async def test_toolonly_message_is_not_dropped_whole():
+    # The worst case: a tool-call-only empty-content turn used to emit only `complete`.
+    frames = await _collect(iter_chunk_frames(build_agent(_toolonly_graph()), "go", "s91only"))
+    calls = [f for f in frames if "tool_calls" in f]
+    assert calls and calls[0]["tool_calls"][0]["name"] == "get_weather", "tool-call-only turn rendered nothing (gh #91)"
+
+
+async def test_snapshot_tool_result_is_capped():
+    # gh #91 + #102: the snapshot tool_result honors max_result_len too.
+    frames = await _collect(iter_chunk_frames(build_agent(_snapshot_tool_graph("X" * 5000)), "go", "s91cap", max_result_len=500))
+    results = [f["tool_result"] for f in frames if "tool_result" in f]
+    assert results and len(results[0]) == 512 and results[0].endswith("…(truncated)")
+
+
+# ── gh #106: the extraction frame must not carry the full uncapped blob ──────────
+async def test_generic_extractor_extraction_frame_is_capped():
+    """GenericToolExtractor echoes content verbatim as a display card, so its
+    extraction frame's data['content'] must be capped like tool_end — otherwise the
+    wire carries a 512-char capped copy AND the full 5000-char copy side by side.
+    Uses the STREAMING (ToolNode) big-result graph, the path #106 was filed against."""
+    from langstage_core import GenericToolExtractor
+
+    frames = await _collect(iter_event_frames(build_agent(_big_result_graph(5000)), "go", "s106e", max_result_len=500, extractors=[GenericToolExtractor()]))
+    tool_end = [f for f in frames if f.get("type") == "tool_end"]
+    extraction = [f for f in frames if f.get("type") == "extraction"]
+    assert tool_end and len(tool_end[0]["result"]) == 512
+    assert extraction, "GenericToolExtractor produced no extraction frame"
+    capped = extraction[0]["data"]["content"]
+    assert len(capped) == 512 and capped.endswith("…(truncated)"), "extraction frame carried the FULL uncapped blob (gh #106)"
+    # both copies on the wire must be the SAME capped string, never the 5000-char raw
+    assert capped == tool_end[0]["result"]
+
+
+async def test_structured_extractor_still_sees_full_content():
+    """The #106 cap must NOT reach a structured extractor that parses raw content —
+    capping its input would corrupt the parse (the reason #102 fed it raw)."""
+    seen = {}
+
+    class LenExtractor:
+        tool_name = "*"
+        extracted_type = "len"
+        def extract(self, content):
+            seen["len"] = len(content)
+            return {"len": len(content)}
+
+    await _collect(iter_event_frames(build_agent(_big_result_graph(5000)), "go", "s106s", max_result_len=500, extractors=[LenExtractor()]))
+    assert seen["len"] == 5000, "structured extractor saw truncated content (regression of #102's decision)"
+
+
+async def test_streaming_turn_does_not_double_emit_tool_frames():
+    """The snapshot dedup guard: a fully-streamed tool turn must emit each tool call
+    and result exactly once, not once from streaming and again from the snapshot."""
+    from typing import Iterator, List
+    from langchain_core.language_models.chat_models import BaseChatModel
+    from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage, ToolMessage
+    from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+    from langchain_core.tools import tool
+    from langgraph.prebuilt import create_react_agent
+
+    @tool
+    def note(text: str) -> str:
+        """Write a note."""
+        return "saved"
+
+    class M(BaseChatModel):
+        @property
+        def _llm_type(self): return "m"
+        def bind_tools(self, tools, **k): return self
+        def _stream(self, messages: List[BaseMessage], stop=None, run_manager=None, **k) -> Iterator[ChatGenerationChunk]:
+            if any(isinstance(m, ToolMessage) for m in messages):
+                yield ChatGenerationChunk(message=AIMessageChunk(content="ok"))
+            else:
+                yield ChatGenerationChunk(message=AIMessageChunk(content="", tool_call_chunks=[{"name": "note", "args": '{"text":"hi"}', "id": "c1", "index": 0}]))
+        def _generate(self, messages, stop=None, run_manager=None, **k) -> ChatResult:
+            cs = list(self._stream(messages)); msg = cs[0].message
+            for c in cs[1:]: msg = msg + c.message
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content=msg.content, tool_calls=getattr(msg, "tool_calls", [])))])
+
+    agent = build_agent(create_react_agent(M(), [note]))
+    frames = await _collect(iter_chunk_frames(agent, "note hi", "s91dedup"))
+    assert len([f for f in frames if "tool_calls" in f]) == 1, "tool call double-emitted (streaming + snapshot)"
+    assert len([f for f in frames if "tool_result" in f]) == 1, "tool result double-emitted (streaming + snapshot)"


### PR DESCRIPTION
Three related AG-UI changes. Closes #106 and #105; this is the root-cause fix for **langstage-cli #91** (filed there, but the defect and fix are here in core).

## #91 — the snapshot (non-token) path dropped tool calls and results

A graph whose messages are produced **without token streaming** — a custom node calling `model.invoke()`, a non-streaming provider, a rule-based node returning a finished `AIMessage`/`ToolMessage` (the README "Creating Your Own Agent" shape) — delivers everything via the final `MessagesSnapshotEvent`. Both `iter_*` mappings' snapshot branch yielded **text only** (`role=="assistant" and content`), so:

- a `ToolMessage` result was dropped,
- a tool call on a snapshot `AIMessage` was never surfaced,
- a tool-call-only `AIMessage(content="", tool_calls=[...])` was dropped **whole** — an empty turn, while `verify()` and the exit code reported success.

The headline "tool-call rendering" was invisible for this entire class of agent. A tool executed via a real `ToolNode` emits streaming `ToolCall*` events and rendered fine — which is exactly why the gap survived.

**Fix:** the snapshot branch now emits `tool_calls`/`tool_result` (chunk wire) and `tool_start`/`tool_end` (event wire) for the not-yet-streamed messages, via a shared `_snapshot_items` walk so the two wires can't drift (this repo's recurring lesson). Dedup keeps a fully-streamed turn from double-rendering: content by message id, tool calls by `tool_call_id` (`tool_names` is populated only on the streaming `ToolCallStart`), results by a new `streamed_result_ids` set. The snapshot `tool_result` honors `max_result_len` and runs extractors, at parity with streaming.

The regression test uses the issue's **exact** graph (manual `ToolMessage`, no `ToolNode`) — I first wrote it with a `ToolNode` and it passed against unfixed source, because `ToolNode` triggers streaming events; the faithful shape is what actually exercises the snapshot path.

## #106 — the extraction frame defeated `max_result_len`

`GenericToolExtractor` echoes the tool result verbatim as a display card (`{"content": <raw>}`), and the mappings ran every extractor on the **raw** content — so with it in `extractors=[...]` the wire carried a 512-char capped `tool_end` **and** the full 5000-char blob in the adjacent `extraction` frame. A `caps_content` marker now feeds a display-passthrough extractor the already-truncated result, while a **structured** extractor still parses raw content (capping its input would corrupt the parse — the deliberate #102 decision). This also corrected an existing test that had used `GenericToolExtractor` to assert the "structured extractor sees full content" principle — it now uses a structured extractor for that, and the passthrough-is-capped case is its own test.

## #105 — `langstage-agui --verify`

The shipped, exported, keyless `verify()` preflight was reachable only from Python. `--verify` loads the spec (same clean error handling as serve), drives `verify()`, prints the result, exits `0`/`1`. Documented in the README.

```console
$ langstage-agui --demo --verify
ok: one turn completed cleanly (11 frames, 54 chars)   # exit 0
$ langstage-agui --agent nonexistent:graph --verify
error: could not load agent 'nonexistent:graph': No module named 'nonexistent'   # exit 2
```

## Verification

- New tests for all three; reverting the source fails the #91 (5) and #106 (1) bug tests, the structured-extractor guard passes both ways by design.
- Full suite **202 passed**.
- Dogfooded `--verify` and the snapshot frame output directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B