### PR TITLE
Keyless rich-frame demo agent: tool_start/tool_end/extraction/reasoning/interrupt (gh #99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## [1.0.25] - 2026-07-23
+
+### Added
+- **A keyless, network-free demo agent that exercises *every* rich frame type, not just
+  text echo (gh #99).** The shared demo stub (`langstage_core.demo.stub:graph`) behind every
+  surface's `--demo` and the README Quick Start only ever emitted `content` frames — a plain
+  echo. But `content` is one of *eight* documented frame types, and the rich ones
+  (`tool_start` / `tool_end` / `extraction` / `reasoning` / `interrupt`) are the library's
+  whole selling point, reachable before now only by hand-building a LangGraph graph *and*
+  correctly wiring a real `ToolNode`. That was the single biggest dogfooding friction, and it
+  left the largest bug class in this repo's history — rich-frame emission defects (#41/#43/#45,
+  #50, #71, #89, #90, #91) — with no keyless regression fixture. `langstage_core.demo.tools:graph`
+  (built by `create_tool_demo_agent()`) closes the gap: a real compiled graph — a router node
+  plus a real `langgraph.prebuilt.ToolNode` — that routes on a trigger in the user's message:
+  a normal message streams a token-by-token `content` reply (as the echo stub does); `"use a
+  tool"` calls a built-in keyless `demo_lookup` tool through the `ToolNode`, producing
+  `tool_start` → `tool_end` plus an `extraction` frame via the paired built-in
+  `DemoLookupExtractor` (pass `demo_extractors()` to the `iter_*` mappings' `extractors=`);
+  `"think"` streams a `reasoning` delta (kept separate from the answer); and `"ask me"` raises
+  a resumable `interrupt(...)`. Everything is deterministic and offline — the "model" is a local
+  fake, no API key, no network, no model call. The tool path deliberately goes through a **real
+  `ToolNode`**, because the AG-UI adapter emits streaming `ToolCall*` events only when a tool
+  runs through one — a hand-rolled `AIMessage(tool_calls=...)` + manually-appended `ToolMessage`
+  arrives via the snapshot path instead (the distinction 1.0.24 / #91 hinges on); the demo bakes
+  the correct wiring in so no adopter has to rediscover it. Doubles as a live keyless smoke test
+  and the regression fixture the issue asked for.
+- **`langstage-agui --demo=tools` serves the rich demo over AG-UI, keyless (gh #99).** `--demo`
+  now takes an optional value: bare `--demo` still serves the echo stub unchanged, and
+  `--demo=tools` serves `langstage_core.demo.tools:graph`. `--show-config`, `--verify`, and
+  mutual-exclusion with `--agent` all behave for both. The README's frame-type list now points
+  at a runnable keyless snippet that prints each of `content` / `reasoning` / `tool_start` /
+  `tool_end` / `extraction` / `interrupt` / `complete`.
+
 ## [1.0.24] - 2026-07-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -64,6 +64,36 @@ asyncio.run(main())
 
 `build_agent` attaches an in-memory checkpointer if the graph has none, so multi-turn memory and interrupts work out of the box; pass a `thread_id` per turn to key per-conversation state.
 
+#### See every frame type, keyless
+
+The echo stub above only emits `content`. To see the *rich* frames without an API key, point `build_agent` at the bundled tool demo (`langstage_core.demo.tools:graph`): it calls a built-in tool through a real `ToolNode`, streams a reasoning delta, and raises a resumable `interrupt`, all deterministically and offline. Each trigger phrase drives a different frame type:
+
+```python
+import asyncio
+from langstage_core import create_resume_input
+from langstage_core.agui import build_agent, iter_event_frames
+from langstage_core.demo.tools import create_tool_demo_agent, demo_extractors
+
+agent = build_agent(create_tool_demo_agent())
+
+async def main():
+    for turn in ("hello", "think about it", "use a tool"):
+        async for frame in iter_event_frames(agent, turn, "s1", extractors=demo_extractors()):
+            print(frame["type"], "→", {k: v for k, v in frame.items() if k != "type"})
+
+    # "ask me" raises interrupt(...); resume the same thread with a decision.
+    async for frame in iter_event_frames(agent, "ask me", "s2"):
+        print(frame["type"])                       # ... interrupt
+    async for frame in iter_event_frames(agent, "", "s2",
+                                         resume=create_resume_input(decisions=[{"type": "approve"}])):
+        print(frame["type"])                       # content, complete
+
+asyncio.run(main())
+# content · reasoning · tool_start · tool_end · extraction · interrupt · complete
+```
+
+Serve the same demo over AG-UI with `langstage-agui --demo=tools`.
+
 ### Human-in-the-loop (interrupt → resume)
 
 When the graph calls `interrupt(...)`, you get an `interrupt` frame; resume by passing the decision back via `resume=`:
@@ -102,6 +132,7 @@ Any LangGraph agent can be served over the **[AG-UI protocol](https://github.com
 ```bash
 langstage-agui --agent my_agent.py:graph     # serve over AG-UI at http://localhost:8050
 langstage-agui --demo                          # keyless echo agent, no API key
+langstage-agui --demo=tools                    # keyless rich-frame demo (tools, reasoning, interrupt)
 langstage-agui --agent my_agent.py:graph --verify   # run one keyless turn; exit 0 ok / 1 failed
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.24"
+version = "1.0.25"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/agui/__main__.py
+++ b/src/langstage_core/agui/__main__.py
@@ -2,6 +2,7 @@
 
     langstage-agui --agent my_agent.py:graph
     langstage-agui --demo                       # keyless echo agent, no API key
+    langstage-agui --demo=tools                 # keyless rich-frame demo (tools/reasoning/interrupt)
     langstage-agui --agent langstage_hermes.agent:graph --port 9000
 
 The agent spec resolves through the shared host config chain, so
@@ -12,7 +13,16 @@ from __future__ import annotations
 
 import sys
 
-DEMO_SPEC = "langstage_core.demo.stub:graph"
+# The keyless built-in demos, keyed by the value of --demo. Bare `--demo` selects
+# "echo" (the plain token echo stub, unchanged); `--demo=tools` selects the rich
+# demo that exercises every frame type — tool_start/tool_end/extraction/reasoning/
+# interrupt (gh #99). DEMO_SPEC stays the echo spec for backward compatibility.
+DEMO_SPECS = {
+    "echo": "langstage_core.demo.stub:graph",
+    "tools": "langstage_core.demo.tools:graph",
+}
+DEMO_SPEC = DEMO_SPECS["echo"]
+DEMO_NAMES = {"echo": "Demo Agent", "tools": "Tool Demo Agent"}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -32,8 +42,13 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--demo",
-        action="store_true",
-        help="Serve the built-in keyless demo agent (no API key needed).",
+        nargs="?",
+        const="echo",
+        choices=["echo", "tools"],
+        default=None,
+        help="Serve a built-in keyless demo agent (no API key needed). Bare --demo "
+        "serves the echo stub; --demo=tools serves the rich-frame demo that exercises "
+        "tool_start/tool_end/extraction/reasoning/interrupt.",
     )
     # host/port default to None so the resolved HostConfig (env / langstage.toml /
     # defaults) supplies them and --show-config matches the real bind; an explicit
@@ -99,11 +114,11 @@ def main(argv: list[str] | None = None) -> int:
         # stdio sidecar and JupyterLab launcher already use). (gh #39)
         described = cfg.describe(omit_keys=["workspace_root", "debug", "title"])
         if args.demo:
-            described += f"\n  demo: agent_spec resolves to {DEMO_SPEC}"
+            described += f"\n  demo: agent_spec resolves to {DEMO_SPECS[args.demo]}"
         print(described)
         return 0
 
-    spec: str | None = DEMO_SPEC if args.demo else cfg.agent_spec
+    spec: str | None = DEMO_SPECS[args.demo] if args.demo else cfg.agent_spec
 
     if not spec:
         print(
@@ -157,7 +172,7 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: agent did not complete a turn: {detail}", file=sys.stderr)
         return 1
 
-    name = args.name or ("Demo Agent" if args.demo else DEFAULT_AGENT_NAME)
+    name = args.name or (DEMO_NAMES[args.demo] if args.demo else DEFAULT_AGENT_NAME)
     # cfg.host/cfg.port are the resolved values --show-config prints, so the
     # advertised config and the real bind agree.
     print(f"Serving {spec!r} over AG-UI at http://{cfg.host}:{cfg.port}{args.path}")

--- a/src/langstage_core/demo/__init__.py
+++ b/src/langstage_core/demo/__init__.py
@@ -10,13 +10,31 @@ Requires the optional ``deepagents`` dependency:
 
     pip install langstage-core[demo]
 
-This package also ships the keyless **stub agent** behind every surface's
-``--demo`` mode (:func:`create_stub_agent` / spec
-``langstage_core.demo.stub:graph``) — that one needs no API key and only
+This package also ships two keyless agents that need no API key and only
 ``langgraph`` (installed by any host surface, or via the lightweight ``[stub]``
-extra), not the full ``[demo]``/deepagents stack.
+extra), not the full ``[demo]``/deepagents stack:
+
+- the **echo stub** behind every surface's ``--demo`` mode
+  (:func:`create_stub_agent` / spec ``langstage_core.demo.stub:graph``) — a plain
+  token-by-token echo; and
+- the **rich tool demo** (:func:`create_tool_demo_agent` / spec
+  ``langstage_core.demo.tools:graph``, served via ``langstage-agui --demo=tools``)
+  — a keyless agent that exercises *every* documented frame type (``tool_start`` /
+  ``tool_end`` / ``extraction`` / ``reasoning`` / ``interrupt``), not just
+  ``content`` (gh #99).
 """
 from .agent import create_default_agent
 from .stub import create_stub_agent
+from .tools import (
+    DemoLookupExtractor,
+    create_tool_demo_agent,
+    demo_extractors,
+)
 
-__all__ = ["create_default_agent", "create_stub_agent"]
+__all__ = [
+    "DemoLookupExtractor",
+    "create_default_agent",
+    "create_stub_agent",
+    "create_tool_demo_agent",
+    "demo_extractors",
+]

--- a/src/langstage_core/demo/tools.py
+++ b/src/langstage_core/demo/tools.py
@@ -1,0 +1,362 @@
+"""A keyless, network-free demo agent that exercises **every** rich frame type.
+
+The echo stub (:mod:`langstage_core.demo.stub`) is deliberately minimal — it only
+ever emits ``content`` frames. But ``content`` is one of *eight* documented frame
+types, and the rich ones (``tool_start`` / ``tool_end`` / ``extraction`` /
+``reasoning`` / ``interrupt``) are the library's whole selling point. Before this
+module the only keyless, documented path exercised exactly one of them, so an
+adopter had no copy-pasteable example of a tool call flowing through to a
+``tool_end`` / ``extraction`` frame, or of an ``interrupt`` → ``resume`` (gh #99).
+
+This agent closes that gap. It is a *real* compiled LangGraph graph — a router
+node plus a real :class:`langgraph.prebuilt.ToolNode` — streaming through the exact
+same parser path a production agent uses, but the "model" is a local, deterministic
+fake, so it needs no network and no API key. Its behaviour is keyed off a trigger
+in the user's message:
+
+===================  ==================================================  ====================================
+Message contains     What the agent does                                 Frame types produced
+===================  ==================================================  ====================================
+``"use a tool"``     calls the built-in :data:`demo_lookup` tool via a   ``tool_start`` → ``tool_end`` →
+                     real ``ToolNode``, then summarizes the result       ``extraction`` (with the paired
+                                                                         :class:`DemoLookupExtractor`) →
+                                                                         ``content``
+``"think"``          streams a chain-of-thought then the answer          ``reasoning`` → ``content``
+``"ask me"``         raises ``interrupt(...)`` (HITL); resume to finish  ``interrupt`` → (resume) ``content``
+anything else        echoes the message token-by-token                   ``content``
+===================  ==================================================  ====================================
+
+Every path ends with the terminal ``complete`` frame (or ``error`` on failure).
+
+Why a real ``ToolNode`` and not a hand-rolled ``AIMessage(tool_calls=...)`` +
+manually-appended ``ToolMessage``? Because the AG-UI adapter emits streaming
+``ToolCall*`` events **only** when a tool runs through a real ``ToolNode`` — a
+manually-appended ``ToolMessage`` arrives via the snapshot path instead (the very
+distinction gh #91 / core 1.0.24 hinges on). A new adopter has no way to know that
+tribal fact; this demo bakes the correct wiring in.
+
+Point any surface at it with the standard spec string::
+
+    LANGSTAGE_AGENT_SPEC=langstage_core.demo.tools:graph
+
+serve it keyless from the CLI::
+
+    langstage-agui --demo=tools
+
+or drive it in code (this is the runnable snippet the README's frame-type list
+points at)::
+
+    import asyncio
+    from langstage_core.agui import build_agent, iter_event_frames
+    from langstage_core.demo.tools import create_tool_demo_agent, demo_extractors
+
+    agent = build_agent(create_tool_demo_agent())
+
+    async def main():
+        for turn in ("hello", "think about it", "use a tool"):
+            async for frame in iter_event_frames(agent, turn, "s1",
+                                                 extractors=demo_extractors()):
+                print(frame["type"])
+
+    asyncio.run(main())
+
+``langgraph`` and ``langchain-core`` are imported lazily — importing this module
+stays dependency-free; only building the agent requires them (the lightweight
+``[stub]`` extra, or any host surface, already provides both).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+DEFAULT_NAME = "Tool Demo Agent"
+DEFAULT_REPLY_PREFIX = "(demo agent) You said: "
+
+# The documented trigger phrases (case-insensitive substrings). Exported so tests
+# and docs reference one source of truth instead of hard-coding the strings.
+TOOL_TRIGGER = "use a tool"
+REASONING_TRIGGER = "think"
+INTERRUPT_TRIGGER = "ask me"
+
+# The keyless "fact" the built-in tool returns — deterministic, so the demo doubles
+# as a regression fixture (the extraction frame's data is stable across runs).
+_DEMO_ANSWER = "42"
+
+# A HumanInterrupt-shaped payload for the "ask me" path. `_normalize_interrupt`
+# (agui) turns a dict already keyed `action_requests` into a populated interrupt
+# frame, so a caller sees a real action request + allowed decisions to resume with.
+_INTERRUPT_REQUEST: dict[str, Any] = {
+    "action_requests": [
+        {"action": "ask_user", "args": {"question": "What should I call you?"}}
+    ],
+    "allowed_decisions": ["respond", "approve"],
+}
+
+_GRAPH_CACHE: Any = None
+
+
+class DemoLookupExtractor:
+    """Extractor paired with the built-in :data:`demo_lookup` tool.
+
+    Implements the :class:`~langstage_core.extractors.base.ToolExtractor` protocol
+    (``tool_name`` / ``extracted_type`` / ``extract``) — the same machinery hosts
+    use for their own tools — so a ``demo_lookup`` result surfaces as an
+    ``extraction`` frame of ``extracted_type="demo_fact"``. This is what makes the
+    ``extraction`` frame reachable keyless; pass it (via :func:`demo_extractors`) to
+    ``iter_event_frames`` / ``iter_chunk_frames``' ``extractors=`` argument.
+    """
+
+    tool_name = "demo_lookup"
+    extracted_type = "demo_fact"
+
+    def extract(self, content: Any) -> dict[str, Any] | None:
+        """Pull ``{query, answer}`` out of a ``demo_lookup`` result.
+
+        Accepts the tool's JSON string (or an already-parsed dict); returns
+        ``None`` for anything that doesn't look like a ``demo_lookup`` payload, so
+        no spurious ``extraction`` frame fires.
+        """
+        data: Any = content
+        if isinstance(content, str):
+            try:
+                data = json.loads(content)
+            except (json.JSONDecodeError, TypeError):
+                return None
+        if isinstance(data, dict) and "answer" in data:
+            return {"query": data.get("query"), "answer": data["answer"]}
+        return None
+
+
+def demo_extractors() -> list[Any]:
+    """The built-in extractors that pair with this demo's tools.
+
+    Pass to ``iter_event_frames`` / ``iter_chunk_frames``' ``extractors=`` so the
+    ``demo_lookup`` result renders as an ``extraction`` frame::
+
+        async for frame in iter_event_frames(agent, "use a tool", "s1",
+                                             extractors=demo_extractors()):
+            ...
+    """
+    return [DemoLookupExtractor()]
+
+
+def _last_human_text(messages: list[Any]) -> str:
+    """The most recent human message's text (''  if none)."""
+    for message in reversed(messages):
+        if getattr(message, "type", None) == "human":
+            content = message.content
+            return content if isinstance(content, str) else str(content)
+    return ""
+
+
+def _last_tool_result(messages: list[Any]) -> str | None:
+    """The tool result produced *this turn* (after the last human message), or None.
+
+    Scans back only to the last human message so a previous turn's tool result
+    doesn't leak into the current turn's routing.
+    """
+    for message in reversed(messages):
+        if getattr(message, "type", None) == "tool":
+            content = message.content
+            return content if isinstance(content, str) else str(content)
+        if getattr(message, "type", None) == "human":
+            return None
+    return None
+
+
+def create_tool_demo_agent(
+    *,
+    name: str = DEFAULT_NAME,
+    checkpointer: Any = None,
+):
+    """Build the keyless rich-frame demo agent.
+
+    Args:
+        name: Display name surfaced in host UIs.
+        checkpointer: Optional LangGraph checkpointer. Defaults to ``None`` — like
+            the echo stub, the graph compiles **without** one so the config-free
+            keyless paths (content / reasoning / tool) just work. The ``interrupt``
+            path needs threaded state to resume, but every documented resume route
+            supplies it: ``build_agent`` attaches an ``InMemorySaver`` when the
+            graph has none, and the AG-UI wire always passes a ``thread_id``. Pass
+            one explicitly to persist across process restarts.
+
+    Returns:
+        A compiled LangGraph graph (``messages``-state) that routes on the trigger
+        phrases documented at the module level and emits every rich frame type.
+
+    Raises:
+        RuntimeError: If ``langgraph`` / ``langchain-core`` are not installed.
+    """
+    try:
+        from langchain_core.callbacks import CallbackManagerForLLMRun
+        from langchain_core.language_models import BaseChatModel
+        from langchain_core.messages import AIMessage, AIMessageChunk, BaseMessage
+        from langchain_core.outputs import (
+            ChatGeneration,
+            ChatGenerationChunk,
+            ChatResult,
+        )
+        from langchain_core.tools import tool
+        from langgraph.graph import END, START, MessagesState, StateGraph
+        from langgraph.prebuilt import ToolNode
+        from langgraph.types import interrupt
+    except ImportError as e:  # pragma: no cover — exercised only without the deps
+        raise RuntimeError(
+            "The tool demo agent needs langgraph + langchain-core, which aren't "
+            "installed. Install the lightweight stub extra "
+            '(`pip install "langstage-core[stub]"`) — or your stage\'s own demo '
+            f"extra, or plain `pip install langgraph`: {e}"
+        ) from e
+
+    from typing import Iterator, List, Optional
+
+    @tool
+    def demo_lookup(query: str) -> str:
+        """Look up a fact in the demo knowledge base (keyless, deterministic)."""
+        return json.dumps({"query": query, "answer": _DEMO_ANSWER, "source": "demo-kb"})
+
+    def _reasoning_and_reply(messages: List[BaseMessage]) -> tuple[list[str], str]:
+        """Decide the (reasoning deltas, answer text) the fake model should stream.
+
+        Pure function of the conversation so ``_generate`` and ``_stream`` can't
+        drift. The node handles the tool-call and interrupt control flow; the model
+        only ever streams ``content`` (and ``reasoning`` on the ``think`` trigger).
+        """
+        tool_result = _last_tool_result(messages)
+        if tool_result is not None:
+            return [], (
+                f"The demo tool returned {tool_result}. That completes the "
+                "tool_start -> tool_end -> extraction flow."
+            )
+        trigger = _last_human_text(messages).lower()
+        if REASONING_TRIGGER in trigger:
+            return (
+                [
+                    "Let me reason about this step by step. ",
+                    "The demo streams this as a `reasoning` frame, kept separate "
+                    "from the answer. ",
+                ],
+                "Done reasoning — that was the `reasoning` frame demo.",
+            )
+        return [], DEFAULT_REPLY_PREFIX + _last_human_text(messages)
+
+    class DemoChatModel(BaseChatModel):
+        """A no-API chat model that streams a deterministic content (and, on the
+        ``think`` trigger, ``reasoning``) reply — the keyless stand-in for a real
+        LLM. Implements ``_stream`` so tokens surface one-by-one through the parser,
+        exactly as a streaming provider would."""
+
+        @property
+        def _llm_type(self) -> str:
+            return "tool-demo-stub"
+
+        def _generate(
+            self,
+            messages: List[BaseMessage],
+            stop: Optional[List[str]] = None,
+            run_manager: Optional[CallbackManagerForLLMRun] = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            _, text = _reasoning_and_reply(messages)
+            return ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content=text))]
+            )
+
+        def _stream(
+            self,
+            messages: List[BaseMessage],
+            stop: Optional[List[str]] = None,
+            run_manager: Optional[CallbackManagerForLLMRun] = None,
+            **kwargs: Any,
+        ) -> Iterator[ChatGenerationChunk]:
+            reasoning, text = _reasoning_and_reply(messages)
+            # Reasoning deltas carry the chain-of-thought in the `reasoning_content`
+            # additional_kwarg (the DeepSeek / Qwen / xAI shape the AG-UI adapter's
+            # resolve_reasoning_content recognizes), with empty text content so they
+            # surface as `reasoning` frames, never as the answer. (gh #71 / #99)
+            for delta in reasoning:
+                chunk = ChatGenerationChunk(
+                    message=AIMessageChunk(
+                        content="", additional_kwargs={"reasoning_content": delta}
+                    )
+                )
+                if run_manager is not None:
+                    run_manager.on_llm_new_token(delta, chunk=chunk)
+                yield chunk
+            tokens = text.split(" ")
+            for i, token in enumerate(tokens):
+                piece = token if i == len(tokens) - 1 else token + " "
+                chunk = ChatGenerationChunk(message=AIMessageChunk(content=piece))
+                if run_manager is not None:
+                    run_manager.on_llm_new_token(piece, chunk=chunk)
+                yield chunk
+
+    model = DemoChatModel()
+
+    def _agent(state: MessagesState) -> dict:
+        messages = state["messages"]
+        trigger = _last_human_text(messages).lower()
+        tool_ran = _last_tool_result(messages) is not None
+
+        # Interrupt path (HITL). `interrupt()` raises a GraphInterrupt on the first
+        # pass (yielding the `interrupt` frame) and returns the resume decision on
+        # the second — at which point we finish the turn with a `content` reply.
+        # Only before any tool has run, so the tool path's second pass can't re-fire.
+        if INTERRUPT_TRIGGER in trigger and not tool_ran:
+            decision = interrupt(_INTERRUPT_REQUEST)
+            return {
+                "messages": [
+                    AIMessage(content=f"Resumed. Your decision was: {decision}.")
+                ]
+            }
+
+        # Tool path (first pass): return a tool-call AIMessage and let the real
+        # ToolNode execute it — the only wiring that makes the adapter emit
+        # streaming ToolCall* events (core 1.0.24 / gh #91). The conditional edge
+        # routes to "tools"; the second pass sees the ToolMessage and summarizes it.
+        if TOOL_TRIGGER in trigger and not tool_ran:
+            return {
+                "messages": [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "demo_lookup",
+                                "args": {"query": _last_human_text(messages)},
+                                "id": "demo_lookup_1",
+                            }
+                        ],
+                    )
+                ]
+            }
+
+        # Content / reasoning / tool-summary: the streaming model handles the reply.
+        return {"messages": [model.invoke(messages)]}
+
+    builder = StateGraph(MessagesState)
+    builder.add_node("agent", _agent)
+    builder.add_node("tools", ToolNode([demo_lookup]))
+    builder.add_edge(START, "agent")
+    builder.add_conditional_edges(
+        "agent",
+        lambda s: "tools" if getattr(s["messages"][-1], "tool_calls", None) else END,
+        {"tools": "tools", END: END},
+    )
+    builder.add_edge("tools", "agent")
+
+    graph = builder.compile(checkpointer=checkpointer)
+    graph.name = name
+    return graph
+
+
+def __getattr__(attr: str) -> Any:
+    # ``graph`` is built lazily on first access so plain imports of this module
+    # never require langgraph — but ``load_agent_spec("...demo.tools:graph")`` gets
+    # a ready compiled agent (mirrors demo.stub).
+    if attr == "graph":
+        global _GRAPH_CACHE
+        if _GRAPH_CACHE is None:
+            _GRAPH_CACHE = create_tool_demo_agent()
+        return _GRAPH_CACHE
+    raise AttributeError(f"module {__name__!r} has no attribute {attr!r}")

--- a/tests/test_agui_cli.py
+++ b/tests/test_agui_cli.py
@@ -49,6 +49,35 @@ def test_show_config_default_host_port_present(capsys):
     assert "host" in out and "port" in out
 
 
+def test_demo_show_config_resolves_echo_spec(capsys):
+    # Bare --demo is unchanged: it serves the echo stub.
+    rc = main(["--demo", "--show-config"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "langstage_core.demo.stub:graph" in out
+
+
+def test_demo_tools_show_config_resolves_tools_spec(capsys):
+    # gh #99: --demo=tools serves the rich-frame demo instead of the echo stub.
+    rc = main(["--demo=tools", "--show-config"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "langstage_core.demo.tools:graph" in out
+
+
+def test_demo_tools_is_still_mutually_exclusive_with_agent(capsys):
+    rc = main(["--demo=tools", "--agent", "my_agent.py:graph"])
+    assert rc == 2
+    assert "mutually exclusive" in capsys.readouterr().err
+
+
+def test_demo_rejects_unknown_value(capsys):
+    # An unknown --demo value is an argparse error (SystemExit 2), not a silent fall-through.
+    with pytest.raises(SystemExit) as exc:
+        main(["--demo=bogus"])
+    assert exc.value.code == 2
+
+
 def test_show_config_omits_keys_the_server_ignores(capsys):
     # The AG-UI server consumes only agent_spec/host/port; workspace_root/debug/
     # title are inherited but inert on this surface, so --show-config must not

--- a/tests/test_demo_tools.py
+++ b/tests/test_demo_tools.py
@@ -1,0 +1,276 @@
+"""The keyless rich-frame demo agent (``langstage_core.demo.tools``) — gh #99.
+
+This is the regression fixture the issue asks for: the echo stub only ever emits
+``content``, so the entire rich-frame class (``tool_start`` / ``tool_end`` /
+``extraction`` / ``reasoning`` / ``interrupt``) — the largest bug class in this
+repo's history — had no keyless test exercising it end-to-end. These tests drive
+the demo through **both** shipped mappings (``iter_event_frames`` and
+``iter_chunk_frames``) and assert every documented frame type actually appears,
+and that the interrupt path resumes.
+
+Skipped unless the agui extra is installed (dev pulls it, so CI runs it).
+"""
+import pytest
+
+pytest.importorskip("ag_ui_langgraph")
+pytest.importorskip("fastapi")
+
+from langstage_core import create_resume_input, load_agent_spec
+from langstage_core.agui import build_agent, iter_chunk_frames, iter_event_frames
+from langstage_core.demo.tools import (
+    DemoLookupExtractor,
+    create_tool_demo_agent,
+    demo_extractors,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _collect(aiter):
+    return [frame async for frame in aiter]
+
+
+def _agent():
+    return build_agent(create_tool_demo_agent())
+
+
+# ── the spec loads, so every surface can point at it keyless ─────────────────────
+
+
+async def test_spec_loads_and_factory_builds():
+    # The advertised spec string resolves to a compiled graph (the --demo=tools path).
+    graph = load_agent_spec("langstage_core.demo.tools:graph")
+    assert graph is not None
+    assert getattr(graph, "name", None) == "Tool Demo Agent"
+
+
+# ── content (normal message) — token-by-token, exactly like the echo stub ────────
+
+
+async def test_content_frame_event_wire():
+    frames = await _collect(iter_event_frames(_agent(), "hello there", "c-e"))
+    content = [f for f in frames if f.get("type") == "content"]
+    assert content, frames
+    assert "hello there" in "".join(f["content"] for f in content)
+    assert frames[-1] == {"type": "complete"}
+    # token-by-token: the reply arrives as multiple content frames, not one blob.
+    assert len(content) > 1
+
+
+async def test_content_frame_chunk_wire():
+    frames = await _collect(iter_chunk_frames(_agent(), "hello there", "c-c"))
+    chunks = [f for f in frames if f.get("status") == "streaming" and "chunk" in f]
+    assert chunks and "hello there" in "".join(f["chunk"] for f in chunks)
+    assert frames[-1] == {"status": "complete"}
+
+
+# ── reasoning ("think") — surfaced as a `reasoning` frame, separate from content ──
+
+
+async def test_reasoning_frame_event_wire():
+    frames = await _collect(iter_event_frames(_agent(), "think about it", "r-e"))
+    reasoning = [f for f in frames if f.get("type") == "reasoning"]
+    content = [f for f in frames if f.get("type") == "content"]
+    assert reasoning, f"no reasoning frame: {[f.get('type') for f in frames]}"
+    assert content, "reasoning turn must still produce a content answer"
+    # reasoning is the chain-of-thought, never the answer text.
+    assert "reason" in "".join(f["content"] for f in reasoning).lower()
+    assert frames[-1] == {"type": "complete"}
+
+
+async def test_reasoning_frame_chunk_wire():
+    frames = await _collect(iter_chunk_frames(_agent(), "think about it", "r-c"))
+    reasoning = [f for f in frames if "reasoning" in f]
+    chunks = [f for f in frames if "chunk" in f]
+    assert reasoning, f"no reasoning chunk: {frames}"
+    assert chunks, "reasoning turn must still stream a content answer"
+    assert frames[-1] == {"status": "complete"}
+
+
+# ── tool_start → tool_end → extraction ("use a tool"), via a REAL ToolNode ───────
+
+
+async def test_tool_frames_event_wire():
+    frames = await _collect(
+        iter_event_frames(_agent(), "use a tool now", "t-e", extractors=demo_extractors())
+    )
+    starts = [f for f in frames if f.get("type") == "tool_start"]
+    ends = [f for f in frames if f.get("type") == "tool_end"]
+    extraction = [f for f in frames if f.get("type") == "extraction"]
+    content = [f for f in frames if f.get("type") == "content"]
+    assert starts and starts[0]["name"] == "demo_lookup", frames
+    assert ends and ends[0]["name"] == "demo_lookup" and ends[0]["status"] == "success"
+    assert extraction, "no extraction frame — the paired extractor never fired"
+    assert extraction[0]["extracted_type"] == "demo_fact"
+    assert extraction[0]["data"]["answer"] == "42"
+    assert content, "the tool turn must end with a content summary"
+    assert frames[-1] == {"type": "complete"}
+
+
+async def test_tool_frames_chunk_wire():
+    frames = await _collect(
+        iter_chunk_frames(_agent(), "use a tool now", "t-c", extractors=demo_extractors())
+    )
+    calls = [f for f in frames if "tool_calls" in f]
+    results = [f for f in frames if "tool_result" in f]
+    extraction = [f["extraction"] for f in frames if "extraction" in f]
+    chunks = [f for f in frames if "chunk" in f]
+    assert calls and calls[0]["tool_calls"][0]["name"] == "demo_lookup", frames
+    assert results, "no tool_result chunk"
+    assert extraction and extraction[0]["extracted_type"] == "demo_fact"
+    assert extraction[0]["data"]["answer"] == "42"
+    assert chunks, "the tool turn must end with a content summary"
+    assert frames[-1] == {"status": "complete"}
+
+
+# ── interrupt ("ask me") + resume ────────────────────────────────────────────────
+
+
+async def test_interrupt_frame_event_wire():
+    frames = await _collect(iter_event_frames(_agent(), "ask me a question", "i-e"))
+    interrupts = [f for f in frames if f.get("type") == "interrupt"]
+    assert interrupts, f"no interrupt frame: {[f.get('type') for f in frames]}"
+    assert not any(f.get("type") == "error" for f in frames)
+    assert interrupts[0]["action_requests"] == [
+        {"action": "ask_user", "args": {"question": "What should I call you?"}}
+    ]
+    assert "respond" in interrupts[0]["allowed_decisions"]
+
+
+async def test_interrupt_frame_chunk_wire():
+    frames = await _collect(iter_chunk_frames(_agent(), "ask me a question", "i-c"))
+    interrupts = [f for f in frames if f.get("status") == "interrupt"]
+    assert interrupts, f"no interrupt frame: {frames}"
+    assert not any(f.get("status") == "error" for f in frames)
+    assert interrupts[0]["interrupt"]["action_requests"][0]["action"] == "ask_user"
+
+
+async def test_interrupt_resumes_event_wire():
+    # The full HITL round-trip: hit the interrupt, then resume the SAME thread with a
+    # decision via the documented create_resume_input path; the turn must complete.
+    agent = _agent()
+    first = await _collect(iter_event_frames(agent, "ask me a question", "i-resume"))
+    assert any(f.get("type") == "interrupt" for f in first)
+
+    resumed = await _collect(
+        iter_event_frames(
+            agent, "", "i-resume", resume=create_resume_input(decisions=[{"type": "approve"}])
+        )
+    )
+    assert not any(f.get("type") == "error" for f in resumed), resumed
+    content = "".join(f["content"] for f in resumed if f.get("type") == "content")
+    assert "approve" in content, f"resume decision not reflected: {content!r}"
+    assert resumed[-1] == {"type": "complete"}
+
+
+async def test_interrupt_resumes_chunk_wire():
+    agent = _agent()
+    first = await _collect(iter_chunk_frames(agent, "ask me a question", "i-resume-c"))
+    assert any(f.get("status") == "interrupt" for f in first)
+
+    resumed = await _collect(
+        iter_chunk_frames(
+            agent, "", "i-resume-c", resume=create_resume_input(decisions=[{"type": "approve"}])
+        )
+    )
+    assert not any(f.get("status") == "error" for f in resumed), resumed
+    text = "".join(f["chunk"] for f in resumed if "chunk" in f)
+    assert "approve" in text
+    assert resumed[-1] == {"status": "complete"}
+
+
+# ── the headline regression fixture: EVERY documented frame type is reachable ─────
+
+_EVENT_FRAME_TYPES = {
+    "content",
+    "tool_start",
+    "tool_end",
+    "extraction",
+    "reasoning",
+    "interrupt",
+    "complete",
+}
+
+
+async def test_demo_covers_every_documented_frame_type_event_wire():
+    """Union of frame types across the demo's triggers covers the full taxonomy —
+    the copy-paste example + smoke test gh #99 asks for."""
+    agent = _agent()
+    seen: set[str] = set()
+    seen.update(f["type"] for f in await _collect(iter_event_frames(agent, "hi", "cov1")))
+    seen.update(f["type"] for f in await _collect(iter_event_frames(agent, "think", "cov2")))
+    seen.update(
+        f["type"]
+        for f in await _collect(
+            iter_event_frames(agent, "use a tool", "cov3", extractors=demo_extractors())
+        )
+    )
+    seen.update(f["type"] for f in await _collect(iter_event_frames(agent, "ask me", "cov4")))
+    missing = _EVENT_FRAME_TYPES - seen
+    assert not missing, f"demo never emitted: {missing} (saw {seen})"
+
+
+async def test_demo_covers_every_documented_frame_type_chunk_wire():
+    agent = _agent()
+
+    def _kinds(frames):
+        kinds = set()
+        for f in frames:
+            if f.get("status") == "interrupt":
+                kinds.add("interrupt")
+            elif f.get("status") == "complete":
+                kinds.add("complete")
+            elif f.get("status") == "streaming":
+                for key in ("chunk", "reasoning", "tool_calls", "tool_result", "extraction"):
+                    if key in f:
+                        kinds.add(key)
+        return kinds
+
+    seen: set[str] = set()
+    seen |= _kinds(await _collect(iter_chunk_frames(agent, "hi", "kc1")))
+    seen |= _kinds(await _collect(iter_chunk_frames(agent, "think", "kc2")))
+    seen |= _kinds(
+        await _collect(iter_chunk_frames(agent, "use a tool", "kc3", extractors=demo_extractors()))
+    )
+    seen |= _kinds(await _collect(iter_chunk_frames(agent, "ask me", "kc4")))
+    expected = {"chunk", "reasoning", "tool_calls", "tool_result", "extraction", "interrupt", "complete"}
+    missing = expected - seen
+    assert not missing, f"demo never emitted (chunk wire): {missing} (saw {seen})"
+
+
+# ── contrast: the echo stub CANNOT reach the rich frames (proves the asserts real) ─
+
+
+async def test_echo_stub_lacks_rich_frames():
+    """The same 'use a tool' + 'think' + 'ask me' triggers against the plain echo
+    stub emit only content/complete — so the assertions above are testing a real
+    capability difference, not a tautology. This is the gh #99 gap, made explicit."""
+    stub = build_agent(load_agent_spec("langstage_core.demo.stub:graph"))
+    seen: set[str] = set()
+    for msg in ("use a tool", "think", "ask me"):
+        seen.update(
+            f["type"]
+            for f in await _collect(
+                iter_event_frames(stub, msg, f"stub-{msg}", extractors=demo_extractors())
+            )
+        )
+    assert seen <= {"content", "complete"}, f"echo stub unexpectedly rich: {seen}"
+    assert "tool_start" not in seen and "reasoning" not in seen and "interrupt" not in seen
+
+
+# ── the paired extractor in isolation ────────────────────────────────────────────
+
+
+async def test_demo_lookup_extractor_unit():
+    ex = DemoLookupExtractor()
+    assert ex.tool_name == "demo_lookup"
+    assert ex.extracted_type == "demo_fact"
+    assert ex.extract('{"query": "q", "answer": "42"}') == {"query": "q", "answer": "42"}
+    # non-matching / unparseable content yields no extraction frame.
+    assert ex.extract("not json") is None
+    assert ex.extract('{"unrelated": 1}') is None
+
+
+async def test_demo_extractors_returns_the_paired_extractor():
+    exts = demo_extractors()
+    assert len(exts) == 1 and isinstance(exts[0], DemoLookupExtractor)


### PR DESCRIPTION
## What & why

The shared demo stub (`langstage_core.demo.stub:graph`) behind every surface's `--demo` and the README Quick Start only ever emitted **`content`** frames — a plain echo. But `content` is one of *eight* documented frame types, and the rich ones — `tool_start` / `tool_end` / `extraction` / `reasoning` / `interrupt` — are the library's whole selling point, reachable before now only by hand-building a LangGraph graph **and** correctly wiring a real `ToolNode`. That was the biggest dogfooding friction (gh #99), and it left the largest bug class in this repo's history — rich-frame emission defects (#41/#43/#45, #50, #71, #89, #90, #91) — with no keyless regression fixture.

## What's added (alongside the echo stub, not replacing it)

`langstage_core.demo.tools:graph`, built by `create_tool_demo_agent()` — a **real** compiled graph (router node + real `langgraph.prebuilt.ToolNode`) that routes on a trigger in the user's message:

| Message contains | Behavior | Frame types |
|---|---|---|
| *(anything else)* | token-by-token echo (as the stub) | `content` |
| `"use a tool"` | calls built-in keyless `demo_lookup` via a real `ToolNode`, then summarizes | `tool_start` → `tool_end` → `extraction` → `content` |
| `"think"` | streams a chain-of-thought, then the answer | `reasoning` → `content` |
| `"ask me"` | raises a resumable `interrupt(...)` | `interrupt` → *(resume)* `content` |

Deterministic and offline — the "model" is a local fake, **no API key, no network, no model call**. Reasoning uses the DeepSeek/Qwen `reasoning_content` shape the AG-UI adapter recognizes; the `extraction` frame comes from a paired built-in `DemoLookupExtractor` (exposed via `demo_extractors()`), reusing the existing extractor machinery.

The tool path deliberately goes through a **real `ToolNode`**, because the AG-UI adapter emits streaming `ToolCall*` events only when a tool runs through one — a hand-rolled `AIMessage(tool_calls=...)` + manually-appended `ToolMessage` arrives via the snapshot path instead (the distinction 1.0.24 / #91 hinges on). The demo bakes the correct wiring in so no adopter has to rediscover it.

## CLI

`--demo` now takes an optional value: bare `--demo` serves the echo stub **unchanged**; `--demo=tools` serves the rich demo. `--show-config`, `--verify`, and mutual-exclusion with `--agent` behave for both. Chosen over a separate `--demo-tools` flag because it keeps the existing `--demo` handling (one truthy check drives spec/name/mutual-exclusion) with a single spec-lookup swap.

## Docs

The README frame-type list now points at a runnable keyless snippet that prints each of `content` / `reasoning` / `tool_start` / `tool_end` / `extraction` / `interrupt` / `complete`.

## Tests (the regression fixture the issue asks for)

`tests/test_demo_tools.py` asserts every documented frame type appears through **both** `iter_event_frames` and `iter_chunk_frames`, that the interrupt resumes via `create_resume_input`, and — as a contrast that proves the assertions are real — that the echo stub reaches none of the rich frames. Plus CLI tests for the new flag.

Transcript (both wires):

\`\`\`
EVENT WIRE
  'hello world'    -> [content..., complete]
  'think about it' -> [reasoning, reasoning, content..., complete]
  'use a tool'     -> [tool_start, tool_end, extraction, content..., complete]
  'ask me'         -> [interrupt, complete]
  '(resume)'       -> [content, complete]
CHUNK WIRE
  'think about it' -> [reasoning, reasoning, chunk..., complete]
  'use a tool'     -> [tool_calls, tool_result, extraction, chunk..., complete]
  'ask me'         -> [interrupt, complete]
  '(resume)'       -> [chunk, complete]
\`\`\`

**Full suite: 222 passed** (202 baseline + 20 new). Bumps 1.0.24 → 1.0.25 with a dated CHANGELOG entry. `uv.lock` left untouched (chronically stale; version-only bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B