### PR TITLE
One-shot run_turn / collect_event_frames → typed TurnResult (gh #110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## [1.0.26] - 2026-07-23
+
+### Added
+- **A one-shot "run a turn, get a typed result" helper over the `iter_*` mappings (gh #110).**
+  The library exposed exactly two consumers — `iter_event_frames` and `iter_chunk_frames`, both
+  *streaming* async generators. That's the right primitive for a live UI, but a large share of
+  real usage is *not* a live UI: a test, an eval/grading harness, a batch job, a `@tool` that
+  delegates to a sub-agent, a "run my agent once, give me the answer" script. Every one of those
+  wanted a single call that runs one turn and returns the result, so each hand-rolled the same
+  accumulator loop over `iter_event_frames` (collect `content` deltas, watch for `interrupt`,
+  map `complete` → outcome, catch `error`) — four copies in one dogfooding session. New
+  `langstage_core.agui.collect_event_frames(agent, message, thread_id, *, resume, max_result_len,
+  extractors, state)` (async) drives one turn and returns a typed `TurnResult` dataclass:
+  `text` (joined `content`), `tool_calls` (`[{name, args, id}]`), `extractions`
+  (`[{tool_name, extracted_type, data}]`), `reasoning`, `outcome`
+  (`"complete"`/`"interrupted"`/`"error"`), `interrupt` (the interrupt frame when paused),
+  `error` (the message when it failed), and `frames` (total seen). It takes the *same* kwargs as
+  `iter_event_frames` and forwards them unchanged, so it's a drop-in "I don't need the stream,
+  just the result." A chunk-wire counterpart `collect_chunk_frames` (same `TurnResult`, for
+  CLI/Jupyter parity) and a sync convenience `run_turn(graph_or_agent, message, *, thread_id=...)`
+  — which accepts a compiled graph **or** a prebuilt `LangGraphAgent` like `verify`, builds it if
+  needed, and runs under `asyncio.run` — round out the set, mirroring the `averify`/`verify`
+  async+sync pairing. Exported from `langstage_core.agui` (alongside `iter_event_frames` /
+  `verify`, not top-level). This makes asserting "message X yields answer Y / calls tool Z /
+  raises an interrupt" a one-liner in a test, directly serving the largest bug class in this
+  repo's history (the turn is wrong/empty).
+- **The `complete` / `interrupted` / `error` terminal-outcome rule now lives in ONE place
+  (gh #110).** `SessionAdapter._produce` already implemented the exact state machine (`error` ⇒
+  `error`; a `complete` after a pending `interrupt` ⇒ `interrupted`; else `complete`), but it was
+  welded to the session/queue object, so every non-streaming consumer reimplemented it and could
+  drift. Factored a small shared `_terminal_outcome(*, saw_interrupt, saw_error)` in
+  `langstage_core.agui`; `_produce`, both new collectors, and `verify()` all call it now, so the
+  rule is defined and tested once. (`_produce`'s `cancelled` outcome stays where it is — it's a
+  transport concern set on `asyncio.CancelledError`, not part of the frame-driven rule. `verify()`
+  is unchanged on every turn a probe actually produces: `outcome == "complete"` iff `not saw_error`
+  there, so its `ok` verdict is identical, now derived from the shared rule instead of an inline
+  `saw_complete and not saw_error`.)
+
+### Note
+- The sibling `langstage` package's `oneturn.py` (`complete_turn` / `run_turn_sync`) is a
+  *different* layer — it buffers a `SessionAdapter` for the web server's one-turn HTTP endpoint,
+  where the session/queue is needed. These core `collect_*` / `run_turn` helpers are the
+  lower-level, **session-free** collectors: they just iterate the `iter_*` mappings, no
+  `SessionAdapter`. Use these in tests/evals/scripts; the web endpoint keeps using its own.
+
 ## [1.0.25] - 2026-07-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ asyncio.run(main())
 
 Serve the same demo over AG-UI with `langstage-agui --demo=tools`.
 
+#### One call, one answer (no streaming)
+
+The `iter_*` mappings are streaming generators — perfect for a live UI, but a test, an eval/grading harness, a batch job, or a "run my agent once, give me the answer" script wants a **single call that returns the result**. `run_turn` (sync) / `collect_event_frames` (async) do exactly that, returning a typed `TurnResult` (`text`, `tool_calls`, `extractions`, `reasoning`, `outcome`, `interrupt`, `error`, `frames`) — nothing streamed, nothing hand-accumulated:
+
+```python
+from langstage_core.agui import run_turn
+from langstage_core.demo.tools import create_tool_demo_agent, demo_extractors
+
+result = run_turn(create_tool_demo_agent(), "use a tool", extractors=demo_extractors())
+result.text          # 'The demo tool returned {"query": "use a tool", "answer": "42", ...}'
+result.tool_calls    # [{'name': 'demo_lookup', 'args': {'query': 'use a tool'}, 'id': 'demo_lookup_1'}]
+result.extractions   # [{'tool_name': 'demo_lookup', 'extracted_type': 'demo_fact', 'data': {...}}]
+result.outcome       # 'complete'   ('interrupted' on "ask me", 'error' on a failing turn)
+```
+
+`run_turn` accepts a compiled graph **or** a prebuilt `build_agent(...)` and runs the turn under `asyncio.run`; inside an event loop, `await collect_event_frames(agent, message, thread_id, ...)` instead (or `collect_chunk_frames` for the chunk wire). The `complete` / `interrupted` / `error` verdict is the same rule `SessionAdapter` uses, so a one-shot turn and a streamed one agree. (The sibling `langstage` package's `oneturn.py` is a *different* layer — it buffers a `SessionAdapter` for the web one-turn HTTP endpoint; these core helpers are session-free, for tests/evals/scripts.)
+
 ### Human-in-the-loop (interrupt → resume)
 
 When the graph calls `interrupt(...)`, you get an `interrupt` frame; resume by passing the decision back via `resume=`:
@@ -119,7 +136,7 @@ Everything is re-exported from the top-level `langstage_core` package (except th
 | Area | API | What it does |
 |---|---|---|
 | **Host** | `load_agent_spec`, `HostConfig`, `Workspace` | Load a graph from a `module:attr` / `file.py:attr` spec; resolve layered config (defaults < `langstage.toml` < `LANGSTAGE_*` env < overrides). |
-| **AG-UI bridge** (`langstage_core.agui`) | `build_agent`, `iter_event_frames`, `iter_chunk_frames`, `build_app`, `serve`, `add_agui_endpoint` | Stream any `CompiledGraph` in-process (the `iter_*` mappings) or serve it as an AG-UI HTTP endpoint. |
+| **AG-UI bridge** (`langstage_core.agui`) | `build_agent`, `iter_event_frames`, `iter_chunk_frames`, `collect_event_frames` / `collect_chunk_frames` / `run_turn` (→ `TurnResult`), `build_app`, `serve`, `add_agui_endpoint` | Stream any `CompiledGraph` in-process (the `iter_*` mappings), collect one turn into a typed `TurnResult` (the `collect_*` / `run_turn` one-shots), or serve it as an AG-UI HTTP endpoint. |
 | **Session adapter** (top-level; also `langstage_core.adapters`) | `SessionAdapter`, `Session` | A session-scoped driver over the AG-UI agent with a typed terminal `outcome` — the streaming engine behind the web app + task board. |
 | **Input helpers** | `prepare_agent_input`, `create_resume_input` | Build graph input from a message (+ optional context) or a resume decision. |
 | **Extractors** | `ToolExtractor` + built-ins (`ThinkToolExtractor`, `TodoExtractor`, `DisplayInlineExtractor`, `SkillManageExtractor`, `MemoryExtractor`, …) | Turn a tool's result into a structured `extraction` frame; pass `extractors=[...]` to the `iter_*` mappings. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "langstage-core"
-version = "1.0.25"
+version = "1.0.26"
 description = "Universal parser + host layer for LangGraph agents — typed stream events, agent-spec loading, layered config, an AG-UI bridge, and an async task-delegation engine"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/langstage_core/adapters/session.py
+++ b/src/langstage_core/adapters/session.py
@@ -229,7 +229,7 @@ class SessionAdapter:
         outcome (``session.outcome`` + ``session.interrupt`` / ``session.error``) so
         headless consumers (the task runner) don't re-inspect the event stream.
         """
-        from ..agui import build_agent, iter_event_frames
+        from ..agui import _terminal_outcome, build_agent, iter_event_frames
 
         session.outcome = None
         session.interrupt = None
@@ -254,18 +254,23 @@ class SessionAdapter:
             ):
                 session.push(data)
                 kind = data.get("type")
+                # The complete/interrupted/error decision is the shared
+                # _terminal_outcome rule (gh #110) — the same one collect_event_frames
+                # / collect_chunk_frames use — so this session-scoped path and the
+                # one-shot collectors can't drift. (`cancelled`, below, is orthogonal:
+                # a transport concern, not part of the frame-driven rule.)
                 if kind == "interrupt":
                     pending_interrupt = data
                 elif kind == "error":
-                    session.outcome = "error"
+                    session.outcome = _terminal_outcome(saw_interrupt=False, saw_error=True)
                     session.error = data.get("error")
                     return
                 elif kind == "complete":
-                    if pending_interrupt is not None:
-                        session.outcome = "interrupted"
+                    session.outcome = _terminal_outcome(
+                        saw_interrupt=pending_interrupt is not None, saw_error=False
+                    )
+                    if session.outcome == "interrupted":
                         session.interrupt = pending_interrupt
-                    else:
-                        session.outcome = "complete"
                     return
         except asyncio.CancelledError:
             session.outcome = "cancelled"

--- a/src/langstage_core/agui/__init__.py
+++ b/src/langstage_core/agui/__init__.py
@@ -37,6 +37,10 @@ __all__ = [
     "ensure_available",
     "iter_event_frames",
     "iter_chunk_frames",
+    "collect_event_frames",
+    "collect_chunk_frames",
+    "run_turn",
+    "TurnResult",
     "verify",
     "averify",
     "VerifyResult",
@@ -409,6 +413,37 @@ def _unwrap_resume(resume):
     except ImportError:  # pragma: no cover - langgraph is always present in practice
         return resume
     return resume.resume if isinstance(resume, Command) else resume
+
+
+def _terminal_outcome(*, saw_interrupt: bool, saw_error: bool) -> str:
+    """The single source of truth for a turn's typed terminal outcome (gh #110).
+
+    Given whether the turn saw an ``error`` frame and/or a pending ``interrupt``
+    frame by the time it terminated, return the outcome string the whole family
+    agrees on:
+
+    - ``"error"`` if an ``error`` frame fired — it wins even over a pending
+      interrupt, because a turn that errors after pausing did **not** pause
+      cleanly;
+    - else ``"interrupted"`` if a ``complete`` frame arrived while an
+      ``interrupt`` was pending (a HITL turn waiting on a decision);
+    - else ``"complete"``.
+
+    This is exactly the rule ``SessionAdapter._produce`` used to inline over the
+    ``iter_event_frames`` stream (``adapters/session.py``) and that
+    ``collect_event_frames`` / ``collect_chunk_frames`` — and every hand-rolled
+    accumulator the issue counted (four in one session) — would otherwise
+    re-implement and drift on. ``_produce`` and both collectors now call this, so
+    the ``complete`` / ``interrupted`` / ``error`` state machine lives in one
+    tested place. (``verify()``'s simpler pass/fail ``ok`` derives from it too;
+    ``"cancelled"`` is orthogonal — a transport concern ``_produce`` sets on
+    ``asyncio.CancelledError``, not part of this frame-driven rule.)
+    """
+    if saw_error:
+        return "error"
+    if saw_interrupt:
+        return "interrupted"
+    return "complete"
 
 
 async def iter_event_frames(
@@ -846,6 +881,13 @@ async def iter_chunk_frames(
     yield {"status": "complete"}
 
 
-# Imported at the bottom so verify.py can reference build_agent / iter_event_frames
-# as already-defined names (avoids a circular import). See ADR 0004.
+# Imported at the bottom so verify.py / collect.py can reference build_agent /
+# iter_event_frames / _terminal_outcome as already-defined names (avoids a circular
+# import). See ADR 0004.
+from .collect import (  # noqa: E402,F401
+    TurnResult,
+    collect_chunk_frames,
+    collect_event_frames,
+    run_turn,
+)
 from .verify import VerifyResult, averify, verify  # noqa: E402,F401

--- a/src/langstage_core/agui/collect.py
+++ b/src/langstage_core/agui/collect.py
@@ -1,0 +1,273 @@
+"""One-shot turn collectors — run a turn, get a typed result (gh #110).
+
+The library exposes exactly two consumers, :func:`iter_event_frames` and
+:func:`iter_chunk_frames`, both **streaming** async generators. That is the right
+primitive for a live UI, but a large share of real usage is *not* a live UI: a
+test, an eval/grading harness, a batch job, a ``@tool`` that delegates to a
+sub-agent, a "run my agent once, give me the answer" script. Every one of those
+wants a **single call that runs one turn and returns the result** — the final
+text, the tool calls it made, any extractions and reasoning, and whether it
+completed / interrupted / errored.
+
+Before this module each such consumer hand-rolled the same accumulator loop over
+:func:`iter_event_frames` (collect ``content`` deltas, watch for ``interrupt``,
+map ``complete`` → outcome, catch ``error``) — and, crucially, re-implemented the
+terminal-outcome state machine that already lives in ``SessionAdapter._produce``.
+This centralizes both: a small accumulator plus the shared
+:func:`~langstage_core.agui._terminal_outcome` rule, returning a typed
+:class:`TurnResult`.
+
+Three entry points, mirroring the two ``iter_*`` mappings and the
+``averify`` / ``verify`` async+sync pairing:
+
+- :func:`collect_event_frames` — async, over :func:`iter_event_frames` (the
+  ``{"type": ...}`` event wire); the primary one.
+- :func:`collect_chunk_frames` — async, over :func:`iter_chunk_frames` (the
+  ``{"status": ...}`` chunk wire), for CLI/Jupyter parity.
+- :func:`run_turn` — the sync "one call, one answer" convenience: it accepts a
+  compiled graph **or** a prebuilt ``LangGraphAgent`` (like ``verify``), builds
+  the agent if needed, and drives :func:`collect_event_frames` under
+  ``asyncio.run``.
+
+Relationship to the sibling ``langstage`` package's ``langstage/oneturn.py``
+(``complete_turn`` / ``run_turn_sync``): that one buffers a ``SessionAdapter`` for
+the web server's one-turn HTTP endpoint — it needs the session/queue plumbing.
+These helpers are the lower-level, **session-free** collectors the issue asked
+for: they just iterate the ``iter_*`` mappings, no ``SessionAdapter`` involved.
+Reach for these in tests/evals/scripts; the web endpoint keeps using its own.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import (
+    _is_langgraph_agent,
+    _terminal_outcome,
+    build_agent,
+    iter_chunk_frames,
+    iter_event_frames,
+)
+
+
+@dataclass
+class TurnResult:
+    """The typed result of running one turn to termination.
+
+    Produced by :func:`collect_event_frames` / :func:`collect_chunk_frames` /
+    :func:`run_turn`. Every field is populated from the frames a single turn
+    emitted — nothing is thrown away (contrast ``VerifyResult``, which reports
+    ``content_chars`` but discards the content itself).
+
+    Attributes:
+        text: The concatenated ``content`` deltas — the agent's answer.
+        outcome: ``"complete"`` | ``"interrupted"`` | ``"error"`` — the shared
+            :func:`~langstage_core.agui._terminal_outcome` verdict.
+        tool_calls: One ``{"name", "args", "id"}`` per tool the turn called (the
+            chunk wire carries no ``id``, so it is ``None`` there).
+        extractions: One ``{"tool_name", "extracted_type", "data"}`` per
+            ``extraction`` frame (empty unless ``extractors=`` was passed).
+        reasoning: The concatenated ``reasoning`` deltas (reasoning-model
+            chain-of-thought), kept separate from ``text``.
+        interrupt: The interrupt frame when ``outcome == "interrupted"``
+            (carrying ``action_requests`` / ``allowed_decisions`` to build a
+            resume decision), else ``None``.
+        error: The error message when ``outcome == "error"``, else ``None``.
+        frames: Total frames seen — handy for smoke checks.
+    """
+
+    text: str
+    outcome: str
+    tool_calls: list[dict] = field(default_factory=list)
+    extractions: list[dict] = field(default_factory=list)
+    reasoning: str = ""
+    interrupt: dict | None = None
+    error: str | None = None
+    frames: int = 0
+
+
+async def collect_event_frames(
+    agent: Any,
+    message: str,
+    thread_id: str,
+    *,
+    resume: Any = None,
+    max_result_len: int = 500,
+    extractors: Any = (),
+    state: Any = None,
+) -> TurnResult:
+    """Run one turn through :func:`iter_event_frames` and return a :class:`TurnResult`.
+
+    A drop-in "I don't need the stream, just the result" over the event wire:
+    same signature and kwargs as :func:`iter_event_frames` (``agent`` is an
+    already-built ``LangGraphAgent`` — see :func:`build_agent`), all forwarded
+    unchanged. Accumulates ``content`` / ``reasoning`` deltas, ``tool_start`` and
+    ``extraction`` frames, captures any ``interrupt`` / ``error``, and derives the
+    typed ``outcome`` from the shared
+    :func:`~langstage_core.agui._terminal_outcome` rule — so it can't drift from
+    ``SessionAdapter._produce``.
+    """
+    text_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    tool_calls: list[dict] = []
+    extractions: list[dict] = []
+    interrupt: dict | None = None
+    error: str | None = None
+    frames = 0
+
+    async for frame in iter_event_frames(
+        agent,
+        message,
+        thread_id,
+        resume=resume,
+        max_result_len=max_result_len,
+        extractors=extractors,
+        state=state,
+    ):
+        frames += 1
+        kind = frame.get("type")
+        if kind == "content":
+            text_parts.append(frame.get("content") or "")
+        elif kind == "reasoning":
+            reasoning_parts.append(frame.get("content") or "")
+        elif kind == "tool_start":
+            tool_calls.append(
+                {"name": frame.get("name"), "args": frame.get("args"), "id": frame.get("id")}
+            )
+        elif kind == "extraction":
+            extractions.append(
+                {
+                    "tool_name": frame.get("tool_name"),
+                    "extracted_type": frame.get("extracted_type"),
+                    "data": frame.get("data"),
+                }
+            )
+        elif kind == "interrupt":
+            interrupt = frame
+        elif kind == "error":
+            error = frame.get("error")
+
+    outcome = _terminal_outcome(saw_interrupt=interrupt is not None, saw_error=error is not None)
+    return TurnResult(
+        text="".join(text_parts),
+        outcome=outcome,
+        tool_calls=tool_calls,
+        extractions=extractions,
+        reasoning="".join(reasoning_parts),
+        # Match _produce: surface the interrupt only when that's the outcome
+        # (an interrupt followed by an error is an errored turn, not a paused one).
+        interrupt=interrupt if outcome == "interrupted" else None,
+        error=error,
+        frames=frames,
+    )
+
+
+async def collect_chunk_frames(
+    agent: Any,
+    message: str,
+    thread_id: str,
+    *,
+    resume: Any = None,
+    max_result_len: int = 500,
+    extractors: Any = (),
+    state: Any = None,
+) -> TurnResult:
+    """Run one turn through :func:`iter_chunk_frames` and return a :class:`TurnResult`.
+
+    The chunk-wire counterpart of :func:`collect_event_frames`, for CLI/Jupyter
+    parity. Same kwargs, same :class:`TurnResult` shape, same shared
+    :func:`~langstage_core.agui._terminal_outcome` verdict — only the frame
+    vocabulary differs (``{"status": "streaming", "chunk"/"reasoning"/"tool_calls"/
+    "extraction": ...}``, ``{"status": "interrupt"/"error"/"complete"}``). The
+    chunk wire's ``tool_calls`` carry no ``id``, so ``TurnResult.tool_calls[*]["id"]``
+    is ``None`` here; ``TurnResult.interrupt`` is the inner interrupt dict, whose
+    ``action_requests`` / ``allowed_decisions`` keys match the event wire's, so
+    ``result.interrupt["action_requests"]`` reads the same across both collectors.
+    """
+    text_parts: list[str] = []
+    reasoning_parts: list[str] = []
+    tool_calls: list[dict] = []
+    extractions: list[dict] = []
+    interrupt: dict | None = None
+    error: str | None = None
+    frames = 0
+
+    async for chunk in iter_chunk_frames(
+        agent,
+        message,
+        thread_id,
+        resume=resume,
+        max_result_len=max_result_len,
+        extractors=extractors,
+        state=state,
+    ):
+        frames += 1
+        status = chunk.get("status")
+        if status == "streaming":
+            if "chunk" in chunk:
+                text_parts.append(chunk.get("chunk") or "")
+            if "reasoning" in chunk:
+                reasoning_parts.append(chunk.get("reasoning") or "")
+            for tc in chunk.get("tool_calls") or []:
+                tool_calls.append(
+                    {"name": tc.get("name"), "args": tc.get("args"), "id": tc.get("id")}
+                )
+            if "extraction" in chunk:
+                ex = chunk["extraction"] or {}
+                extractions.append(
+                    {
+                        "tool_name": ex.get("tool_name"),
+                        "extracted_type": ex.get("extracted_type"),
+                        "data": ex.get("data"),
+                    }
+                )
+        elif status == "interrupt":
+            interrupt = chunk.get("interrupt", chunk)
+        elif status == "error":
+            error = chunk.get("error")
+
+    outcome = _terminal_outcome(saw_interrupt=interrupt is not None, saw_error=error is not None)
+    return TurnResult(
+        text="".join(text_parts),
+        outcome=outcome,
+        tool_calls=tool_calls,
+        extractions=extractions,
+        reasoning="".join(reasoning_parts),
+        interrupt=interrupt if outcome == "interrupted" else None,
+        error=error,
+        frames=frames,
+    )
+
+
+def run_turn(
+    graph_or_agent: Any,
+    message: str,
+    *,
+    thread_id: str = "oneshot",
+    **kwargs: Any,
+) -> TurnResult:
+    """Synchronous "one call, one answer" convenience over :func:`collect_event_frames`.
+
+    Accepts a compiled LangGraph graph **or** an already-built ``LangGraphAgent``
+    (like :func:`~langstage_core.agui.verify`) — builds the agent if needed, then
+    runs one turn under ``asyncio.run`` and returns the :class:`TurnResult`::
+
+        from langstage_core.agui import run_turn
+        from langstage_core.demo.tools import create_tool_demo_agent, demo_extractors
+
+        r = run_turn(create_tool_demo_agent(), "use a tool", extractors=demo_extractors())
+        assert r.outcome == "complete"
+        assert r.tool_calls[0]["name"] == "demo_lookup"
+
+    ``thread_id`` defaults to ``"oneshot"``; extra kwargs (``extractors``,
+    ``max_result_len``, ``resume``, ``state``) are forwarded to
+    :func:`collect_event_frames`. For a caller already inside an event loop, await
+    :func:`collect_event_frames` directly. Resuming across two calls needs the
+    *same* agent + ``thread_id`` on both, so pass a prebuilt ``build_agent(...)``
+    (a fresh graph gets a fresh in-memory checkpointer each call).
+    """
+    agent = (
+        graph_or_agent if _is_langgraph_agent(graph_or_agent) else build_agent(graph_or_agent)
+    )
+    return asyncio.run(collect_event_frames(agent, message, thread_id, **kwargs))

--- a/src/langstage_core/agui/verify.py
+++ b/src/langstage_core/agui/verify.py
@@ -22,7 +22,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import Any
 
-from . import _is_langgraph_agent, build_agent, iter_event_frames
+from . import _is_langgraph_agent, _terminal_outcome, build_agent, iter_event_frames
 
 # A tiny, model-agnostic probe. It only needs the turn to *complete*; the content
 # is incidental (the keyless demo stub echoes it, a real model answers it).
@@ -82,13 +82,17 @@ async def averify(
     )
 
     result = VerifyResult(ok=False, reason="turn produced no completion frame")
+    saw_interrupt = False
 
     async def _run() -> None:
+        nonlocal saw_interrupt
         async for frame in iter_event_frames(agent, message, thread_id, state=state):
             result.frames += 1
             kind = frame.get("type")
             if kind == "content":
                 result.content_chars += len(frame.get("content") or "")
+            elif kind == "interrupt":
+                saw_interrupt = True
             elif kind == "error":
                 result.saw_error = True
                 result.error_message = frame.get("error")
@@ -104,11 +108,21 @@ async def averify(
         result.reason = f"{type(exc).__name__}: {exc}"
         return result
 
-    result.ok = result.saw_complete and not result.saw_error
+    # A clean preflight is a turn that reached a `complete` frame with the
+    # `complete` outcome — no error, and no pending interrupt (a probe never
+    # resumes, so pausing for a decision isn't a clean pass). The outcome comes
+    # from the one shared _terminal_outcome rule the collectors + _produce use
+    # (gh #110), so verify can't drift from them. On the non-interrupt turns a
+    # probe actually produces, `outcome == "complete"` iff `not saw_error`, so
+    # this is identical to the prior `saw_complete and not saw_error`.
+    outcome = _terminal_outcome(saw_interrupt=saw_interrupt, saw_error=result.saw_error)
+    result.ok = result.saw_complete and outcome == "complete"
     if result.ok:
         result.reason = "one turn completed cleanly"
     elif result.saw_error:
         result.reason = f"agent errored: {result.error_message}"
+    elif saw_interrupt:
+        result.reason = "turn paused on an interrupt (did not complete cleanly)"
     return result
 
 

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,0 +1,176 @@
+"""One-shot turn collectors — run a turn, get a typed result (gh #110).
+
+``collect_event_frames`` / ``collect_chunk_frames`` / ``run_turn`` are the
+non-streaming counterpart to the two ``iter_*`` mappings: one call runs a turn and
+returns a typed :class:`TurnResult` (text, tool_calls, extractions, reasoning,
+outcome, interrupt, error). These tests assert the typed result for each terminal
+outcome — a plain text turn, a tool turn, an interrupt turn, and an error turn —
+and that the ``complete``/``interrupted``/``error`` verdict comes from the one
+shared ``_terminal_outcome`` rule (so it can't drift from ``SessionAdapter._produce``).
+
+Skipped unless the agui extra is installed (the dev extra pulls it, so CI runs it).
+"""
+
+import pytest
+
+pytest.importorskip("ag_ui_langgraph")
+pytest.importorskip("fastapi")
+
+from langstage_core import load_agent_spec
+from langstage_core.agui import (
+    TurnResult,
+    build_agent,
+    collect_chunk_frames,
+    collect_event_frames,
+    run_turn,
+)
+from langstage_core.agui import _terminal_outcome
+from langstage_core.demo.tools import create_tool_demo_agent, demo_extractors
+
+# asyncio_mode = "auto" (pyproject) runs the async tests as coroutines; the sync
+# run_turn tests stay sync, so no module-level asyncio mark here.
+
+
+def _erroring_graph():
+    """A compiled graph whose only node raises — the AG-UI adapter surfaces this
+    as an ``error`` frame, so the turn's outcome is ``error`` (not an exception)."""
+    from langgraph.graph import END, START, MessagesState, StateGraph
+
+    def boom(state):
+        raise RuntimeError("tool exploded")
+
+    b = StateGraph(MessagesState)
+    b.add_node("boom", boom)
+    b.add_edge(START, "boom")
+    b.add_edge("boom", END)
+    return b.compile()
+
+
+# ── The shared terminal-outcome rule (single source of truth) ────────────────
+
+
+def test_terminal_outcome_rule_precedence():
+    # error wins over interrupt; interrupt over complete; else complete.
+    assert _terminal_outcome(saw_interrupt=False, saw_error=False) == "complete"
+    assert _terminal_outcome(saw_interrupt=True, saw_error=False) == "interrupted"
+    assert _terminal_outcome(saw_interrupt=False, saw_error=True) == "error"
+    assert _terminal_outcome(saw_interrupt=True, saw_error=True) == "error"
+
+
+# ── (a) a plain text turn ────────────────────────────────────────────────────
+
+
+async def test_collect_event_frames_plain_text_turn():
+    agent = build_agent(load_agent_spec("langstage_core.demo.stub:graph"))
+    r = await collect_event_frames(agent, "hello there", "s1")
+    assert isinstance(r, TurnResult)
+    assert r.outcome == "complete"
+    assert "hello there" in r.text
+    assert r.tool_calls == [] and r.extractions == []
+    assert r.reasoning == ""
+    assert r.interrupt is None and r.error is None
+    assert r.frames > 0
+
+
+def test_run_turn_sync_plain_text_turn():
+    # The sync "one call, one answer" convenience, accepting a bare graph.
+    r = run_turn(load_agent_spec("langstage_core.demo.stub:graph"), "hi from a script")
+    assert r.outcome == "complete"
+    assert "hi from a script" in r.text
+
+
+def test_run_turn_accepts_a_prebuilt_agent():
+    # Like verify/averify, run_turn takes a graph OR an already-built agent.
+    agent = build_agent(load_agent_spec("langstage_core.demo.stub:graph"))
+    r = run_turn(agent, "prebuilt")
+    assert r.outcome == "complete" and "prebuilt" in r.text
+
+
+# ── (b) a tool turn (text + tool_calls + extraction) ─────────────────────────
+
+
+async def test_collect_event_frames_tool_turn():
+    agent = build_agent(create_tool_demo_agent())
+    r = await collect_event_frames(agent, "use a tool", "s1", extractors=demo_extractors())
+    assert r.outcome == "complete"
+    # text: the agent summarizes the tool result
+    assert r.text and "demo tool returned" in r.text
+    # tool_calls: the real ToolNode call, carrying name + args + id
+    assert len(r.tool_calls) == 1
+    call = r.tool_calls[0]
+    assert call["name"] == "demo_lookup"
+    assert call["args"] == {"query": "use a tool"}
+    assert call["id"]  # a non-empty tool_call id
+    # extraction: the paired DemoLookupExtractor fired
+    assert len(r.extractions) == 1
+    ex = r.extractions[0]
+    assert ex["tool_name"] == "demo_lookup"
+    assert ex["extracted_type"] == "demo_fact"
+    assert ex["data"] == {"query": "use a tool", "answer": "42"}
+    assert r.interrupt is None and r.error is None
+
+
+def test_run_turn_tool_turn_sync():
+    r = run_turn(create_tool_demo_agent(), "use a tool", extractors=demo_extractors())
+    assert r.outcome == "complete"
+    assert r.tool_calls[0]["name"] == "demo_lookup"
+    assert r.extractions[0]["data"]["answer"] == "42"
+
+
+async def test_collect_chunk_frames_tool_turn_parity():
+    # The chunk-wire collector accumulates the same typed result (its tool_calls
+    # carry no id — that's the chunk vocabulary — but name/args/extraction match).
+    agent = build_agent(create_tool_demo_agent())
+    r = await collect_chunk_frames(agent, "use a tool", "s1", extractors=demo_extractors())
+    assert r.outcome == "complete"
+    assert r.tool_calls[0]["name"] == "demo_lookup"
+    assert r.tool_calls[0]["args"] == {"query": "use a tool"}
+    assert r.extractions[0]["extracted_type"] == "demo_fact"
+    assert r.extractions[0]["data"] == {"query": "use a tool", "answer": "42"}
+
+
+# ── (c) an interrupt turn (outcome interrupted, interrupt captured) ───────────
+
+
+async def test_collect_event_frames_interrupt_turn():
+    agent = build_agent(create_tool_demo_agent())
+    r = await collect_event_frames(agent, "ask me", "s-int")
+    assert r.outcome == "interrupted"
+    assert r.interrupt is not None
+    assert r.interrupt["type"] == "interrupt"
+    assert r.interrupt["action_requests"]  # a populated action request to resume with
+    assert r.error is None
+
+
+def test_run_turn_interrupt_turn_sync():
+    r = run_turn(create_tool_demo_agent(), "ask me")
+    assert r.outcome == "interrupted"
+    assert r.interrupt and r.interrupt["action_requests"]
+
+
+# ── (d) an error turn (outcome error) ────────────────────────────────────────
+
+
+async def test_collect_event_frames_error_turn():
+    agent = build_agent(_erroring_graph())
+    r = await collect_event_frames(agent, "go", "s-err")
+    assert r.outcome == "error"
+    assert r.error and "tool exploded" in r.error
+    assert r.interrupt is None
+
+
+def test_run_turn_error_turn_sync():
+    r = run_turn(_erroring_graph(), "go")
+    assert r.outcome == "error"
+    assert r.error
+
+
+# ── Export surface ───────────────────────────────────────────────────────────
+
+
+def test_collectors_exported_from_agui():
+    import langstage_core.agui as agui
+
+    for name in ("collect_event_frames", "collect_chunk_frames", "run_turn", "TurnResult"):
+        assert name in agui.__all__, f"{name} missing from langstage_core.agui.__all__"
+        assert hasattr(agui, name)


### PR DESCRIPTION
## What

Closes #110. Adds a public **one-shot "run a turn, get a typed result"** helper over the `iter_*` mappings, so a non-streaming consumer (a test, an eval/grading harness, a batch job, a `@tool` delegating to a sub-agent, a "run my agent once, give me the answer" script) makes **one call** instead of hand-rolling the accumulator loop over `iter_event_frames` (the issue counted four hand-rolled copies in one dogfooding session).

### New public API (`langstage_core.agui`)

```python
from langstage_core.agui import run_turn, collect_event_frames, collect_chunk_frames, TurnResult

result = run_turn(create_tool_demo_agent(), "use a tool", extractors=demo_extractors())
result.text        # 'The demo tool returned {"query": "use a tool", "answer": "42", ...}'
result.tool_calls  # [{'name': 'demo_lookup', 'args': {'query': 'use a tool'}, 'id': 'demo_lookup_1'}]
result.extractions # [{'tool_name': 'demo_lookup', 'extracted_type': 'demo_fact', 'data': {...}}]
result.outcome     # 'complete' | 'interrupted' | 'error'
```

- **`collect_event_frames(agent, message, thread_id, *, resume, max_result_len, extractors, state)`** (async) — drives one turn over `iter_event_frames` and returns a `TurnResult`. Same kwargs as `iter_event_frames`, forwarded unchanged.
- **`collect_chunk_frames`** — chunk-wire counterpart (same `TurnResult`), for CLI/Jupyter parity.
- **`run_turn(graph_or_agent, message, *, thread_id="oneshot", **kw)`** — sync convenience: accepts a compiled graph **or** a prebuilt `LangGraphAgent` (like `verify`), builds it if needed, runs under `asyncio.run`. Mirrors the `averify`/`verify` async+sync pairing.

`TurnResult` fields: `text`, `outcome`, `tool_calls`, `extractions`, `reasoning`, `interrupt`, `error`, `frames` — exactly the shape the issue proposed. Exported from `langstage_core.agui` (alongside `iter_event_frames` / `verify`, not top-level).

## Single source of truth for the terminal outcome — no third copy of the state machine

The issue's CRITICAL constraint: don't add a third copy of the `complete`/`interrupted`/`error` rule that `SessionAdapter._produce` already implements. I factored the decision into one shared helper `_terminal_outcome(*, saw_interrupt, saw_error)` in `agui` (`error` wins over `interrupt`; a `complete` after a pending `interrupt` ⇒ `interrupted`; else `complete`), and routed **all three** callers through it:

- **`collect_event_frames` / `collect_chunk_frames`** — use it (the new code).
- **`SessionAdapter._produce`** — refactored its inline branches to call it (this *is* the canonical existing implementation the issue points at). `_produce`'s `cancelled` outcome stays put — it's a transport concern set on `asyncio.CancelledError`, not part of the frame-driven rule.
- **`verify()`** — now derives its `ok` from the shared rule too. Behavior-identical on every turn a probe actually produces (`outcome == "complete"` iff `not saw_error` there); it additionally treats an interrupt as not-a-clean-pass, which no test exercised.

So the 3-way state machine is defined and tested **once**.

## Relationship to `langstage`'s `oneturn.py`

The sibling `langstage` package already ships `langstage/oneturn.py` (`complete_turn` / `run_turn_sync`), but that's a **different layer**: it buffers a `SessionAdapter` for the web server's one-turn HTTP endpoint, where the session/queue is needed. These `langstage_core` helpers are the lower-level, **session-free** collectors the issue asked for — they just iterate the `iter_*` mappings, no `SessionAdapter`. Use these in tests/evals/scripts; the web endpoint keeps using its own. (Not touched here — different repo.)

## Tests

New `tests/test_collect.py` asserts the typed result for each terminal outcome:
- **(a) plain text turn** — `outcome == "complete"`, `text` carries the answer, no tools/extractions/interrupt/error.
- **(b) tool turn** (`demo.tools:graph`) — `text` + `tool_calls` (name/args/id) + `extraction` (demo_fact, `answer == "42"`).
- **(c) interrupt turn** (`"ask me"`) — `outcome == "interrupted"`, interrupt frame captured (populated `action_requests`).
- **(d) error turn** — `outcome == "error"`, error message captured.
- Plus `_terminal_outcome` precedence, chunk-wire parity, sync `run_turn` (graph + prebuilt agent), and the export surface.

**Fail-without-fix confirmed:** with the `run_turn`/`collect_*`/`TurnResult` re-export removed (tests kept), `test_collect.py` fails collection with `ImportError: cannot import name 'TurnResult'`; restored → pass.

**Full suite: 234 passed** (222 baseline + 12 new), `.venv/Scripts/python.exe -m pytest -q`.

## Also
- README: new "One call, one answer" keyless snippet (via `demo.tools:graph`) + the What's-in-the-box AG-UI row.
- `pyproject.toml` → **1.0.26**; dated CHANGELOG entry referencing gh #110.
- No `uv.lock` change (chronically stale; version bump isn't its only delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B
